### PR TITLE
Add support to detect refactorings between tags or commits

### DIFF
--- a/src/org/refactoringminer/RefactoringMiner.java
+++ b/src/org/refactoringminer/RefactoringMiner.java
@@ -1,5 +1,10 @@
 package org.refactoringminer;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 import org.eclipse.jgit.lib.Repository;
@@ -12,35 +17,238 @@ import org.refactoringminer.util.GitServiceImpl;
 
 public class RefactoringMiner {
 
-    public static void main(String[] args) throws Exception {
-        if (args.length != 2) {
-            throw new IllegalArgumentException("Usage: RefactoringMiner <git-repo-folder> <commit-SHA1>");
-        }
-        final String folder = args[0];
-        final String commitId = args[1];
-        
-        GitService gitService = new GitServiceImpl(); 
-        try (Repository repo = gitService.openRepository(folder)) {
-            GitHistoryRefactoringMiner detector = new GitHistoryRefactoringMinerImpl();
-            detector.detectAtCommit(repo, null, commitId, new RefactoringHandler() {
-                @Override
-                public void handle(String commitId, List<Refactoring> refactorings) {
-                    if (refactorings.isEmpty()) {
-                        System.out.println("No refactorings found in commit " + commitId);
-                    } else {
-                        System.out.println(refactorings.size() + " refactorings found in commit " + commitId + ": ");
-                        for (Refactoring ref : refactorings) {
-                            System.out.println("  " + ref);
-                        }
-                    }
-                }
-                @Override
-                public void handleException(String commit, Exception e) {
-                    System.err.println("Error processing commit " + commitId);
-                    e.printStackTrace(System.err);
-                }
-            });
-        }
-    }
+	public static void main(String[] args) throws Exception {
+		if (args.length < 1) {
+			throw argumentException();
+		}
+
+		final String option = args[0];
+		if (option.equalsIgnoreCase("-h") || option.equalsIgnoreCase("--h") || option.equalsIgnoreCase("-help")
+				|| option.equalsIgnoreCase("--help")) {
+			printTips();
+			return;
+		}
+
+		if (option.equalsIgnoreCase("-a")) {
+			detectAll(args);
+		} else if (option.equalsIgnoreCase("-bc")) {
+			detectBetweenCommits(args);
+		} else if (option.equalsIgnoreCase("-bt")) {
+			detectBetweenTags(args);
+		} else if (option.equalsIgnoreCase("-c")) {
+			detectAtCommit(args);
+		} else {
+			throw argumentException();
+		}
+	}
+
+	private static void detectAll(String[] args) throws Exception {
+		if (args.length > 3) {
+			throw argumentException();
+		}
+		String folder = args[1];
+		String branch = null;
+		if (args.length == 3) {
+			branch = args[2];
+		}
+		GitService gitService = new GitServiceImpl();
+		try (Repository repo = gitService.openRepository(folder)) {
+			Path folderPath = Paths.get(folder);
+			String fileName = (branch == null) ? "all_refactorings.csv" : "all_refactorings_" + branch + ".csv";
+			String filePath = folderPath.toString() + "/" + fileName;
+			Files.deleteIfExists(Paths.get(filePath));
+			saveToFile(filePath, getResultHeader());
+
+			GitHistoryRefactoringMiner detector = new GitHistoryRefactoringMinerImpl();
+			detector.detectAll(repo, branch, new RefactoringHandler() {
+				@Override
+				public void handle(String commitId, List<Refactoring> refactorings) {
+					if (refactorings.isEmpty()) {
+						System.out.println("No refactorings found in commit " + commitId);
+					} else {
+						System.out.println(refactorings.size() + " refactorings found in commit " + commitId);
+
+						for (Refactoring ref : refactorings) {
+							saveToFile(filePath, getResultRefactoringDescription(commitId, ref));
+						}
+					}
+				}
+
+				@Override
+				public void onFinish(int refactoringsCount, int commitsCount, int errorCommitsCount) {
+					System.out.println("Finish mining, result is saved to file: " + filePath);
+					System.out.println(String.format("Total count: [Commits: %d, Errors: %d, Refactorings: %d]",
+							commitsCount, errorCommitsCount, refactoringsCount));
+				}
+
+				@Override
+				public void handleException(String commit, Exception e) {
+					System.err.println("Error processing commit " + commit);
+					e.printStackTrace(System.err);
+				}
+			});
+		}
+	}
+
+	private static void detectBetweenCommits(String[] args) throws Exception {
+		if (args.length != 4) {
+			throw argumentException();
+		}
+		String folder = args[1];
+		String startCommit = args[2];
+		String endCommit = args[3];
+		GitService gitService = new GitServiceImpl();
+		try (Repository repo = gitService.openRepository(folder)) {
+			Path folderPath = Paths.get(folder);
+			String fileName = "refactorings_" + startCommit + "_" + endCommit + ".csv";
+			String filePath = folderPath.toString() + "/" + fileName;
+			Files.deleteIfExists(Paths.get(filePath));
+			saveToFile(filePath, getResultHeader());
+
+			GitHistoryRefactoringMiner detector = new GitHistoryRefactoringMinerImpl();
+			detector.detectBetweenCommits(repo, startCommit, endCommit, new RefactoringHandler() {
+				@Override
+				public void handle(String commitId, List<Refactoring> refactorings) {
+					if (refactorings.isEmpty()) {
+						System.out.println("No refactorings found in commit " + commitId);
+					} else {
+						System.out.println(refactorings.size() + " refactorings found in commit " + commitId);
+						for (Refactoring ref : refactorings) {
+							saveToFile(filePath, getResultRefactoringDescription(commitId, ref));
+						}
+					}
+				}
+
+				@Override
+				public void onFinish(int refactoringsCount, int commitsCount, int errorCommitsCount) {
+					System.out.println("Finish mining, result is saved to file: " + filePath);
+					System.out.println(String.format("Total count: [Commits: %d, Errors: %d, Refactorings: %d]",
+							commitsCount, errorCommitsCount, refactoringsCount));
+				}
+
+				@Override
+				public void handleException(String commit, Exception e) {
+					System.err.println("Error processing commit " + commit);
+					e.printStackTrace(System.err);
+				}
+			});
+		}
+	}
+
+	private static void detectBetweenTags(String[] args) throws Exception {
+		if (args.length != 4) {
+			throw argumentException();
+		}
+		String folder = args[1];
+		String startTag = args[2];
+		String endTag = args[3];
+		GitService gitService = new GitServiceImpl();
+		try (Repository repo = gitService.openRepository(folder)) {
+			Path folderPath = Paths.get(folder);
+			String fileName = "refactorings_" + startTag + "_" + endTag + ".csv";
+			String filePath = folderPath.toString() + "/" + fileName;
+			Files.deleteIfExists(Paths.get(filePath));
+			saveToFile(filePath, getResultHeader());
+
+			GitHistoryRefactoringMiner detector = new GitHistoryRefactoringMinerImpl();
+			detector.detectBetweenTags(repo, startTag, endTag, new RefactoringHandler() {
+				@Override
+				public void handle(String commitId, List<Refactoring> refactorings) {
+					if (refactorings.isEmpty()) {
+						System.out.println("No refactorings found in commit " + commitId);
+					} else {
+						System.out.println(refactorings.size() + " refactorings found in commit " + commitId);
+						for (Refactoring ref : refactorings) {
+							saveToFile(filePath, getResultRefactoringDescription(commitId, ref));
+						}
+					}
+				}
+
+				@Override
+				public void onFinish(int refactoringsCount, int commitsCount, int errorCommitsCount) {
+					System.out.println("Finish mining, result is saved to file: " + filePath);
+					System.out.println(String.format("Total count: [Commits: %d, Errors: %d, Refactorings: %d]",
+							commitsCount, errorCommitsCount, refactoringsCount));
+				}
+
+				@Override
+				public void handleException(String commit, Exception e) {
+					System.err.println("Error processing commit " + commit);
+					e.printStackTrace(System.err);
+				}
+			});
+		}
+	}
+
+	private static void detectAtCommit(String[] args) throws Exception {
+		if (args.length != 3) {
+			throw argumentException();
+		}
+		String folder = args[1];
+		String commitId = args[2];
+		GitService gitService = new GitServiceImpl();
+		try (Repository repo = gitService.openRepository(folder)) {
+			GitHistoryRefactoringMiner detector = new GitHistoryRefactoringMinerImpl();
+			detector.detectAtCommit(repo, null, commitId, new RefactoringHandler() {
+				@Override
+				public void handle(String commitId, List<Refactoring> refactorings) {
+					if (refactorings.isEmpty()) {
+						System.out.println("No refactorings found in commit " + commitId);
+					} else {
+						System.out.println(refactorings.size() + " refactorings found in commit " + commitId + ": ");
+						for (Refactoring ref : refactorings) {
+							System.out.println("  " + ref);
+						}
+					}
+				}
+
+				@Override
+				public void handleException(String commit, Exception e) {
+					System.err.println("Error processing commit " + commit);
+					e.printStackTrace(System.err);
+				}
+			});
+		}
+	}
+
+	private static void printTips() {
+		System.out.println("-h\t\t\t\t\t\t\t\tShow tips");
+		System.out.println(
+				"-a <git-repo-folder> <branch>\t\t\t\t\tDetect all refactorings at <branch> for <git-repo-folder>. If <branch> is not specified, commits from all branches are analyzed.");
+		System.out.println(
+				"-bc <git-repo-folder> <start-commit-sha1> <end-commit-sha1>\tDetect refactorings Between <star-commit-sha1> and <end-commit-sha1> for project <git-repo-folder>");
+		System.out.println(
+				"-bt <git-repo-folder> <start-tag> <end-tag>\t\t\tDetect refactorings Between <start-tag> and <end-tag> for project <git-repo-folder>");
+		System.out.println(
+				"-c <git-repo-folder> <commit-sha1>\t\t\t\tDetect refactorings at specified commit <commit-sha1> for project <git-repo-folder>");
+	}
+
+	private static IllegalArgumentException argumentException() {
+		return new IllegalArgumentException("Type `RefactoringMiner -h` to show usage.");
+	}
+
+	private static String getResultRefactoringDescription(String commitId, Refactoring ref) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(commitId);
+		builder.append(";");
+		builder.append(ref.getName());
+		builder.append(";");
+		builder.append(ref);
+		return builder.toString();
+	}
+
+	private static void saveToFile(String fileName, String content) {
+		Path path = Paths.get(fileName);
+		byte[] contentBytes = (content + System.lineSeparator()).getBytes();
+		try {
+			Files.write(path, contentBytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static String getResultHeader() {
+		return "CommitId;RefactoringType;RefactoringDetail";
+	}
 
 }

--- a/src/org/refactoringminer/RefactoringMiner.java
+++ b/src/org/refactoringminer/RefactoringMiner.java
@@ -91,16 +91,21 @@ public class RefactoringMiner {
 	}
 
 	private static void detectBetweenCommits(String[] args) throws Exception {
-		if (args.length != 4) {
+		if (!(args.length == 3 || args.length == 4)) {
 			throw argumentException();
 		}
 		String folder = args[1];
 		String startCommit = args[2];
-		String endCommit = args[3];
+		String endCommit = (args.length == 4) ? args[3] : null;
 		GitService gitService = new GitServiceImpl();
 		try (Repository repo = gitService.openRepository(folder)) {
 			Path folderPath = Paths.get(folder);
-			String fileName = "refactorings_" + startCommit + "_" + endCommit + ".csv";
+			String fileName = null;
+			if (endCommit == null) {
+				fileName = "refactorings_" + startCommit + "_begin" + ".csv";
+			} else {
+				fileName = "refactorings_" + startCommit + "_" + endCommit + ".csv";
+			}
 			String filePath = folderPath.toString() + "/" + fileName;
 			Files.deleteIfExists(Paths.get(filePath));
 			saveToFile(filePath, getResultHeader());
@@ -136,16 +141,21 @@ public class RefactoringMiner {
 	}
 
 	private static void detectBetweenTags(String[] args) throws Exception {
-		if (args.length != 4) {
+		if (!(args.length == 3 || args.length == 4)) {
 			throw argumentException();
 		}
 		String folder = args[1];
 		String startTag = args[2];
-		String endTag = args[3];
+		String endTag = (args.length == 4) ? args[3] : null;
 		GitService gitService = new GitServiceImpl();
 		try (Repository repo = gitService.openRepository(folder)) {
 			Path folderPath = Paths.get(folder);
-			String fileName = "refactorings_" + startTag + "_" + endTag + ".csv";
+			String fileName = null;
+			if (endTag == null) {
+				fileName = "refactorings_" + startTag + "_begin" + ".csv";
+			} else {
+				fileName = "refactorings_" + startTag + "_" + endTag + ".csv";
+			}
 			String filePath = folderPath.toString() + "/" + fileName;
 			Files.deleteIfExists(Paths.get(filePath));
 			saveToFile(filePath, getResultHeader());

--- a/src/org/refactoringminer/api/GitHistoryRefactoringMiner.java
+++ b/src/org/refactoringminer/api/GitHistoryRefactoringMiner.java
@@ -22,6 +22,36 @@ public interface GitHistoryRefactoringMiner {
 	void detectAll(Repository repository, String branch, RefactoringHandler handler) throws Exception;
 
 	/**
+	 * Iterate over commits between two release tags of a git repository and detect refactorings performed
+	 * in the entire repository history. Merge commits are ignored to avoid detecting the same refactoring 
+	 * multiple times.
+	 * 
+	 * @param repository A git repository (from JGit library).
+	 * @param startTag An annotated tag to start the log lookup.
+	 * @param endTag An annotated tag to end the log lookup.
+	 * @param handler A handler object that is responsible to process the detected refactorings and
+	 *                control when to skip a commit. 
+	 * @throws Exception propagated from JGit library.
+	 */
+	void detectBetweenTags(Repository repository, String startTag, String endTag, RefactoringHandler handler)
+			throws Exception;
+	
+	/**
+	 * Iterate over commits between two commits of a git repository and detect refactorings performed
+	 * in the entire repository history. Merge commits are ignored to avoid detecting the same refactoring 
+	 * multiple times.
+	 * 
+	 * @param repository A git repository (from JGit library).
+	 * @param startCommitId The SHA key that identifies the commit to start the log lookup.
+	 * @param endCommitId The SHA key that identifies the commit to end the log lookup.
+	 * @param handler A handler object that is responsible to process the detected refactorings and
+	 *                control when to skip a commit. 
+	 * @throws Exception propagated from JGit library.
+	 */
+	void detectBetweenCommits(Repository repository, String startCommitId, String endCommitId, RefactoringHandler handler)
+			throws Exception;
+	
+	/**
 	 * Fetch new commits from the remote repo and detect all refactorings performed in these
 	 * commits.
 	 * 

--- a/src/org/refactoringminer/api/GitService.java
+++ b/src/org/refactoringminer/api/GitService.java
@@ -37,5 +37,9 @@ public interface GitService {
 
 	RevWalk createAllRevsWalk(Repository repository, String branch) throws Exception;
 
+	RevWalk createRevsWalkBetweenTags(Repository repository, String startTag, String endTag) throws Exception;
+
+	RevWalk createRevsWalkBetweenCommits(Repository repository, String startCommitId, String endCommitId) throws Exception;
+
 	void fileTreeDiff(Repository repository, RevCommit currentCommit, List<String> filesBefore, List<String> filesCurrent, Map<String, String> renamedFilesHint, boolean detectRenames) throws Exception;
 }

--- a/src/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
+++ b/src/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
@@ -19,6 +19,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -285,5 +287,43 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 	@Override
 	public String getConfigId() {
 	    return "RM1";
+	}
+
+	@Override
+	public void detectBetweenTags(Repository repository, String startTag, String endTag, RefactoringHandler handler)
+			throws Exception {
+		GitService gitService = new GitServiceImpl() {
+			@Override
+			public boolean isCommitAnalyzed(String sha1) {
+				return handler.skipCommit(sha1);
+			}
+		};
+		
+		RevWalk walk = gitService.createRevsWalkBetweenTags(repository, startTag, endTag);
+
+		try {
+			detect(gitService, repository, handler, walk.iterator());
+		} finally {
+			walk.dispose();
+		}
+	}
+
+	@Override
+	public void detectBetweenCommits(Repository repository, String startCommitId, String endCommitId,
+			RefactoringHandler handler) throws Exception {
+		GitService gitService = new GitServiceImpl() {
+			@Override
+			public boolean isCommitAnalyzed(String sha1) {
+				return handler.skipCommit(sha1);
+			}
+		};
+		
+		RevWalk walk = gitService.createRevsWalkBetweenCommits(repository, startCommitId, endCommitId);
+
+		try {
+			detect(gitService, repository, handler, walk.iterator());
+		} finally {
+			walk.dispose();
+		}
 	}
 }

--- a/src/org/refactoringminer/rm2/analysis/GitHistoryRefactoringMiner2.java
+++ b/src/org/refactoringminer/rm2/analysis/GitHistoryRefactoringMiner2.java
@@ -74,4 +74,18 @@ public class GitHistoryRefactoringMiner2 implements GitHistoryRefactoringMiner {
 	    return config.getId();
 	}
 
+	@Override
+	public void detectBetweenTags(Repository repository, String startTag, String endTag, RefactoringHandler handler)
+			throws Exception {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void detectBetweenCommits(Repository repository, String startCommitId, String endCommitId,
+			RefactoringHandler handler) throws Exception {
+		// TODO Auto-generated method stub
+		
+	}
+
 }

--- a/src/org/refactoringminer/util/GitServiceImpl.java
+++ b/src/org/refactoringminer/util/GitServiceImpl.java
@@ -212,6 +212,34 @@ public class GitServiceImpl implements GitService {
 		walk.setRevFilter(commitsFilter);
 		return walk;
 	}
+	
+	@Override
+	public RevWalk createRevsWalkBetweenTags(Repository repository, String startTag, String endTag)
+			throws Exception {
+		RevWalk walk = new RevWalk(repository);
+		
+		Ref startTagRef = repository.findRef(startTag);
+		Ref endTagRef = repository.findRef(endTag);
+		ObjectId startCommit = startTagRef.getObjectId();
+		ObjectId endCommit = endTagRef.getObjectId();
+        
+        walk.markStart(walk.parseCommit(startCommit));
+        walk.markUninteresting(walk.parseCommit(endCommit));
+		return walk;
+	}
+	
+	@Override
+	public RevWalk createRevsWalkBetweenCommits(Repository repository, String startCommitId, String endCommitId)
+			throws Exception {
+		RevWalk walk = new RevWalk(repository);
+		
+		ObjectId startCommit = repository.resolve(startCommitId);
+		ObjectId endCommit = repository.resolve(endCommitId);
+        
+        walk.markStart(walk.parseCommit(startCommit));
+        walk.markUninteresting(walk.parseCommit(endCommit));
+		return walk;
+	}
 
 	public boolean isCommitAnalyzed(String sha1) {
 		return false;

--- a/src/org/refactoringminer/util/GitServiceImpl.java
+++ b/src/org/refactoringminer/util/GitServiceImpl.java
@@ -219,12 +219,14 @@ public class GitServiceImpl implements GitService {
 		RevWalk walk = new RevWalk(repository);
 		
 		Ref startTagRef = repository.findRef(startTag);
-		Ref endTagRef = repository.findRef(endTag);
 		ObjectId startCommit = startTagRef.getObjectId();
-		ObjectId endCommit = endTagRef.getObjectId();
-        
         walk.markStart(walk.parseCommit(startCommit));
-        walk.markUninteresting(walk.parseCommit(endCommit));
+        
+        if (endTag != null) {
+	    		Ref endTagRef = repository.findRef(endTag);
+	    		ObjectId endCommit = endTagRef.getObjectId();
+            walk.markUninteresting(walk.parseCommit(endCommit));
+        }
 		
         walk.setRevFilter(commitsFilter);
 		return walk;
@@ -236,11 +238,13 @@ public class GitServiceImpl implements GitService {
 		RevWalk walk = new RevWalk(repository);
 		
 		ObjectId startCommit = repository.resolve(startCommitId);
-		ObjectId endCommit = repository.resolve(endCommitId);
-        
         walk.markStart(walk.parseCommit(startCommit));
-        walk.markUninteresting(walk.parseCommit(endCommit));
-        
+
+        if (endCommitId != null) {
+        		ObjectId endCommit = repository.resolve(endCommitId);  
+            walk.markUninteresting(walk.parseCommit(endCommit));
+        }
+		
 		walk.setRevFilter(commitsFilter);
 		return walk;
 	}

--- a/src/org/refactoringminer/util/GitServiceImpl.java
+++ b/src/org/refactoringminer/util/GitServiceImpl.java
@@ -225,6 +225,8 @@ public class GitServiceImpl implements GitService {
         
         walk.markStart(walk.parseCommit(startCommit));
         walk.markUninteresting(walk.parseCommit(endCommit));
+		
+        walk.setRevFilter(commitsFilter);
 		return walk;
 	}
 	
@@ -238,6 +240,8 @@ public class GitServiceImpl implements GitService {
         
         walk.markStart(walk.parseCommit(startCommit));
         walk.markUninteresting(walk.parseCommit(endCommit));
+        
+		walk.setRevFilter(commitsFilter);
 		return walk;
 	}
 


### PR DESCRIPTION
1. Add support to detect refactorings between tags or commits.
2. Add command line interface.
3. Save result to csv file when detecting all commits, between tags or commits.

The new added methods in GitHistoryRefactoringMiner2.java are not implemented, because it seems they are not related to the function which demonstrated in README.md.