### PR TITLE
Flush the detection results whenever a new result is obtained

### DIFF
--- a/src/org/refactoringminer/RefactoringMiner.java
+++ b/src/org/refactoringminer/RefactoringMiner.java
@@ -62,6 +62,8 @@ public class RefactoringMiner {
 				public void handle(String commitId, List<Refactoring> refactorings) {
 					if(commitCount > 0) {
 						sb.append(",").append("\n");
+						System.out.print(sb.toString());
+						sb.setLength(0);
 					}
 					commitJSON(sb, gitURL, commitId, refactorings);
 					commitCount++;
@@ -103,6 +105,8 @@ public class RefactoringMiner {
 				public void handle(String commitId, List<Refactoring> refactorings) {
 					if(commitCount > 0) {
 						sb.append(",").append("\n");
+						System.out.print(sb.toString());
+						sb.setLength(0);
 					}
 					commitJSON(sb, gitURL, commitId, refactorings);
 					commitCount++;
@@ -144,6 +148,8 @@ public class RefactoringMiner {
 				public void handle(String commitId, List<Refactoring> refactorings) {
 					if(commitCount > 0) {
 						sb.append(",").append("\n");
+						System.out.print(sb.toString());
+						sb.setLength(0);
 					}
 					commitJSON(sb, gitURL, commitId, refactorings);
 					commitCount++;
@@ -237,6 +243,8 @@ public class RefactoringMiner {
 			public void handle(String commitId, List<Refactoring> refactorings) {
 				if(commitCount > 0) {
 					sb.append(",").append("\n");
+					System.out.print(sb.toString());
+					sb.setLength(0);
 				}
 				commitJSON(sb, gitURL, commitId, refactorings);
 				commitCount++;


### PR DESCRIPTION
The current RefactoringMiner accumulates all the detection results in a StringBuilder object when analyzing multiple commits (e.g., an entire repository) and then prints it to the standard output. This behavior might be less useful from the following two viewpoints, especially when the repository to be analyzed is very large.
1. Storing all the results in a StringBuilder accelerates the memory consumption of the process.
2. Waiting for the output until completing the analysis of all the commits hinders monitoring the progress from outside. Continuous outputting the results to the stream is useful to check whether the analysis is well in progress. Also, such an output is useful when restarting from an appropriate commit after the process terminated accidentally.

The following is an ad-hoc patch (rationale: minimizing the changes) that flushes the results stored in StringBuilder to standard output whenever any new result is obtained. An alternative solution might be to make the variable `sb` more abstract (java.lang.Appendable) and use `System.out` (PrintStream) directly in the methods that may analyze multiple commits.