### PR TITLE
Uniform attribute level refactoring types

### DIFF
--- a/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
@@ -148,18 +148,18 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> leftSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		ranges.add(originalAttribute.codeRange()
+		ranges.add(originalAttribute.getVariableDeclaration().codeRange()
 				.setDescription("original attribute declaration")
-				.setCodeElement(originalAttribute.toString()));
+				.setCodeElement(originalAttribute.getVariableDeclaration().toString()));
 		return ranges;
 	}
 
 	@Override
 	public List<CodeRange> rightSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		ranges.add(changedTypeAttribute.codeRange()
+		ranges.add(changedTypeAttribute.getVariableDeclaration().codeRange()
 				.setDescription("changed-type attribute declaration")
-				.setCodeElement(changedTypeAttribute.toString()));
+				.setCodeElement(changedTypeAttribute.getVariableDeclaration().toString()));
 		return ranges;
 	}
 }

--- a/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
@@ -10,6 +10,7 @@ import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 
 import gr.uom.java.xmi.decomposition.AbstractCodeMapping;
+import gr.uom.java.xmi.decomposition.VariableDeclaration;
 import gr.uom.java.xmi.UMLAttribute;
 
 public class ChangeAttributeTypeRefactoring implements Refactoring {
@@ -70,11 +71,13 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		boolean qualified = originalAttribute.getType().equals(changedTypeAttribute.getType()) && !originalAttribute.getType().equalsQualified(changedTypeAttribute.getType());
+		VariableDeclaration originalVariableDeclaration = originalAttribute.getVariableDeclaration();
+		VariableDeclaration changedTypeVariableDeclaration = changedTypeAttribute.getVariableDeclaration();
+		boolean qualified = originalVariableDeclaration.getType().equals(changedTypeVariableDeclaration.getType()) && !originalVariableDeclaration.getType().equalsQualified(changedTypeVariableDeclaration.getType());
 		sb.append(getName()).append("\t");
-		sb.append(qualified ? originalAttribute.toQualifiedString() : originalAttribute.toString());
+		sb.append(qualified ? originalVariableDeclaration.toQualifiedString() : originalVariableDeclaration.toString());
 		sb.append(" to ");
-		sb.append(qualified ? changedTypeAttribute.toQualifiedString() : changedTypeAttribute.toString());
+		sb.append(qualified ? changedTypeVariableDeclaration.toQualifiedString() : changedTypeVariableDeclaration.toString());
 		sb.append(" in class ").append(classNameAfter);
 		return sb.toString();
 	}
@@ -83,10 +86,10 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((changedTypeAttribute == null) ? 0 : changedTypeAttribute.hashCode());
+		result = prime * result + ((changedTypeAttribute == null || changedTypeAttribute.getVariableDeclaration() == null) ? 0 : changedTypeAttribute.getVariableDeclaration().hashCode());
 		result = prime * result + ((classNameAfter == null) ? 0 : classNameAfter.hashCode());
 		result = prime * result + ((classNameBefore == null) ? 0 : classNameBefore.hashCode());
-		result = prime * result + ((originalAttribute == null) ? 0 : originalAttribute.hashCode());
+		result = prime * result + ((originalAttribute == null || changedTypeAttribute.getVariableDeclaration() == null) ? 0 : originalAttribute.getVariableDeclaration().hashCode());
 		return result;
 	}
 
@@ -102,7 +105,10 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 		if (changedTypeAttribute == null) {
 			if (other.changedTypeAttribute != null)
 				return false;
-		} else if (!changedTypeAttribute.equals(other.changedTypeAttribute))
+		} else if(changedTypeAttribute.getVariableDeclaration() == null) {
+			if(other.changedTypeAttribute.getVariableDeclaration() != null)
+				return false;
+		} else if (!changedTypeAttribute.getVariableDeclaration().equals(other.changedTypeAttribute.getVariableDeclaration()))
 			return false;
 		if (classNameAfter == null) {
 			if (other.classNameAfter != null)
@@ -117,7 +123,10 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 		if (originalAttribute == null) {
 			if (other.originalAttribute != null)
 				return false;
-		} else if (!originalAttribute.equals(other.originalAttribute))
+		} else if(originalAttribute.getVariableDeclaration() == null) {
+			if(other.originalAttribute.getVariableDeclaration() != null)
+				return false;
+		} else if (!originalAttribute.getVariableDeclaration().equals(other.originalAttribute.getVariableDeclaration()))
 			return false;
 		return true;
 	}

--- a/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/ChangeAttributeTypeRefactoring.java
@@ -10,22 +10,22 @@ import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 
 import gr.uom.java.xmi.decomposition.AbstractCodeMapping;
-import gr.uom.java.xmi.decomposition.VariableDeclaration;
+import gr.uom.java.xmi.UMLAttribute;
 
 public class ChangeAttributeTypeRefactoring implements Refactoring {
-	private VariableDeclaration originalAttribute;
-	private VariableDeclaration changedTypeAttribute;
+	private UMLAttribute originalAttribute;
+	private UMLAttribute changedTypeAttribute;
 	private String classNameBefore;
 	private String classNameAfter;
 	private Set<AbstractCodeMapping> attributeReferences;
 	private Set<Refactoring> relatedRefactorings;
 	
-	public ChangeAttributeTypeRefactoring(VariableDeclaration originalAttribute,
-			VariableDeclaration changedTypeAttribute, String classNameBefore, String classNameAfter, Set<AbstractCodeMapping> attributeReferences) {
+	public ChangeAttributeTypeRefactoring(UMLAttribute originalAttribute,
+										  UMLAttribute changedTypeAttribute, Set<AbstractCodeMapping> attributeReferences) {
 		this.originalAttribute = originalAttribute;
 		this.changedTypeAttribute = changedTypeAttribute;
-		this.classNameBefore = classNameBefore;
-		this.classNameAfter = classNameAfter;
+		this.classNameBefore = originalAttribute.getClassName();
+		this.classNameAfter = changedTypeAttribute.getClassName();
 		this.attributeReferences = attributeReferences;
 		this.relatedRefactorings = new LinkedHashSet<Refactoring>();
 	}
@@ -38,11 +38,11 @@ public class ChangeAttributeTypeRefactoring implements Refactoring {
 		return relatedRefactorings;
 	}
 
-	public VariableDeclaration getOriginalAttribute() {
+	public UMLAttribute getOriginalAttribute() {
 		return originalAttribute;
 	}
 
-	public VariableDeclaration getChangedTypeAttribute() {
+	public UMLAttribute getChangedTypeAttribute() {
 		return changedTypeAttribute;
 	}
 

--- a/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
@@ -71,7 +71,7 @@ public class MergeAttributeRefactoring implements Refactoring {
 		result = prime * result + ((classNameAfter == null) ? 0 : classNameAfter.hashCode());
 		result = prime * result + ((classNameBefore == null) ? 0 : classNameBefore.hashCode());
 		Set<VariableDeclaration> mergedVariables = getMergedVariables();
-		result = prime * result + ((mergedVariables == null) ? 0 : mergedVariables.hashCode());
+		result = prime * result + ((mergedVariables.isEmpty()) ? 0 : mergedVariables.hashCode());
 		result = prime * result + ((newAttribute == null || newAttribute.getVariableDeclaration() == null) ? 0 : newAttribute.getVariableDeclaration().hashCode());
 		return result;
 	}
@@ -95,12 +95,7 @@ public class MergeAttributeRefactoring implements Refactoring {
 				return false;
 		} else if (!classNameBefore.equals(other.classNameBefore))
 			return false;
-		Set<VariableDeclaration> thisMergedVariables = this.getMergedVariables();
-		Set<VariableDeclaration> otherMergedVariables = other.getMergedVariables();
-		if (thisMergedVariables == null) {
-			if (otherMergedVariables != null)
-				return false;
-		} else if (!thisMergedVariables.equals(otherMergedVariables))
+		if (!this.getMergedVariables().equals(other.getMergedVariables()))
 			return false;
 		if (newAttribute == null) {
 			if (other.newAttribute != null)
@@ -130,7 +125,7 @@ public class MergeAttributeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> leftSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		for(UMLAttribute mergedAttribute : mergedAttributes) {
+		for(VariableDeclaration mergedAttribute : getMergedVariables()) {
 			ranges.add(mergedAttribute.codeRange()
 					.setDescription("merged attribute declaration")
 					.setCodeElement(mergedAttribute.toString()));
@@ -141,15 +136,15 @@ public class MergeAttributeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> rightSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		ranges.add(newAttribute.codeRange()
+		ranges.add(newAttribute.getVariableDeclaration().codeRange()
 				.setDescription("new attribute declaration")
-				.setCodeElement(newAttribute.toString()));
+				.setCodeElement(newAttribute.getVariableDeclaration().toString()));
 		return ranges;
 	}
 
 	private Set<VariableDeclaration> getMergedVariables() {
 		if (mergedAttributes == null)
-			return null;
+			return Collections.emptySet();
 		return mergedAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toSet());
 	}
 }

--- a/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
@@ -143,8 +143,6 @@ public class MergeAttributeRefactoring implements Refactoring {
 	}
 
 	private Set<VariableDeclaration> getMergedVariables() {
-		if (mergedAttributes == null)
-			return Collections.emptySet();
-		return mergedAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toSet());
+		return mergedAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 }

--- a/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
@@ -9,16 +9,16 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 
-import gr.uom.java.xmi.decomposition.VariableDeclaration;
+import gr.uom.java.xmi.UMLAttribute;
 
 public class MergeAttributeRefactoring implements Refactoring {
-	private Set<VariableDeclaration> mergedAttributes;
-	private VariableDeclaration newAttribute;
+	private Set<UMLAttribute> mergedAttributes;
+	private UMLAttribute newAttribute;
 	private Set<CandidateMergeVariableRefactoring> attributeMerges;
 	private String classNameBefore;
 	private String classNameAfter;
 	
-	public MergeAttributeRefactoring(Set<VariableDeclaration> mergedAttributes, VariableDeclaration newAttribute,
+	public MergeAttributeRefactoring(Set<UMLAttribute> mergedAttributes, UMLAttribute newAttribute,
 			String classNameBefore, String classNameAfter, Set<CandidateMergeVariableRefactoring> attributeMerges) {
 		this.mergedAttributes = mergedAttributes;
 		this.newAttribute = newAttribute;
@@ -27,11 +27,11 @@ public class MergeAttributeRefactoring implements Refactoring {
 		this.attributeMerges = attributeMerges;
 	}
 
-	public Set<VariableDeclaration> getMergedAttributes() {
+	public Set<UMLAttribute> getMergedAttributes() {
 		return mergedAttributes;
 	}
 
-	public VariableDeclaration getNewAttribute() {
+	public UMLAttribute getNewAttribute() {
 		return newAttribute;
 	}
 
@@ -110,7 +110,7 @@ public class MergeAttributeRefactoring implements Refactoring {
 
 	public Set<ImmutablePair<String, String>> getInvolvedClassesBeforeRefactoring() {
 		Set<ImmutablePair<String, String>> pairs = new LinkedHashSet<ImmutablePair<String, String>>();
-		for(VariableDeclaration mergedAttribute : this.mergedAttributes) {
+		for(UMLAttribute mergedAttribute : this.mergedAttributes) {
 			pairs.add(new ImmutablePair<String, String>(mergedAttribute.getLocationInfo().getFilePath(), getClassNameBefore()));
 		}
 		return pairs;
@@ -125,7 +125,7 @@ public class MergeAttributeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> leftSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		for(VariableDeclaration mergedAttribute : mergedAttributes) {
+		for(UMLAttribute mergedAttribute : mergedAttributes) {
 			ranges.add(mergedAttribute.codeRange()
 					.setDescription("merged attribute declaration")
 					.setCodeElement(mergedAttribute.toString()));

--- a/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/MergeAttributeRefactoring.java
@@ -143,6 +143,6 @@ public class MergeAttributeRefactoring implements Refactoring {
 	}
 
 	private Set<VariableDeclaration> getMergedVariables() {
-		return mergedAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
+		return mergedAttributes.stream().map(UMLAttribute::getVariableDeclaration).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 }

--- a/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
@@ -129,18 +129,18 @@ public class RenameAttributeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> leftSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		ranges.add(originalAttribute.codeRange()
+		ranges.add(originalAttribute.getVariableDeclaration().codeRange()
 				.setDescription("original attribute declaration")
-				.setCodeElement(originalAttribute.toString()));
+				.setCodeElement(originalAttribute.getVariableDeclaration().toString()));
 		return ranges;
 	}
 
 	@Override
 	public List<CodeRange> rightSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		ranges.add(renamedAttribute.codeRange()
+		ranges.add(renamedAttribute.getVariableDeclaration().codeRange()
 				.setDescription("renamed attribute declaration")
-				.setCodeElement(renamedAttribute.toString()));
+				.setCodeElement(renamedAttribute.getVariableDeclaration().toString()));
 		return ranges;
 	}
 }

--- a/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
@@ -9,29 +9,29 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 
-import gr.uom.java.xmi.decomposition.VariableDeclaration;
+import gr.uom.java.xmi.UMLAttribute;
 
 public class RenameAttributeRefactoring implements Refactoring {
-	private VariableDeclaration originalAttribute;
-	private VariableDeclaration renamedAttribute;
+	private UMLAttribute originalAttribute;
+	private UMLAttribute renamedAttribute;
 	private Set<CandidateAttributeRefactoring> attributeRenames;
 	private String classNameBefore;
 	private String classNameAfter;
 
-	public RenameAttributeRefactoring(VariableDeclaration originalAttribute, VariableDeclaration renamedAttribute,
-			String classNameBefore, String classNameAfter, Set<CandidateAttributeRefactoring> attributeRenames) {
+	public RenameAttributeRefactoring(UMLAttribute originalAttribute, UMLAttribute renamedAttribute,
+			Set<CandidateAttributeRefactoring> attributeRenames) {
 		this.originalAttribute = originalAttribute;
 		this.renamedAttribute = renamedAttribute;
-		this.classNameBefore = classNameBefore;
-		this.classNameAfter = classNameAfter;
+		this.classNameBefore = originalAttribute.getClassName();;
+		this.classNameAfter = renamedAttribute.getClassName();;
 		this.attributeRenames = attributeRenames;
 	}
 
-	public VariableDeclaration getOriginalAttribute() {
+	public UMLAttribute getOriginalAttribute() {
 		return originalAttribute;
 	}
 
-	public VariableDeclaration getRenamedAttribute() {
+	public UMLAttribute getRenamedAttribute() {
 		return renamedAttribute;
 	}
 

--- a/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/RenameAttributeRefactoring.java
@@ -58,9 +58,9 @@ public class RenameAttributeRefactoring implements Refactoring {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(getName()).append("\t");
-		sb.append(originalAttribute);
+		sb.append(originalAttribute.getVariableDeclaration());
 		sb.append(" to ");
-		sb.append(renamedAttribute);
+		sb.append(renamedAttribute.getVariableDeclaration());
 		sb.append(" in class ").append(classNameAfter);
 		return sb.toString();
 	}
@@ -71,8 +71,8 @@ public class RenameAttributeRefactoring implements Refactoring {
 		int result = 1;
 		result = prime * result + ((classNameAfter == null) ? 0 : classNameAfter.hashCode());
 		result = prime * result + ((classNameBefore == null) ? 0 : classNameBefore.hashCode());
-		result = prime * result + ((originalAttribute == null) ? 0 : originalAttribute.hashCode());
-		result = prime * result + ((renamedAttribute == null) ? 0 : renamedAttribute.hashCode());
+		result = prime * result + ((originalAttribute == null || originalAttribute.getVariableDeclaration() == null) ? 0 : originalAttribute.getVariableDeclaration().hashCode());
+		result = prime * result + ((renamedAttribute == null || renamedAttribute.getVariableDeclaration() == null) ? 0 : renamedAttribute.getVariableDeclaration().hashCode());
 		return result;
 	}
 
@@ -98,12 +98,18 @@ public class RenameAttributeRefactoring implements Refactoring {
 		if (originalAttribute == null) {
 			if (other.originalAttribute != null)
 				return false;
-		} else if (!originalAttribute.equals(other.originalAttribute))
+		} else if(originalAttribute.getVariableDeclaration() == null) {
+			if(other.originalAttribute.getVariableDeclaration() != null)
+				return false;
+		} else if (!originalAttribute.getVariableDeclaration().equals(other.originalAttribute.getVariableDeclaration()))
 			return false;
 		if (renamedAttribute == null) {
 			if (other.renamedAttribute != null)
 				return false;
-		} else if (!renamedAttribute.equals(other.renamedAttribute))
+		} else if(renamedAttribute.getVariableDeclaration() == null) {
+			if(other.renamedAttribute.getVariableDeclaration() != null)
+				return false;
+		} else if (!renamedAttribute.getVariableDeclaration().equals(other.renamedAttribute.getVariableDeclaration()))
 			return false;
 		return true;
 	}

--- a/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
@@ -9,17 +9,17 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 
-import gr.uom.java.xmi.decomposition.VariableDeclaration;
+import gr.uom.java.xmi.UMLAttribute;
 
 public class SplitAttributeRefactoring implements Refactoring {
-	private VariableDeclaration oldAttribute;
-	private Set<VariableDeclaration> splitAttributes;
+	private UMLAttribute oldAttribute;
+	private Set<UMLAttribute> splitAttributes;
 	private Set<CandidateSplitVariableRefactoring> attributeSplits;
 	private String classNameBefore;
 	private String classNameAfter;
 
-	public SplitAttributeRefactoring(VariableDeclaration oldAttribute, Set<VariableDeclaration> splitAttributes,
-			String classNameBefore, String classNameAfter, Set<CandidateSplitVariableRefactoring> attributeSplits) {
+	public SplitAttributeRefactoring(UMLAttribute oldAttribute, Set<UMLAttribute> splitAttributes,
+									 String classNameBefore, String classNameAfter, Set<CandidateSplitVariableRefactoring> attributeSplits) {
 		this.oldAttribute = oldAttribute;
 		this.splitAttributes = splitAttributes;
 		this.classNameBefore = classNameBefore;
@@ -27,11 +27,11 @@ public class SplitAttributeRefactoring implements Refactoring {
 		this.attributeSplits = attributeSplits;
 	}
 
-	public VariableDeclaration getOldAttribute() {
+	public UMLAttribute getOldAttribute() {
 		return oldAttribute;
 	}
 
-	public Set<VariableDeclaration> getSplitAttributes() {
+	public Set<UMLAttribute> getSplitAttributes() {
 		return splitAttributes;
 	}
 
@@ -120,7 +120,7 @@ public class SplitAttributeRefactoring implements Refactoring {
 	@Override
 	public Set<ImmutablePair<String, String>> getInvolvedClassesAfterRefactoring() {
 		Set<ImmutablePair<String, String>> pairs = new LinkedHashSet<ImmutablePair<String, String>>();
-		for(VariableDeclaration splitAttribute : this.splitAttributes) {
+		for(UMLAttribute splitAttribute : this.splitAttributes) {
 			pairs.add(new ImmutablePair<String, String>(splitAttribute.getLocationInfo().getFilePath(), getClassNameAfter()));
 		}
 		return pairs;
@@ -138,7 +138,7 @@ public class SplitAttributeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> rightSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		for(VariableDeclaration splitAttribute : splitAttributes) {
+		for(UMLAttribute splitAttribute : splitAttributes) {
 			ranges.add(splitAttribute.codeRange()
 					.setDescription("split attribute declaration")
 					.setCodeElement(splitAttribute.toString()));

--- a/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
@@ -74,7 +74,7 @@ public class SplitAttributeRefactoring implements Refactoring {
 		result = prime * result + ((classNameBefore == null) ? 0 : classNameBefore.hashCode());
 		result = prime * result + ((oldAttribute == null || oldAttribute.getVariableDeclaration() == null) ? 0 : oldAttribute.getVariableDeclaration().hashCode());
 		Set<VariableDeclaration> splitVariables = getSplitVariables();
-		result = prime * result + ((splitVariables == null) ? 0 : splitVariables.hashCode());
+		result = prime * result + ((splitVariables.isEmpty()) ? 0 : splitVariables.hashCode());
 		return result;
 	}
 
@@ -109,12 +109,7 @@ public class SplitAttributeRefactoring implements Refactoring {
 			if (other.splitAttributes != null)
 				return false;
 		}
-		Set<VariableDeclaration> thisSplitVariables = this.getSplitVariables();
-		Set<VariableDeclaration> otherSplitVariables = other.getSplitVariables();
-		if (thisSplitVariables == null) {
-			if (otherSplitVariables != null)
-				return false;
-		} else if (!thisSplitVariables.equals(otherSplitVariables))
+		if (!this.getSplitVariables().equals(other.getSplitVariables()))
 				return false;
 		return true;
 	}
@@ -138,26 +133,26 @@ public class SplitAttributeRefactoring implements Refactoring {
 	@Override
 	public List<CodeRange> leftSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		ranges.add(oldAttribute.codeRange()
+		ranges.add(oldAttribute.getVariableDeclaration().codeRange()
 				.setDescription("original attribute declaration")
-				.setCodeElement(oldAttribute.toString()));
+				.setCodeElement(oldAttribute.getVariableDeclaration().toString()));
 		return ranges;
 	}
 
 	@Override
 	public List<CodeRange> rightSide() {
 		List<CodeRange> ranges = new ArrayList<CodeRange>();
-		for(UMLAttribute splitAttribute : splitAttributes) {
-			ranges.add(splitAttribute.codeRange()
+		for(VariableDeclaration splitVariableDeclaration : getSplitVariables()) {
+			ranges.add(splitVariableDeclaration.codeRange()
 					.setDescription("split attribute declaration")
-					.setCodeElement(splitAttribute.toString()));
+					.setCodeElement(splitVariableDeclaration.toString()));
 		}
 		return ranges;
 	}
 
 	private Set<VariableDeclaration> getSplitVariables() {
 		if (splitAttributes == null)
-			return null;
+			return Collections.emptySet();
 		return splitAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toSet());
 	}
 }

--- a/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
@@ -151,6 +151,6 @@ public class SplitAttributeRefactoring implements Refactoring {
 	}
 
 	private Set<VariableDeclaration> getSplitVariables() {
-		return splitAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
+		return splitAttributes.stream().map(UMLAttribute::getVariableDeclaration).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 }

--- a/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
+++ b/src/gr/uom/java/xmi/diff/SplitAttributeRefactoring.java
@@ -151,8 +151,6 @@ public class SplitAttributeRefactoring implements Refactoring {
 	}
 
 	private Set<VariableDeclaration> getSplitVariables() {
-		if (splitAttributes == null)
-			return Collections.emptySet();
-		return splitAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toSet());
+		return splitAttributes.stream().map(UMLAttribute::getVariableDeclaration).filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 }

--- a/src/gr/uom/java/xmi/diff/UMLAttributeDiff.java
+++ b/src/gr/uom/java/xmi/diff/UMLAttributeDiff.java
@@ -123,7 +123,7 @@ public class UMLAttributeDiff {
 	public Set<Refactoring> getRefactorings() {
 		Set<Refactoring> refactorings = new LinkedHashSet<Refactoring>();
 		if(isTypeChanged() || isQualifiedTypeChanged()) {
-			ChangeAttributeTypeRefactoring ref = new ChangeAttributeTypeRefactoring(removedAttribute.getVariableDeclaration(), addedAttribute.getVariableDeclaration(), removedAttribute.getClassName(), addedAttribute.getClassName(),
+			ChangeAttributeTypeRefactoring ref = new ChangeAttributeTypeRefactoring(removedAttribute, addedAttribute,
 					VariableReferenceExtractor.findReferences(removedAttribute.getVariableDeclaration(), addedAttribute.getVariableDeclaration(), operationBodyMapperList));
 			refactorings.add(ref);
 		}
@@ -139,7 +139,7 @@ public class UMLAttributeDiff {
 			refactorings.add(rename);
 		}
 		if(isTypeChanged() || isQualifiedTypeChanged()) {
-			ChangeAttributeTypeRefactoring ref = new ChangeAttributeTypeRefactoring(removedAttribute.getVariableDeclaration(), addedAttribute.getVariableDeclaration(), removedAttribute.getClassName(), addedAttribute.getClassName(),
+			ChangeAttributeTypeRefactoring ref = new ChangeAttributeTypeRefactoring(removedAttribute, addedAttribute,
 					VariableReferenceExtractor.findReferences(removedAttribute.getVariableDeclaration(), addedAttribute.getVariableDeclaration(), operationBodyMapperList));
 			refactorings.add(ref);
 			if(rename != null) {

--- a/src/gr/uom/java/xmi/diff/UMLAttributeDiff.java
+++ b/src/gr/uom/java/xmi/diff/UMLAttributeDiff.java
@@ -135,7 +135,7 @@ public class UMLAttributeDiff {
 		Set<Refactoring> refactorings = new LinkedHashSet<Refactoring>();
 		RenameAttributeRefactoring rename = null;
 		if(isRenamed()) {
-			rename = new RenameAttributeRefactoring(removedAttribute.getVariableDeclaration(), addedAttribute.getVariableDeclaration(), removedAttribute.getClassName(), addedAttribute.getClassName(), set);
+			rename = new RenameAttributeRefactoring(removedAttribute, addedAttribute, set);
 			refactorings.add(rename);
 		}
 		if(isTypeChanged() || isQualifiedTypeChanged()) {

--- a/src/gr/uom/java/xmi/diff/UMLClassBaseDiff.java
+++ b/src/gr/uom/java/xmi/diff/UMLClassBaseDiff.java
@@ -505,7 +505,7 @@ public abstract class UMLClassBaseDiff implements Comparable<UMLClassBaseDiff> {
 			Set<CandidateMergeVariableRefactoring> set = mergeMap.get(merge);
 			for(CandidateMergeVariableRefactoring candidate : set) {
 				if(mergedVariables.size() > 1 && mergedVariables.size() == merge.getMergedVariables().size() && a2 != null) {
-					MergeAttributeRefactoring ref = new MergeAttributeRefactoring(mergedVariables, a2.getVariableDeclaration(), getOriginalClassName(), getNextClassName(), set);
+					MergeAttributeRefactoring ref = new MergeAttributeRefactoring(mergedAttributes, a2, getOriginalClassName(), getNextClassName(), set);
 					if(!refactorings.contains(ref)) {
 						refactorings.add(ref);
 						break;//it's not necessary to repeat the same process for all candidates in the set
@@ -758,7 +758,7 @@ public abstract class UMLClassBaseDiff implements Comparable<UMLClassBaseDiff> {
 							}
 							UMLAttribute a2 = findAttributeInNextClass(renamedAttributeName);
 							if(mergedVariables.size() > 1 && mergedVariables.size() == merge.getMergedVariables().size() && a2 != null) {
-								MergeAttributeRefactoring ref = new MergeAttributeRefactoring(mergedVariables, a2.getVariableDeclaration(), getOriginalClassName(), getNextClassName(), new LinkedHashSet<CandidateMergeVariableRefactoring>());
+								MergeAttributeRefactoring ref = new MergeAttributeRefactoring(mergedAttributes, a2, getOriginalClassName(), getNextClassName(), new LinkedHashSet<CandidateMergeVariableRefactoring>());
 								if(!refactorings.contains(ref)) {
 									newRefactorings.add(ref);
 								}

--- a/src/gr/uom/java/xmi/diff/UMLClassBaseDiff.java
+++ b/src/gr/uom/java/xmi/diff/UMLClassBaseDiff.java
@@ -532,7 +532,7 @@ public abstract class UMLClassBaseDiff implements Comparable<UMLClassBaseDiff> {
 			Set<CandidateSplitVariableRefactoring> set = splitMap.get(split);
 			for(CandidateSplitVariableRefactoring candidate : set) {
 				if(splitVariables.size() > 1 && splitVariables.size() == split.getSplitVariables().size() && a1 != null) {
-					SplitAttributeRefactoring ref = new SplitAttributeRefactoring(a1.getVariableDeclaration(), splitVariables, getOriginalClassName(), getNextClassName(), set);
+					SplitAttributeRefactoring ref = new SplitAttributeRefactoring(a1, splitAttributes, getOriginalClassName(), getNextClassName(), set);
 					if(!refactorings.contains(ref)) {
 						refactorings.add(ref);
 						break;//it's not necessary to repeat the same process for all candidates in the set
@@ -804,7 +804,7 @@ public abstract class UMLClassBaseDiff implements Comparable<UMLClassBaseDiff> {
 							}
 							UMLAttribute a1 = findAttributeInOriginalClass(originalAttributeName);
 							if(splitVariables.size() > 1 && splitVariables.size() == split.getSplitVariables().size() && a1 != null) {
-								SplitAttributeRefactoring ref = new SplitAttributeRefactoring(a1.getVariableDeclaration(), splitVariables, getOriginalClassName(), getNextClassName(), new LinkedHashSet<CandidateSplitVariableRefactoring>());
+								SplitAttributeRefactoring ref = new SplitAttributeRefactoring(a1, splitAttributes, getOriginalClassName(), getNextClassName(), new LinkedHashSet<CandidateSplitVariableRefactoring>());
 								if(!refactorings.contains(ref)) {
 									newRefactorings.add(ref);
 								}

--- a/src/gr/uom/java/xmi/diff/UMLModelDiff.java
+++ b/src/gr/uom/java/xmi/diff/UMLModelDiff.java
@@ -1344,7 +1344,7 @@ public class UMLModelDiff {
     		  UMLAttribute a2 = diff.findAttributeInNextClass(merge.getAfter());
     		  Set<CandidateMergeVariableRefactoring> set = mergeMap.get(merge);
     		  if(mergedVariables.size() > 1 && mergedVariables.size() == merge.getMergedVariables().size() && a2 != null) {
-    			  MergeAttributeRefactoring ref = new MergeAttributeRefactoring(mergedVariables, a2.getVariableDeclaration(), diff.getOriginalClassName(), diff.getNextClassName(), set);
+    			  MergeAttributeRefactoring ref = new MergeAttributeRefactoring(mergedAttributes, a2, diff.getOriginalClassName(), diff.getNextClassName(), set);
     			  if(!refactorings.contains(ref)) {
     				  refactorings.add(ref);
     				  Refactoring conflictingRefactoring = attributeRenamed(mergedVariables, a2.getVariableDeclaration(), refactorings);


### PR DESCRIPTION
There are some attribute level refactoring-types like ChangeAttributeTypeRefactoring, RenameAttributeRefactoring, MergeAttributeRefactoring, and SplitAttributeRefactoring has instances of VariableDeclaration class as attributes to keep the state of a refactored attribute before and after refactoring.
However, the other attribute level refactoring types like MoveAttributeRefactoring and AddAttributeAnnotationRefactoring have instances of UMLAttribute class to do the same.

Therefore, to make the code more uniform, it is better to refactor those refactoring classes to use UMLAttribute, which contains more information in comparison to VariableDeclaration.