### PR TITLE
Add getRefactoredClass() to Refactoring interface

### DIFF
--- a/src/gr/uom/java/xmi/diff/ConvertAnonymousClassToTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ConvertAnonymousClassToTypeRefactoring.java
@@ -7,10 +7,12 @@ import gr.uom.java.xmi.UMLAnonymousClass;
 import gr.uom.java.xmi.UMLClass;
 
 public class ConvertAnonymousClassToTypeRefactoring implements Refactoring {
+	private UMLClass baseClass;
 	private UMLAnonymousClass anonymousClass;
 	private UMLClass addedClass;
 	
-	public ConvertAnonymousClassToTypeRefactoring(UMLAnonymousClass anonymousClass, UMLClass addedClass) {
+	public ConvertAnonymousClassToTypeRefactoring(UMLClass baseClass, UMLAnonymousClass anonymousClass, UMLClass addedClass) {
+		this.baseClass = baseClass;
 		this.anonymousClass = anonymousClass;
 		this.addedClass = addedClass;
 	}
@@ -22,6 +24,11 @@ public class ConvertAnonymousClassToTypeRefactoring implements Refactoring {
 		sb.append(" was converted to ");
 		sb.append(addedClass);
 		return sb.toString();
+	}
+
+	@Override
+	public String getRefactoredClass () {
+		return baseClass.getName();
 	}
 
 	public String getName() {

--- a/src/gr/uom/java/xmi/diff/ExtractAndMoveOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractAndMoveOperationRefactoring.java
@@ -43,7 +43,12 @@ public class ExtractAndMoveOperationRefactoring implements Refactoring {
 		sb.append(extractedOperation.getClassName());
 		return sb.toString();
 	}
-	
+
+	@Override
+	public String getRefactoredClass () {
+		return sourceOperationBeforeExtraction.getClassName();
+	}
+
 	public String getName() {
 		return this.getRefactoringType().getDisplayName();
 	}

--- a/src/gr/uom/java/xmi/diff/ExtractClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractClassRefactoring.java
@@ -34,6 +34,11 @@ public class ExtractClassRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return originalClass.getName();
+	}
+
 	public RefactoringType getRefactoringType() {
 		if(extractedClass.isSubTypeOf(originalClass))
 			return RefactoringType.EXTRACT_SUBCLASS;

--- a/src/gr/uom/java/xmi/diff/ExtractOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractOperationRefactoring.java
@@ -65,6 +65,11 @@ public class ExtractOperationRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return getClassName();
+	}
+
 	private String getClassName() {
 		String sourceClassName = getSourceOperationBeforeExtraction().getClassName();
 		String targetClassName = getSourceOperationAfterExtraction().getClassName();

--- a/src/gr/uom/java/xmi/diff/ExtractSuperclassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractSuperclassRefactoring.java
@@ -4,6 +4,7 @@ import gr.uom.java.xmi.UMLClass;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -24,6 +25,11 @@ public class ExtractSuperclassRefactoring implements Refactoring {
 		sb.append(" from classes ");
 		sb.append(subclassSet);
 		return sb.toString();
+	}
+
+	@Override
+	public String getRefactoredClass () {
+		return subclassSet.stream().map(x -> x.getName()).collect(Collectors.joining(","));
 	}
 
 	public String getName() {

--- a/src/gr/uom/java/xmi/diff/ExtractVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractVariableRefactoring.java
@@ -42,6 +42,11 @@ public class ExtractVariableRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return operation.getClassName();
+	}
+
 	/**
 	 * @return the code range of the extracted variable declaration in the <b>child</b> commit
 	 */

--- a/src/gr/uom/java/xmi/diff/InlineOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/InlineOperationRefactoring.java
@@ -48,6 +48,11 @@ public class InlineOperationRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return getClassName();
+	}
+
 	private String getClassName() {
 		return targetOperationAfterInline.getClassName();
 	}

--- a/src/gr/uom/java/xmi/diff/InlineVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/InlineVariableRefactoring.java
@@ -42,6 +42,11 @@ public class InlineVariableRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return operation.getClassName();
+	}
+
 	/**
 	 * @return the code range of the inlined variable declaration in the <b>parent</b> commit
 	 */

--- a/src/gr/uom/java/xmi/diff/MoveAndRenameClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveAndRenameClassRefactoring.java
@@ -23,6 +23,11 @@ public class MoveAndRenameClassRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return getOriginalClassName();
+	}
+
 	public String getName() {
 		return this.getRefactoringType().getDisplayName();
 	}

--- a/src/gr/uom/java/xmi/diff/MoveAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveAttributeRefactoring.java
@@ -26,6 +26,11 @@ public class MoveAttributeRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return getSourceClassName();
+	}
+
 	public String getName() {
 		return this.getRefactoringType().getDisplayName();
 	}

--- a/src/gr/uom/java/xmi/diff/MoveClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveClassRefactoring.java
@@ -23,6 +23,11 @@ public class MoveClassRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return originalClass.getName();
+	}
+
 	public RenamePattern getRenamePattern() {
 		int separatorPos = PrefixSuffixUtils.separatorPosOfCommonSuffix('.', originalClass.getName(), movedClass.getName());
 		if (separatorPos == -1) {

--- a/src/gr/uom/java/xmi/diff/MoveOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveOperationRefactoring.java
@@ -41,6 +41,11 @@ public class MoveOperationRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return originalOperation.getClassName();
+	}
+
 	public String getName() {
 		return this.getRefactoringType().getDisplayName();
 	}

--- a/src/gr/uom/java/xmi/diff/MoveSourceFolderRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveSourceFolderRefactoring.java
@@ -2,6 +2,7 @@ package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -42,6 +43,11 @@ public class MoveSourceFolderRefactoring implements Refactoring {
 		String movedPath = pattern.getAfter().endsWith("/") ? pattern.getAfter().substring(0, pattern.getAfter().length()-1) : pattern.getAfter();
 		sb.append(movedPath);
 		return sb.toString();
+	}
+
+	@Override
+	public String getRefactoredClass () {
+		return movedClassesToAnotherSourceFolder.stream().map(x -> x.getClassName()).collect(Collectors.joining(","));
 	}
 
 	public String getName() {

--- a/src/gr/uom/java/xmi/diff/MovedClassToAnotherSourceFolder.java
+++ b/src/gr/uom/java/xmi/diff/MovedClassToAnotherSourceFolder.java
@@ -22,4 +22,8 @@ public class MovedClassToAnotherSourceFolder {
 		String moved = movedPath.substring(0, movedPath.length() - separatorPos);
 		return new RenamePattern(original, moved);
 	}
+
+	public String getClassName () {
+		return className;
+	}
 }

--- a/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
@@ -50,6 +50,11 @@ public class RenameAttributeRefactoring implements Refactoring {
 	}
 
 	@Override
+	public String getRefactoredClass () {
+		return classNameAfter;
+	}
+
+	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;

--- a/src/gr/uom/java/xmi/diff/RenameClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameClassRefactoring.java
@@ -23,6 +23,11 @@ public class RenameClassRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return originalClass.getName();
+	}
+
 	public String getName() {
 		return this.getRefactoringType().getDisplayName();
 	}

--- a/src/gr/uom/java/xmi/diff/RenameOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameOperationRefactoring.java
@@ -37,6 +37,11 @@ public class RenameOperationRefactoring implements Refactoring {
 		return sb.toString();
 	}
 
+	@Override
+	public String getRefactoredClass () {
+		return getClassName();
+	}
+
 	private String getClassName() {
 		String sourceClassName = originalOperation.getClassName();
 		String targetClassName = renamedOperation.getClassName();

--- a/src/gr/uom/java/xmi/diff/RenamePackageRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenamePackageRefactoring.java
@@ -2,6 +2,7 @@ package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -51,5 +52,10 @@ public class RenamePackageRefactoring implements Refactoring {
 		String movedPath = pattern.getAfter().endsWith(".") ? pattern.getAfter().substring(0, pattern.getAfter().length()-1) : pattern.getAfter();
 		sb.append(movedPath);
 		return sb.toString();
+	}
+
+	@Override
+	public String getRefactoredClass () {
+		return moveClassRefactorings.stream().map(x -> x.getMovedClassName()).collect(Collectors.joining(","));
 	}
 }

--- a/src/gr/uom/java/xmi/diff/RenameVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameVariableRefactoring.java
@@ -66,6 +66,11 @@ public class RenameVariableRefactoring implements Refactoring {
 	}
 
 	@Override
+	public String getRefactoredClass () {
+		return operationAfter.getClassName();
+	}
+
+	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;

--- a/src/gr/uom/java/xmi/diff/UMLModelDiff.java
+++ b/src/gr/uom/java/xmi/diff/UMLModelDiff.java
@@ -1025,7 +1025,7 @@ public class UMLModelDiff {
 	         for(UMLClass addedClass : addedClasses) {
 	            if(addedClass.getAttributes().containsAll(anonymousClass.getAttributes()) &&
 	                  addedClass.getOperations().containsAll(anonymousClass.getOperations())) {
-	               ConvertAnonymousClassToTypeRefactoring refactoring = new ConvertAnonymousClassToTypeRefactoring(anonymousClass, addedClass);
+	               ConvertAnonymousClassToTypeRefactoring refactoring = new ConvertAnonymousClassToTypeRefactoring(classDiff.getOriginalClass(), anonymousClass, addedClass);
 	               refactorings.add(refactoring);
 	            }
 	         }

--- a/src/org/refactoringminer/api/Refactoring.java
+++ b/src/org/refactoringminer/api/Refactoring.java
@@ -9,5 +9,7 @@ public interface Refactoring extends Serializable {
 	public String getName();
 
 	public String toString();
+
+	public String getRefactoredClass();
 	
 }


### PR DESCRIPTION
Currently, the `Refactoring` class doesn't offer an easy way to get the base class that was refactored. And each implementation of the interface returns a different toString(), so parsing this information is not straightforward.

This PR introduces a `getRefactoredClass()` method in the interface. Now, one can easily do:
```
for(Refactoring r : refactorings) {
  syso(refactoring.getRefactoringType().toString() + "," + r.getRefactoredClass());
}
```
(which is precisely the data I need right now :) )

The implementation of the method in most subclasses were straightforward (I basically learned how it was done in the `toString()`. But some light review there is appreciated.

Design-wise, in some subclasses, the method returns the list of classes that suffered the refactoring (e.g., move package or similar). Is this good enough?

Finally, I'd appreciate some tips on how to write automated tests for these new methods. I see that test methods right now mostly focus on the precision of the identification.