### PR TITLE
fix NPE on `classDiff.getModelDiff()`

### DIFF
--- a/src/gr/uom/java/xmi/decomposition/AbstractCodeMapping.java
+++ b/src/gr/uom/java/xmi/decomposition/AbstractCodeMapping.java
@@ -328,12 +328,14 @@ public abstract class AbstractCodeMapping {
 					}
 				}
 			}
-			UMLClass addedClass = classDiff.getModelDiff().getAddedClass(operation2.getClassName());
-			if(addedClass != null && addedClass.containsAttributeWithName(initializer.getString())) {
-				for(UMLAttribute attribute : addedClass.getAttributes()) {
-					if(attribute.getName().equals(initializer.getString())) {
-						aliasedWithAttribute = attribute;
-						break;
+			if (classDiff.getModelDiff() != null) {
+				UMLClass addedClass = classDiff.getModelDiff().getAddedClass(operation2.getClassName());
+				if(addedClass != null && addedClass.containsAttributeWithName(initializer.getString())) {
+					for(UMLAttribute attribute : addedClass.getAttributes()) {
+						if(attribute.getName().equals(initializer.getString())) {
+							aliasedWithAttribute = attribute;
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Adding a simple check to make sure we don't hit an NPE condition.

Fixes jodavimehran/code-tracker/issues/153