### PR TITLE
Read OAuthToken from environment variables, prior to checking the .properties file

### DIFF
--- a/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
+++ b/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
@@ -520,10 +520,13 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 	private GitHub connectToGitHub() {
 		if(gitHub == null) {
 			try {
-				Properties prop = new Properties();
-				InputStream input = new FileInputStream("github-oauth.properties");
-				prop.load(input);
-				String oAuthToken = prop.getProperty("OAuthToken");
+				String oAuthToken = System.getenv("OAuthToken");
+				if (oAuthToken == null || oAuthToken.isEmpty()) {
+					Properties prop = new Properties();
+					InputStream input = new FileInputStream("github-oauth.properties");
+					prop.load(input);
+					oAuthToken = prop.getProperty("OAuthToken");
+				}
 				if (oAuthToken != null) {
 					gitHub = GitHub.connectUsingOAuth(oAuthToken);
 					if(gitHub.isCredentialValid()) {


### PR DESCRIPTION
This PR enables the option to have the OAuthToken in the environment variables, thus removing the need for additional `github-oauth.properties`. However, to keep the backward compatibility, the original solution still works.


This will enable us to deploy the project in containerized environments and benefit from _CI/CD_ tools such as _GitHub Actions_.

