### PR TITLE
Fix inner class with static members error

### DIFF
--- a/src-test/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src-test/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -308,12 +308,12 @@ class TestParameterizeTestRefactoring {
     @Disabled("TODO: Replicate testEnumSource use of UMLModelASTReader with fileMap and add support for CSV files")
     @Nested
     class TestCsvFileSource_OtherPathFormats {
-        @TempDir static Path dir;
-        private static UMLModel originalModel;
-        private static Path csvPath;
+        @TempDir Path dir;
+        private UMLModel originalModel;
+        private Path csvPath;
 
-        @BeforeAll
-        static void setUp() throws RefactoringMinerTimedOutException {
+        @BeforeEach
+        void setUp() throws RefactoringMinerTimedOutException {
             String originalSourceCode = new TestSrcCodeBuilder().testMethod("testMethod_A")
                     .statement("assertNotEquals(\"A\", null);")
                     .statement("assertNotEquals(\"B\", null);")
@@ -413,11 +413,11 @@ class TestParameterizeTestRefactoring {
     }
     @Nested
     class TestCsvFileSource_AbsolutePath {
-        @TempDir static Path dir;
-        private static UMLModelDiff diff;
+        @TempDir Path dir;
+        private UMLModelDiff diff;
 
-        @BeforeAll
-        static void setUp() throws RefactoringMinerTimedOutException {
+        @BeforeEach
+        void setUp() throws RefactoringMinerTimedOutException {
             String originalSourceCode = new TestSrcCodeBuilder().testMethod("testMethod_A")
                     .statement("assertNotEquals(\"A\", null);")
                     .statement("assertNotEquals(\"B\", null);")


### PR DESCRIPTION
JUnit 5 requires `@BeforeAll` setUp methods to be static and that means we cannot access non-static fields from them. So it forced me to add the static keywords to those components.

However, Java throws errors when we define static fields and methods inside inner (non-static) classes. And making the inner class static, [aka nested class](https://medium.com/the-kotlin-primer/nested-and-inner-classes-b300243d036d#:~:text=A%20nested%20class%20is%20a,instance%20of%20the%20outer%20class.), would be the right choice except JUnit 5 fails to run such tests when the enclosing class is executed ([see a related open issue](https://issues.apache.org/jira/projects/SUREFIRE/issues/SUREFIRE-1633?filter=allopenissues)).

In this PR, we opted to replace `@BeforeAll` with `@BeforeEach` and remove all static keywords in the associated fields and setup methods.