### PR TITLE
Bug fix

### DIFF
--- a/src-test/org/refactoringminer/astDiff/data/crashub_crash/2801269c7e47bd6e243612654a74cee809d20959/connectors.ssh.src.main.org.crsh.auth.FilePublicKeyProvider.json
+++ b/src-test/org/refactoringminer/astDiff/data/crashub_crash/2801269c7e47bd6e243612654a74cee809d20959/connectors.ssh.src.main.org.crsh.auth.FilePublicKeyProvider.json
@@ -2652,17 +2652,6 @@
 }, {
   "firstType" : "SimpleName",
   "secondType" : "SimpleName",
-  "firstLabel" : "keyPair",
-  "secondLabel" : "pemKeyPair",
-  "firstParentType" : "METHOD_INVOCATION_RECEIVER",
-  "secondParentType" : "METHOD_INVOCATION_RECEIVER",
-  "firstPos" : 2676,
-  "secondPos" : 3361,
-  "firstEndPos" : 2683,
-  "secondEndPos" : 3371
-}, {
-  "firstType" : "SimpleName",
-  "secondType" : "SimpleName",
   "firstLabel" : "getPublicKeyInfo",
   "secondLabel" : "getPublicKeyInfo",
   "firstParentType" : "MethodInvocation",

--- a/src-test/org/refactoringminer/astDiff/data/pouryafard75_TestCases/0ae8f723a59722694e394300656128f9136ef466/testCommit.lambdaExample.json
+++ b/src-test/org/refactoringminer/astDiff/data/pouryafard75_TestCases/0ae8f723a59722694e394300656128f9136ef466/testCommit.lambdaExample.json
@@ -904,13 +904,13 @@
   "firstType" : "SimpleName",
   "secondType" : "SimpleName",
   "firstLabel" : "contains",
-  "secondLabel" : "vector",
+  "secondLabel" : "contains",
   "firstParentType" : "METHOD_INVOCATION_RECEIVER",
-  "secondParentType" : "METHOD_INVOCATION_RECEIVER",
+  "secondParentType" : "METHOD_INVOCATION_ARGUMENTS",
   "firstPos" : 455,
-  "secondPos" : 1142,
+  "secondPos" : 97,
   "firstEndPos" : 463,
-  "secondEndPos" : 1148
+  "secondEndPos" : 105
 }, {
   "firstType" : "SimpleName",
   "secondType" : "SimpleName",
@@ -2653,13 +2653,13 @@
   "firstType" : "SimpleName",
   "secondType" : "SimpleName",
   "firstLabel" : "regexps",
-  "secondLabel" : "vector",
+  "secondLabel" : "regexps",
   "firstParentType" : "METHOD_INVOCATION_RECEIVER",
-  "secondParentType" : "METHOD_INVOCATION_RECEIVER",
+  "secondParentType" : "METHOD_INVOCATION_ARGUMENTS",
   "firstPos" : 1476,
-  "secondPos" : 1142,
+  "secondPos" : 368,
   "firstEndPos" : 1483,
-  "secondEndPos" : 1148
+  "secondEndPos" : 375
 }, {
   "firstType" : "SimpleName",
   "secondType" : "SimpleName",

--- a/src/org/refactoringminer/astDiff/matchers/Constants.java
+++ b/src/org/refactoringminer/astDiff/matchers/Constants.java
@@ -40,4 +40,6 @@ public class Constants {
 	public static final String STATIC = "static";
 	public static final String EQUAL_OPERATOR = "=";
 
+	public static final String METHOD_INVOCATION_ARGUMENTS = "METHOD_INVOCATION_ARGUMENTS";
+
 }

--- a/src/org/refactoringminer/astDiff/matchers/CustomBottomUpMatcher.java
+++ b/src/org/refactoringminer/astDiff/matchers/CustomBottomUpMatcher.java
@@ -24,7 +24,7 @@ public class CustomBottomUpMatcher implements Matcher {
 			if (t.isRoot()) {
 				if (t.getType().name.equals(dst.getType().name))
 				{
-					if (!mappings.isSrcMapped(t) && mappings.isDstMapped(dst))
+					if (!mappings.isSrcMapped(t) && !mappings.isDstMapped(dst))
 						mappings.addMapping(t, dst);
 				}
 				lastChanceMatch(mappings, t, dst);

--- a/src/org/refactoringminer/astDiff/utils/TreeUtilFunctions.java
+++ b/src/org/refactoringminer/astDiff/utils/TreeUtilFunctions.java
@@ -22,7 +22,25 @@ public class TreeUtilFunctions {
 	public static Tree findByLocationInfo(Tree tree, LocationInfo locationInfo){
 		int startoffset = locationInfo.getStartOffset();
 		int endoffset = locationInfo.getEndOffset();
-		return getTreeBetweenPositions(tree, startoffset, endoffset);
+
+		Tree treeBetweenPositions = getTreeBetweenPositions(tree, startoffset, endoffset);
+		if (treeBetweenPositions == null) return null;
+		if (treeBetweenPositions.getType().name.equals(Constants.METHOD_INVOCATION_ARGUMENTS))
+		{
+			if (treeBetweenPositions.getChildren().size() > 0 )
+			{
+				if (treeBetweenPositions.getChild(0).getPos() == startoffset
+						&& treeBetweenPositions.getChild(0).getEndPos() == endoffset)
+					return treeBetweenPositions.getChild(0);
+				else {
+					return treeBetweenPositions;
+				}
+			}
+			else {
+				return treeBetweenPositions;
+			}
+		}
+		return treeBetweenPositions;
 	}
 
 	public static Tree findByLocationInfo(Tree tree, LocationInfo locationInfo, String type){


### PR DESCRIPTION
- This is related to https://github.com/tsantalis/RefactoringMiner/issues/348#issuecomment-1423798262.
- Ignoring the MethodInvocationArguments in case of having a child with the exact same offset
- Test cases that were failing due to the introduction of argument mappings have been updated.

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/28820932/219549798-a419fc8e-3503-46f4-a000-02d85c399c27.png">
