### PR TITLE
Fix NPE

### DIFF
--- a/src/gr/uom/java/xmi/decomposition/UMLOperationBodyMapper.java
+++ b/src/gr/uom/java/xmi/decomposition/UMLOperationBodyMapper.java
@@ -1803,6 +1803,9 @@ public class UMLOperationBodyMapper implements Comparable<UMLOperationBodyMapper
 					AnonymousClassDeclarationObject anonymousClassDeclaration2 = anonymousClassDeclarations2.get(j);
 					String statementWithoutAnonymous1 = statementWithoutAnonymous(statement1, anonymousClassDeclaration1, operation1);
 					String statementWithoutAnonymous2 = statementWithoutAnonymous(statement2, anonymousClassDeclaration2, operation2);
+					if(statementWithoutAnonymous1 == null || statementWithoutAnonymous2 == null) {
+							continue;
+					}
 					if(statementWithoutAnonymous1.equals(statementWithoutAnonymous2) ||
 							identicalAfterVariableAndTypeReplacements(statementWithoutAnonymous1, statementWithoutAnonymous2, replacementInfo.getReplacements()) ||
 							(invocationCoveringTheEntireStatement1 != null && invocationCoveringTheEntireStatement2 != null &&


### PR DESCRIPTION
I found NPE when I was running rminer in [Flink](https://github.com/apache/flink)
stack trace
```
2019-10-16 16:25:06,191 [main] WARN  o.r.r.GitHistoryRefactoringMinerImpl - Ignored revision 3561222c5d6c7cee79f8c5872f32227632135c48 due to error
java.lang.NullPointerException: null
	at gr.uom.java.xmi.decomposition.UMLOperationBodyMapper.findReplacementsWithExactMatching(UMLOperationBodyMapper.java:1806) 
	at gr.uom.java.xmi.decomposition.UMLOperationBodyMapper.processLeaves(UMLOperationBodyMapper.java:1008) 
	at gr.uom.java.xmi.decomposition.UMLOperationBodyMapper.<init>(UMLOperationBodyMapper.java:124) 
	at gr.uom.java.xmi.diff.UMLClassDiff.createBodyMappers(UMLClassDiff.java:113) 
	at gr.uom.java.xmi.diff.UMLClassBaseDiff.process(UMLClassBaseDiff.java:95) 
	at gr.uom.java.xmi.UMLModel.diff(UMLModel.java:147) 
	at org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl.detectRefactorings(GitHistoryRefactoringMinerImpl.java:182) 
	at org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl.detect(GitHistoryRefactoringMinerImpl.java:138) 
	at org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl.detectAll(GitHistoryRefactoringMinerImpl.java:390) 
```

I think this is because `statementWithoutAnonumous1` or `statementWithoutAnonumous2` is null.
Thus, I inserted null checker.