### PR TITLE
Revert Monaco view to stable version

### DIFF
--- a/src/main/resources/web/dist/monaco.js
+++ b/src/main/resources/web/dist/monaco.js
@@ -1,4 +1,4 @@
-const maxAllowedHeight = 600;
+const maxAllowedHeight = 5000;
 
 function mymonaco(config) {
     require.config({paths: {'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.39.0/min/vs'}});

--- a/src/main/resources/web/dist/monaco.js
+++ b/src/main/resources/web/dist/monaco.js
@@ -1,4 +1,4 @@
-const maxAllowedHeight = 5000;
+const maxAllowedHeight = 600;
 
 function mymonaco(config) {
     require.config({paths: {'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.39.0/min/vs'}});

--- a/src/main/resources/web/dist/utils.js
+++ b/src/main/resources/web/dist/utils.js
@@ -3,7 +3,7 @@ function getEditorOptions(config, text) {
         value: text,
         readOnly: true,
         language: getLanguage(config),
-        automaticLayout: config.spv !== true,
+        automaticLayout: true,
         scrollBeyondLastLine: false,
         lineDecorationsWidth: 0,
         glyphMargin: false,


### PR DESCRIPTION
This PR reverts Monaco to what we had months ago, which means it will be slow for cases which have large number of files in the single page view