### PR TITLE
Return the files involved before and after a refactoring

### DIFF
--- a/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -51,6 +48,18 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 
 	public String getClassNameAfter() {
 		return classNameAfter;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(originalAttribute.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(changedTypeAttribute.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public Set<AbstractCodeMapping> getAttributeReferences() {

--- a/src/gr/uom/java/xmi/diff/ChangeReturnTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ChangeReturnTypeRefactoring.java
@@ -1,6 +1,7 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -49,6 +50,18 @@ public class ChangeReturnTypeRefactoring implements Refactoring {
 
 	public UMLOperation getOperationAfter() {
 		return operationAfter;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public Set<AbstractCodeMapping> getReturnReferences() {

--- a/src/gr/uom/java/xmi/diff/ChangeVariableTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ChangeVariableTypeRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -62,6 +59,18 @@ public class ChangeVariableTypeRefactoring implements Refactoring {
 
 	public UMLOperation getOperationAfter() {
 		return operationAfter;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public Set<AbstractCodeMapping> getVariableReferences() {

--- a/src/gr/uom/java/xmi/diff/ConvertAnonymousClassToTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ConvertAnonymousClassToTypeRefactoring.java
@@ -1,7 +1,9 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -37,6 +39,18 @@ public class ConvertAnonymousClassToTypeRefactoring implements Refactoring {
 
 	public String getName() {
 		return this.getRefactoringType().getDisplayName();
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(anonymousClass.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(addedClass.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public RefactoringType getRefactoringType() {

--- a/src/gr/uom/java/xmi/diff/ExtractAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractAttributeRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -47,6 +44,18 @@ public class ExtractAttributeRefactoring implements Refactoring {
 		sb.append(" in class ");
 		sb.append(attributeDeclaration.getClassName());
 		return sb.toString();
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(attributeDeclaration.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(attributeDeclaration.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	/**

--- a/src/gr/uom/java/xmi/diff/ExtractClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractClassRefactoring.java
@@ -1,6 +1,7 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -76,6 +77,18 @@ public class ExtractClassRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getExtractedClass().getName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getOriginalClass().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getExtractedClass().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/ExtractOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractOperationRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -180,6 +177,18 @@ public class ExtractOperationRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getSourceOperationAfterExtraction().getClassName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getSourceOperationBeforeExtraction().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getSourceOperationAfterExtraction().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/ExtractSuperclassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractSuperclassRefactoring.java
@@ -2,10 +2,8 @@ package gr.uom.java.xmi.diff;
 
 import gr.uom.java.xmi.UMLClass;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -65,6 +63,16 @@ public class ExtractSuperclassRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getExtractedClass().getName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		return this.subclassSet.stream().map(x -> x.getLocationInfo().getFilePath()).collect(Collectors.toSet());
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getExtractedClass().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/ExtractVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ExtractVariableRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -47,6 +44,18 @@ public class ExtractVariableRefactoring implements Refactoring {
 
 	public UMLOperation getOperationAfter() {
 		return operationAfter;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public Set<AbstractCodeMapping> getReferences() {

--- a/src/gr/uom/java/xmi/diff/InlineOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/InlineOperationRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -162,6 +159,18 @@ public class InlineOperationRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getTargetOperationAfterInline().getClassName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getTargetOperationBeforeInline().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getTargetOperationAfterInline().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/InlineVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/InlineVariableRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -112,6 +109,18 @@ public class InlineVariableRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(operationAfter.getClassName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
@@ -1,8 +1,10 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -116,6 +118,16 @@ public class MergeAttributeRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(classNameAfter);
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		return mergedAttributes.stream().map(x -> x.getLocationInfo().getFilePath()).collect(Collectors.toSet());
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(newAttribute.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/MergeVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MergeVariableRefactoring.java
@@ -1,6 +1,7 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -78,6 +79,18 @@ public class MergeVariableRefactoring implements Refactoring {
 		return classNames;
 	}
 
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
+	}
+
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(getName()).append("\t");
@@ -152,4 +165,6 @@ public class MergeVariableRefactoring implements Refactoring {
 				.setCodeElement(newVariable.toString()));
 		return ranges;
 	}
+
+
 }

--- a/src/gr/uom/java/xmi/diff/MoveAndRenameClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveAndRenameClassRefactoring.java
@@ -3,7 +3,9 @@ package gr.uom.java.xmi.diff;
 import gr.uom.java.xmi.UMLClass;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -61,6 +63,18 @@ public class MoveAndRenameClassRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getRenamedClass().getName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getOriginalClass().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getRenamedClass().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/MoveAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveAttributeRefactoring.java
@@ -1,7 +1,9 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -29,6 +31,18 @@ public class MoveAttributeRefactoring implements Refactoring {
 		sb.append(" from class ");
 		sb.append(getTargetClassName());
 		return sb.toString();
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(originalAttribute.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(movedAttribute.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public String getName() {

--- a/src/gr/uom/java/xmi/diff/MoveClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveClassRefactoring.java
@@ -3,7 +3,9 @@ package gr.uom.java.xmi.diff;
 import gr.uom.java.xmi.UMLClass;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -71,6 +73,18 @@ public class MoveClassRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getMovedClass().getName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getOriginalClass().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getMovedClass().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/MoveOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveOperationRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -106,6 +103,18 @@ public class MoveOperationRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getMovedOperation().getClassName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getOriginalOperation().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getMovedOperation().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/MoveSourceFolderRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MoveSourceFolderRefactoring.java
@@ -1,7 +1,10 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -67,6 +70,15 @@ public class MoveSourceFolderRefactoring implements Refactoring {
 		}
 		return classNames;
 	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		return movedClassesToAnotherSourceFolder.stream().map(x -> x.getOriginalClass().getLocationInfo().getFilePath()).collect(Collectors.toSet());
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		return movedClassesToAnotherSourceFolder.stream().map(x -> x.getMovedClass().getLocationInfo().getFilePath()).collect(Collectors.toSet());
+	}
+
 
 	@Override
 	public List<CodeRange> leftSide() {

--- a/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
@@ -1,6 +1,7 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -108,6 +109,18 @@ public class RenameAttributeRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(classNameAfter);
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(originalAttribute.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(renamedAttribute.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/RenameClassRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameClassRefactoring.java
@@ -3,7 +3,9 @@ package gr.uom.java.xmi.diff;
 import gr.uom.java.xmi.UMLClass;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -61,6 +63,18 @@ public class RenameClassRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getRenamedClass().getName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getOriginalClass().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getRenamedClass().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/RenameOperationRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameOperationRefactoring.java
@@ -1,9 +1,6 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -107,6 +104,18 @@ public class RenameOperationRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(getRenamedOperation().getClassName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getOriginalOperation().getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(getRenamedOperation().getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/RenamePackageRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenamePackageRefactoring.java
@@ -1,7 +1,10 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
@@ -67,6 +70,14 @@ public class RenamePackageRefactoring implements Refactoring {
 			classNames.add(ref.getMovedClassName());
 		}
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		return moveClassRefactorings.stream().map(x -> x.getOriginalClass().getLocationInfo().getFilePath()).collect(Collectors.toSet());
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		return moveClassRefactorings.stream().map(x -> x.getMovedClass().getLocationInfo().getFilePath()).collect(Collectors.toSet());
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/RenameVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameVariableRefactoring.java
@@ -1,6 +1,7 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -63,6 +64,18 @@ public class RenameVariableRefactoring implements Refactoring {
 
 	public Set<AbstractCodeMapping> getVariableReferences() {
 		return variableReferences;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public String toString() {

--- a/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
@@ -1,13 +1,11 @@
 package gr.uom.java.xmi.diff;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
+import gr.uom.java.xmi.decomposition.VariableDeclaration;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 
-import gr.uom.java.xmi.decomposition.VariableDeclaration;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class SplitAttributeRefactoring implements Refactoring {
 	private VariableDeclaration oldAttribute;
@@ -43,6 +41,16 @@ public class SplitAttributeRefactoring implements Refactoring {
 
 	public String getClassNameAfter() {
 		return classNameAfter;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		return splitAttributes.stream().map(x -> x.getLocationInfo().getFilePath()).collect(Collectors.toSet());
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(oldAttribute.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	@Override

--- a/src/gr/uom/java/xmi/diff/SplitVariableRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/SplitVariableRefactoring.java
@@ -1,6 +1,7 @@
 package gr.uom.java.xmi.diff;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -80,6 +81,18 @@ public class SplitVariableRefactoring implements Refactoring {
 		List<String> classNames = new ArrayList<String>();
 		classNames.add(operationAfter.getClassName());
 		return classNames;
+	}
+
+	public Set<String> getInvolvedFilesBeforeRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationBefore.getLocationInfo().getFilePath());
+		return files;
+	}
+
+	public Set<String> getInvolvedFilesAfterRefactoring() {
+		HashSet<String> files = new HashSet<>();
+		files.add(operationAfter.getLocationInfo().getFilePath());
+		return files;
 	}
 
 	public String toString() {

--- a/src/org/refactoringminer/api/Refactoring.java
+++ b/src/org/refactoringminer/api/Refactoring.java
@@ -2,6 +2,7 @@ package org.refactoringminer.api;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Set;
 
 public interface Refactoring extends Serializable, CodeRangeProvider {
 
@@ -10,7 +11,11 @@ public interface Refactoring extends Serializable, CodeRangeProvider {
 	public String getName();
 
 	public String toString();
-	
+
+	public Set<String> getInvolvedFilesBeforeRefactoring();
+
+	public Set<String> getInvolvedFilesAfterRefactoring();
+
 	public List<String> getInvolvedClassesBeforeRefactoring();
 	
 	public List<String> getInvolvedClassesAfterRefactoring();


### PR DESCRIPTION
I am using the output of RefactoringMiner as input to other tools. Knowing not only the class name (as already provided), but also the file name helps me in matching the output of both tools.

This is a large commit, as I added the `Set<String> getInvolvedFilesBeforeRefactoring()` and `Set<String> getInvolvedFilesAfterRefactoring()` methods in the `Refactoring` interface, and thus, in all its implementations.

Please make sure I return the correct files in all the implementations. Most of them were trivial, but some I had to think a bit more.