### PR TITLE
Apply requested changes

### DIFF
--- a/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -170,7 +170,7 @@ class TestParameterizeTestRefactoring {
                             .statement("assertThrows(NullPointerException.class,()->en.number());")
                         .build()),
                     Set.of("."),
-                    repeat(RefactoringType.PARAMETERIZE_TEST, 1)));
+                    repeat(RefactoringType.PARAMETERIZE_TEST, 2)));
         }
         {
 

--- a/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -154,8 +154,6 @@ class TestParameterizeTestRefactoring {
                         .testMethod("testNullEnum_null")
                             .statement("TestEnum te = null;")
                             .statement("assertThrows(NullPointerException.class,()->te.number());")
-                        .testMethod("testNullEnum_nullLiteral")
-                            .statement("assertThrows(NullPointerException.class,()->null.number());")
                         .build()),
                     Map.of("src/test/java/com/test/TestClass.java",new TestSrcCodeBuilder()
                         .testPackage("com.test")

--- a/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -166,8 +166,8 @@ class TestParameterizeTestRefactoring {
                                 .parameterize()
                                 .annotate("@NullSource")
                                 .annotate("@EnumSource(value=TestEnum.class,names={\"TEST1\"})")
-                                .parameter("TestEnum te")
-                            .statement("assertThrows(NullPointerException.class,()->te.number());")
+                                .parameter("TestEnum en")
+                            .statement("assertThrows(NullPointerException.class,()->en.number());")
                         .build()),
                     Set.of("."),
                     repeat(RefactoringType.PARAMETERIZE_TEST, 1)));

--- a/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -114,7 +114,7 @@ class TestParameterizeTestRefactoring {
                     .statement("assertTrue(te.number() >= 1 && te.number() <= 5);");
             Map<String, String> files = new HashMap<>(Map.of(
                     "src/main/java/com/test/TestEnum.java",
-                    enumDeclaration.apply("int number() {return Integer.parseInt(name().substring(name().length() - 1));}"),
+                    "package com.test;\n" + enumDeclaration.apply("int number() {return Integer.parseInt(name().substring(name().length() - 1));}"),
                     "src/test/java/com/test/TestClass.java", newCodeBuilder.build()));
             HashMap<String, String> oldFiles = new HashMap<>(files);
             TestSrcCodeBuilder oldCodeBuilder = new TestSrcCodeBuilder().testPackage("com.test")


### PR DESCRIPTION
This PR modifies three aspects of the failing generated test case:

1. Drop incorrect use of null literal
2. Rename new parameter
3. Increase the number of expected parameterize test refactoring (from one to two)