### PR TITLE
Fix TestParameterizeTestRefactoring.testParameterizeTest case 2

### DIFF
--- a/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -57,6 +58,9 @@ class TestParameterizeTestRefactoring {
             result.add(r);
         }
         return result;
+    }
+    private static List<RefactoringType> combine(List<RefactoringType>... lists) {
+        return Arrays.stream(lists).flatMap(List::stream).collect(Collectors.toList());
     }
     private static Collection<Arguments> testParameterizeTest() {
         List<Arguments> arguments = new ArrayList<>();
@@ -99,7 +103,7 @@ class TestParameterizeTestRefactoring {
             }
             arguments.add(Arguments.of(Map.of("src/test/java/com/test/TestClass.java", originalCodeBuilder.build()),
                     Map.of("src/test/java/com/test/TestClass.java", newCodeBuilder.build()),
-                    Set.of("."), repeat(RefactoringType.PARAMETERIZE_TEST, 6)));
+                    Set.of("."), combine(repeat(RefactoringType.PARAMETERIZE_TEST, 6),repeat(RefactoringType.PARAMETERIZE_VARIABLE, 6))));
         }
         Function<String, String> enumDeclaration = (String methoDeclaration) -> String.format("public enum TestEnum {TEST1, TEST2, TEST3, TEST4, TEST5;\n%s}",methoDeclaration);
         {


### PR DESCRIPTION
- Extract test utility method to combine different repeated refactorings in the test oracle
- fix failing test case to acknowledge new PARAMETERIZE_VARIABLE feature (of which 6 occurrences have been found)