### PR TITLE
Fixing Diff problems

### DIFF
--- a/src/org/refactoringminer/astDiff/matchers/ExtendedMultiMappingStore.java
+++ b/src/org/refactoringminer/astDiff/matchers/ExtendedMultiMappingStore.java
@@ -225,4 +225,26 @@ public class ExtendedMultiMappingStore extends MultiMappingStore implements Iter
 				this.replaceMapping(realSrc,realDst);
 		}
 	}
+
+	public void replaceWithOptimizedMappings(ExtendedMultiMappingStore optimizationMappings) {
+		for (Mapping optimizationMapping : optimizationMappings) {
+			Tree srcMapped = optimizationMapping.first;
+			Tree dstMapped = optimizationMapping.second;
+			if (this.getDsts(srcMapped) != null)
+			{
+				Set<Tree> dstForSrcList = new LinkedHashSet<>(this.getDsts(srcMapped));
+				for (Tree dstForSrc : dstForSrcList)
+					removeMapping(srcMapped,dstForSrc);
+			}
+			if (this.getSrcs(dstMapped) != null)
+			{
+				Set<Tree> srcForDstList = new LinkedHashSet<>(this.getSrcs(dstMapped));
+				for (Tree srcForDst : srcForDstList)
+					removeMapping(srcForDst,dstMapped);
+			}
+		}
+		for (Mapping optimizationMapping : optimizationMappings) {
+			this.addMapping(optimizationMapping.first,optimizationMapping.second);
+		}
+	}
 }

--- a/src/org/refactoringminer/astDiff/matchers/ExtendedMultiMappingStore.java
+++ b/src/org/refactoringminer/astDiff/matchers/ExtendedMultiMappingStore.java
@@ -7,7 +7,6 @@ import com.github.gumtreediff.matchers.MappingStore;
 import com.github.gumtreediff.matchers.MultiMappingStore;
 import com.github.gumtreediff.tree.FakeTree;
 import com.github.gumtreediff.tree.Tree;
-import com.github.gumtreediff.tree.TreeContext;
 import com.github.gumtreediff.tree.TreeUtils;
 import com.github.gumtreediff.utils.Pair;
 
@@ -16,13 +15,13 @@ import com.github.gumtreediff.utils.Pair;
  * @since   2022-12-26 12:19 a.m.
  */
 public class ExtendedMultiMappingStore extends MultiMappingStore implements Iterable<Mapping> {
-	private TreeContext srcTC;
-	private TreeContext dstTC;
+	private final Tree src;
+	private final Tree dst;
 
-	public ExtendedMultiMappingStore(TreeContext srcTC, TreeContext dstTC) {
+	public ExtendedMultiMappingStore(Tree srcTree, Tree dstTree) {
 		super();
-		this.srcTC = srcTC;
-		this.dstTC = dstTC;
+		this.src = srcTree;
+		this.dst = dstTree;
 	}
 
 	public boolean isDstMultiMapped(Tree dstTree) {
@@ -95,7 +94,7 @@ public class ExtendedMultiMappingStore extends MultiMappingStore implements Iter
 	}
 
 	public MappingStore getMonoMappingStore() {
-		MappingStore monoStore = new MappingStore(srcTC.getRoot(),dstTC.getRoot());
+		MappingStore monoStore = new MappingStore(src,dst);
 		for (Map.Entry<Tree,Tree> entry : getSrcToDstMono().entrySet())
 			monoStore.addMapping(entry.getKey(),entry.getValue());
 		return monoStore;

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -690,23 +690,21 @@ public class ProjectASTDiffer
 		return pairs;
 	}
 
-	private void processFieldDeclaration(Tree srcTree, Tree dstTree, UMLAttribute srcUMLAttribute,UMLAttribute dstUMLAttribute, ExtendedMultiMappingStore mappingStore)
-	{
+	private void processFieldDeclaration(Tree srcTree, Tree dstTree, UMLAttribute srcUMLAttribute,UMLAttribute dstUMLAttribute, ExtendedMultiMappingStore mappingStore) {
 
-		Tree srcAttr = TreeUtilFunctions.findByLocationInfo(srcTree,srcUMLAttribute.getLocationInfo());
-		Tree dstAttr = TreeUtilFunctions.findByLocationInfo(dstTree,dstUMLAttribute.getLocationInfo());
-		Tree srcFieldDeclaration = TreeUtilFunctions.getParentUntilType(srcAttr,Constants.FIELD_DECLARATION);
-		Tree dstFieldDeclaration = TreeUtilFunctions.getParentUntilType(dstAttr,Constants.FIELD_DECLARATION);
-		if (srcFieldDeclaration == null)
-		{
-			srcFieldDeclaration = TreeUtilFunctions.getParentUntilType(srcAttr,Constants.ENUM_CONSTANT_DECLARATION);
+		Tree srcAttr = TreeUtilFunctions.findByLocationInfo(srcTree, srcUMLAttribute.getLocationInfo());
+		Tree dstAttr = TreeUtilFunctions.findByLocationInfo(dstTree, dstUMLAttribute.getLocationInfo());
+		Tree srcFieldDeclaration = TreeUtilFunctions.getParentUntilType(srcAttr, Constants.FIELD_DECLARATION);
+		Tree dstFieldDeclaration = TreeUtilFunctions.getParentUntilType(dstAttr, Constants.FIELD_DECLARATION);
+		if (srcFieldDeclaration == null) {
+			srcFieldDeclaration = TreeUtilFunctions.getParentUntilType(srcAttr, Constants.ENUM_CONSTANT_DECLARATION);
 		}
-		if (dstFieldDeclaration == null)
-		{
-			dstFieldDeclaration = TreeUtilFunctions.getParentUntilType(dstAttr,Constants.ENUM_CONSTANT_DECLARATION);
+		if (dstFieldDeclaration == null) {
+			dstFieldDeclaration = TreeUtilFunctions.getParentUntilType(dstAttr, Constants.ENUM_CONSTANT_DECLARATION);
 		}
-		if (srcFieldDeclaration.getMetrics().hash == dstFieldDeclaration.getMetrics().hash ||
-				srcFieldDeclaration.isIsoStructuralTo(dstFieldDeclaration))
+		if (srcFieldDeclaration.getMetrics().hash == dstFieldDeclaration.getMetrics().hash
+//				|| srcFieldDeclaration.isIsoStructuralTo(dstFieldDeclaration))
+			)
 		{
 			// TODO: 8/3/2022 isoStructural can't be a good idea here, i.e anonymous class
 			mappingStore.addMappingRecursively(srcFieldDeclaration,dstFieldDeclaration);
@@ -746,8 +744,8 @@ public class ProjectASTDiffer
 		//if (attributeAccessModifierPair.first != null && attributeAccessModifierPair.second != null)
 		//	mappingStore.addMapping(attributeAccessModifierPair.first, attributeAccessModifierPair.second);
 
-		if (srcUMLAttribute.getVisibility().equals(dstUMLAttribute.getVisibility()))
-			matchModifierForField(srcFieldDeclaration,dstFieldDeclaration,srcUMLAttribute.getVisibility().toString(),mappingStore);
+//		if (srcUMLAttribute.getVisibility().equals(dstUMLAttribute.getVisibility()))
+		matchModifiersForField(srcFieldDeclaration,dstFieldDeclaration,srcUMLAttribute.getVisibility().toString(),dstUMLAttribute.getVisibility().toString(),mappingStore);
 		if (srcUMLAttribute.isFinal() && dstUMLAttribute.isFinal())
 			matchModifierForField(srcFieldDeclaration,dstFieldDeclaration,Constants.FINAL,mappingStore);
 		if (srcUMLAttribute.isVolatile() && dstUMLAttribute.isVolatile())
@@ -756,6 +754,13 @@ public class ProjectASTDiffer
 			matchModifierForField(srcFieldDeclaration,dstFieldDeclaration,Constants.STATIC,mappingStore);
 		if (srcUMLAttribute.isTransient() && dstUMLAttribute.isTransient())
 			matchModifierForField(srcFieldDeclaration,dstFieldDeclaration,Constants.TRANSIENT,mappingStore);
+	}
+
+	private void matchModifiersForField(Tree srcFieldDeclaration, Tree dstFieldDeclaration, String srcModifier, String dstModifier, ExtendedMultiMappingStore mappingStore) {
+		Tree srcModifierTree = findAttributeModifierByLabel(srcFieldDeclaration, srcModifier);
+		Tree dstModifierTree = findAttributeModifierByLabel(dstFieldDeclaration, dstModifier);
+		if (srcModifierTree != null && dstModifierTree != null)
+			mappingStore.addMapping(srcModifierTree,dstModifierTree);
 	}
 
 	private void matchModifierForField(Tree srcFieldDeclaration, Tree dstFieldDeclaration, String modifier, ExtendedMultiMappingStore mappingStore) {

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -26,10 +26,10 @@ public class ProjectASTDiffer
 {
 	private final static Logger logger = LoggerFactory.getLogger(ProjectASTDiffer.class);
 	private final boolean CHECK_COMMENTS = false;
-	private UMLModelDiff modelDiff;
+	private final UMLModelDiff modelDiff;
 	private List<AbstractCodeMapping> lastStepMappings;
 	private List<Refactoring> modelDiffRefactorings;
-	private Set<ASTDiff> diffSet = new LinkedHashSet<>();
+	private final Set<ASTDiff> diffSet = new LinkedHashSet<>();
 
 	public ProjectASTDiffer(UMLModelDiff modelDiff) throws RefactoringMinerTimedOutException {
 		this.modelDiff = modelDiff;
@@ -64,7 +64,7 @@ public class ProjectASTDiffer
 		logger.info("EditScript execution: " + (editScript_end - editScript_start)/ 1000 + " seconds");
 	}
 
-	private void makeASTDiff(List<? extends UMLClassBaseDiff> umlClassBaseDiffList, boolean mergeFlag) throws RefactoringMinerTimedOutException {
+	private void makeASTDiff(List<? extends UMLClassBaseDiff> umlClassBaseDiffList, boolean mergeFlag){
 		for (UMLClassBaseDiff classDiff : umlClassBaseDiffList) {
 			ASTDiff classASTDiff = process(classDiff, findTreeContexts(classDiff),mergeFlag);
 			ASTDiff append = findAppend(classASTDiff);
@@ -90,7 +90,7 @@ public class ProjectASTDiffer
 				modelDiff.getChildModel().getTreeContextMap().get(classDiff.getNextClass().getSourceFile()));
 	}
 
-	private ASTDiff process(UMLClassBaseDiff classDiff, Pair<TreeContext, TreeContext> treeContextPair,boolean mergeFlag) throws RefactoringMinerTimedOutException {
+	private ASTDiff process(UMLClassBaseDiff classDiff, Pair<TreeContext, TreeContext> treeContextPair,boolean mergeFlag){
 		TreeContext srcTreeContext = treeContextPair.first;
 		TreeContext dstTreeContext = treeContextPair.second;
 		Tree srcTree = srcTreeContext.getRoot();
@@ -504,14 +504,6 @@ public class ProjectASTDiffer
 				for(AbstractCodeMapping expressionMapping : inlineOperationRefactoring.getArgumentMappings()) {
 					lastStepMappings.add(expressionMapping);
 				}
-			}
-			else if (refactoring instanceof RenameAttributeRefactoring) {
-				RenameAttributeRefactoring renameAttributeRefactoring = (RenameAttributeRefactoring) refactoring;
-//				Tree srcAttrTree =TreeUtilFunctions.findByLocationInfo(srcTree,renameAttributeRefactoring.getOriginalAttribute().getLocationInfo()).getParent(); //Super Risky
-//				Tree dstAttrTree =TreeUtilFunctions.findByLocationInfo(dstTree,renameAttributeRefactoring.getRenamedAttribute().getLocationInfo()).getParent(); //Super Risky
-//				//if (dstAttrTree.isIsomorphicTo(srcAttrTree))
-//				//	mappingStore.addMappingRecursively(srcAttrTree.getParent(),dstAttrTree.getParent());
-//				processFieldDeclaration(srcAttrTree,dstAttrTree,renameAttributeRefactoring.getOriginalAttribute(),renameAttributeRefactoring.getRenamedAttribute(),mappingStore);
 			}
 			else if (refactoring instanceof ExtractVariableRefactoring) {
 				ExtractVariableRefactoring extractVariableRefactoring = (ExtractVariableRefactoring) refactoring;

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -829,6 +829,26 @@ public class ProjectASTDiffer
 			if (srcImportStatement != null && dstImportStatement != null)
 				mappingStore.addMappingRecursively(srcImportStatement,dstImportStatement);
 		}
+		//Grouped Imports
+		for (Map.Entry<Set<UMLImport>, UMLImport> setUMLImportEntry : importDiffList.getGroupedImports().entrySet()) {
+			Set<UMLImport> srcImportSet = setUMLImportEntry.getKey();
+			UMLImport dstImport = setUMLImportEntry.getValue();
+			Tree dstImportStatement = findImportByTypeAndLabel(dstChildren,searchingType,dstImport);
+			for (UMLImport srcUMLImport : srcImportSet) {
+				Tree srcImportStatement = findImportByTypeAndLabel(srcChildren,searchingType,srcUMLImport);
+				mappingStore.addMappingRecursively(srcImportStatement,dstImportStatement);
+			}
+		}
+		//UnGrouped Imports
+		for (Map.Entry<UMLImport, Set<UMLImport>> umlImportSetEntry : importDiffList.getUnGroupedImports().entrySet()) {
+			UMLImport srcImport = umlImportSetEntry.getKey();
+			Set<UMLImport> dstImportSet = umlImportSetEntry.getValue();
+			Tree srcImportStatement = findImportByTypeAndLabel(dstChildren,searchingType,srcImport);
+			for (UMLImport dstUMLImport : dstImportSet) {
+				Tree dstImportStatement = findImportByTypeAndLabel(srcChildren,searchingType,dstUMLImport);
+				mappingStore.addMappingRecursively(srcImportStatement,dstImportStatement);
+			}
+		}
 	}
 
 	private Tree findImportByTypeAndLabel(List<Tree> inputTree, String searchingType, UMLImport label) {

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -10,6 +10,7 @@ import gr.uom.java.xmi.diff.*;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringMinerTimedOutException;
+import org.refactoringminer.api.RefactoringType;
 import org.refactoringminer.astDiff.utils.TreeUtilFunctions;
 import org.refactoringminer.astDiff.actions.ASTDiff;
 
@@ -611,6 +612,24 @@ public class ProjectASTDiffer
 					new CompositeMatcher().match(srcTree,dstTree,
 							(AbstractStatement) eachMerged, (AbstractStatement) mergeCatchRefactoring.getNewCatchBlock()
 							,mappingStore);
+				}
+			}
+			else if (refactoring instanceof RenameVariableRefactoring)
+			{
+				RenameVariableRefactoring renameVariableRefactoring = (RenameVariableRefactoring) refactoring;
+				if (renameVariableRefactoring.getRefactoringType().equals(RefactoringType.REPLACE_VARIABLE_WITH_ATTRIBUTE))
+				{
+					VariableDeclaration originalVariable = renameVariableRefactoring.getOriginalVariable();
+					VariableDeclaration renamedVariable = renameVariableRefactoring.getRenamedVariable();
+					Tree srcVar = TreeUtilFunctions.findByLocationInfo(srcTree,originalVariable.getLocationInfo());
+					Tree dstVar = TreeUtilFunctions.findByLocationInfo(dstTree, renamedVariable.getLocationInfo());
+					System.out.println();
+					new LeafMatcher(false).match(
+							TreeUtilFunctions.getParentUntilType(srcVar,Constants.VARIABLE_DECLARATION_STATEMENT),
+							TreeUtilFunctions.getParentUntilType(dstVar,Constants.FIELD_DECLARATION),
+							null,
+							mappingStore);
+					//TODO: need more cases to generalize the logic
 				}
 			}
 		}

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -533,6 +533,36 @@ public class ProjectASTDiffer
 					processLeafMatcherForExtractVariables(srcTree,dstTree,mapping,mappingStore);
 				}
 			}
+			else if (refactoring instanceof InlineVariableRefactoring) {
+				//TODO: As same as ExVarRefactoring: API must be updated
+				InlineVariableRefactoring inlineVariableRefactoring = (InlineVariableRefactoring) refactoring;
+//				for(LeafMapping mapping : inlineVariableRefactoring.getSubExpressionMappings()) {
+//					processLeafMatcherForExtractVariables(srcTree,dstTree,mapping,mappingStore);
+//				}
+			}
+			else if (refactoring instanceof ReplaceAttributeRefactoring)
+			{
+				//TODO:
+				ReplaceAttributeRefactoring replaceAttributeRefactoring = (ReplaceAttributeRefactoring) refactoring;
+			}
+			else if (refactoring instanceof InlineAttributeRefactoring)
+			{
+				InlineAttributeRefactoring inlineAttributeRefactoring = (InlineAttributeRefactoring) refactoring;
+				Tree srcAttrDeclaration = TreeUtilFunctions.findByLocationInfo(srcTree, inlineAttributeRefactoring.getVariableDeclaration().getLocationInfo());
+				for (AbstractCodeMapping reference : inlineAttributeRefactoring.getReferences()) {
+					Tree dstStatementTree = TreeUtilFunctions.findByLocationInfo(dstTree,reference.getFragment2().getLocationInfo());
+					new LeafMatcher(false).match(srcAttrDeclaration,dstStatementTree,reference,mappingStore);
+				}
+			}
+			else if (refactoring instanceof ExtractAttributeRefactoring)
+			{
+				ExtractAttributeRefactoring extractAttributeRefactoring = (ExtractAttributeRefactoring) refactoring;
+				Tree dstAttrDeclaration = TreeUtilFunctions.findByLocationInfo(dstTree, extractAttributeRefactoring.getVariableDeclaration().getLocationInfo());
+				for (AbstractCodeMapping reference : extractAttributeRefactoring.getReferences()) {
+					Tree srcStatementTree = TreeUtilFunctions.findByLocationInfo(srcTree,reference.getFragment1().getLocationInfo());
+					new LeafMatcher(false).match(srcStatementTree,dstAttrDeclaration,reference,mappingStore);
+				}
+			}
 			else if (refactoring instanceof MergeVariableRefactoring)
 			{
 				MergeVariableRefactoring mergeVariableRefactoring = (MergeVariableRefactoring) refactoring;

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -95,7 +95,7 @@ public class ProjectASTDiffer
 		TreeContext dstTreeContext = treeContextPair.second;
 		Tree srcTree = srcTreeContext.getRoot();
 		Tree dstTree = dstTreeContext.getRoot();
-		ExtendedMultiMappingStore mappingStore = new ExtendedMultiMappingStore(srcTreeContext,dstTreeContext);
+		ExtendedMultiMappingStore mappingStore = new ExtendedMultiMappingStore(srcTree,dstTree);
 		this.lastStepMappings = new ArrayList<>();
 		if (!mergeFlag) {
 			mappingStore.addMapping(srcTree, dstTree);

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -562,6 +562,9 @@ public class ProjectASTDiffer
 					Tree srcStatementTree = TreeUtilFunctions.findByLocationInfo(srcTree,reference.getFragment1().getLocationInfo());
 					new LeafMatcher(false).match(srcStatementTree,dstAttrDeclaration,reference,mappingStore);
 				}
+				for (UMLAnonymousClassDiff umlAnonymousClassDiff : extractAttributeRefactoring.getAnonymousClassDiffList()) {
+					processAnonymousClassDiff(srcTree,dstTree,umlAnonymousClassDiff,mappingStore);
+				}
 			}
 			else if (refactoring instanceof MergeVariableRefactoring)
 			{
@@ -663,10 +666,14 @@ public class ProjectASTDiffer
 		processFieldDeclaration(srcTree,dstTree,umlEnumConstantDiff.getRemovedEnumConstant(),umlEnumConstantDiff.getAddedEnumConstant(),mappingStore);
 		if(umlEnumConstantDiff.getAnonymousClassDiff().isPresent()) {
 			UMLAnonymousClassDiff anonymousClassDiff = umlEnumConstantDiff.getAnonymousClassDiff().get();
-			List<UMLOperationBodyMapper> operationBodyMapperList = anonymousClassDiff.getOperationBodyMapperList();
-			for (UMLOperationBodyMapper umlOperationBodyMapper : operationBodyMapperList) {
-				processMethod(srcTree,dstTree,umlOperationBodyMapper,mappingStore);
-			}
+			processAnonymousClassDiff(srcTree, dstTree, anonymousClassDiff, mappingStore);
+		}
+	}
+
+	private void processAnonymousClassDiff(Tree srcTree, Tree dstTree, UMLAnonymousClassDiff anonymousClassDiff, ExtendedMultiMappingStore mappingStore) {
+		List<UMLOperationBodyMapper> operationBodyMapperList = anonymousClassDiff.getOperationBodyMapperList();
+		for (UMLOperationBodyMapper umlOperationBodyMapper : operationBodyMapperList) {
+			processMethod(srcTree, dstTree,umlOperationBodyMapper, mappingStore);
 		}
 	}
 

--- a/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
+++ b/src/org/refactoringminer/astDiff/matchers/ProjectASTDiffer.java
@@ -146,13 +146,15 @@ public class ProjectASTDiffer
 	}
 
 	private void processLastStepMappings(Tree srcTree, Tree dstTree, ExtendedMultiMappingStore mappingStore) {
+		ExtendedMultiMappingStore optimizationMappings = new ExtendedMultiMappingStore(srcTree,dstTree);
 		for (AbstractCodeMapping lastStepMapping : lastStepMappings) {
 			if (lastStepMapping.getFragment1().getLocationInfo().getFilePath().equals(lastStepMapping.getFragment2().getLocationInfo().getFilePath())) {
 				Tree srcExp = TreeUtilFunctions.findByLocationInfo(srcTree, lastStepMapping.getFragment1().getLocationInfo());
 				Tree dstExp = TreeUtilFunctions.findByLocationInfo(dstTree, lastStepMapping.getFragment2().getLocationInfo());
-				new LeafMatcher(true).match(srcExp, dstExp, lastStepMapping, mappingStore);
+				new LeafMatcher(false).match(srcExp, dstExp, lastStepMapping, optimizationMappings);
 			}
 		}
+		mappingStore.replaceWithOptimizedMappings(optimizationMappings);
 	}
 
 	private void processEnumConstants(Tree srcTree, Tree dstTree, Set<org.apache.commons.lang3.tuple.Pair<UMLEnumConstant, UMLEnumConstant>> commonEnumConstants, ExtendedMultiMappingStore mappingStore) {

--- a/src/org/refactoringminer/astDiff/utils/MappingExportModel.java
+++ b/src/org/refactoringminer/astDiff/utils/MappingExportModel.java
@@ -173,6 +173,8 @@ public class MappingExportModel implements Serializable {
                         .thenComparing(exportModel -> -1 * exportModel.getFirstEndPos())
                         .thenComparing(MappingExportModel::getFirstType)
                         .thenComparing(MappingExportModel::getSecondPos)
+                        .thenComparing(MappingExportModel::getFirstParentType)
+                        .thenComparing(MappingExportModel::getSecondParentType)
         );
         return exportList;
     }


### PR DESCRIPTION
This PR contains the following changes:
- Diff support for Extract/Inline Attribute Refactoring + AnonymousClassDiff for the Extract Attribute Refactoring
- Improvements for https://github.com/pouryafard75/RM-ASTDiff/issues/32
The existing problems are mentioned: https://github.com/pouryafard75/RM-ASTDiff/issues/32#issuecomment-1427241901
- Fix for issue https://github.com/pouryafard75/RM-ASTDiff/issues/29 which happened in the case of iso-structural trees
- Tie-breaker for sorting the mappings 
- Not using the classDiff.getRefactorings due to performance issues. As a result,  calculating the class-specific refactorings from the modelDiffRefactorings. Relying on both className and fileName because of the https://github.com/pouryafard75/RM-ASTDiff/issues/33
- Minor refactorings
- Support for REPLACE_VARIABLE_WITH_ATTRIBUTE refactoring: https://github.com/tsantalis/RefactoringMiner/issues/359#issuecomment-1427057193
- Support for Grouped/Ungrouped Import Statements:
![imports](https://user-images.githubusercontent.com/28820932/218358881-0ec89885-ba83-403b-889f-20b2c1c41ebc.png)

**Important Note:**
Due to the introduction of ParameterToArgumentMappings for the ExtractMethodRefactoring, two tests are failing. If this is a better diff we can modify the JSON files for the tests.  