### PR TITLE
Assert safe var args for buggy combination (generics + varargs)

### DIFF
--- a/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
+++ b/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java
@@ -59,6 +59,7 @@ class TestParameterizeTestRefactoring {
         }
         return result;
     }
+    @SafeVarargs
     private static List<RefactoringType> combine(List<RefactoringType>... lists) {
         return Arrays.stream(lists).flatMap(List::stream).collect(Collectors.toList());
     }


### PR DESCRIPTION
Fix `Note: /Users/victor/IdeaProjects/RefactoringMiner/src/test/java/org/refactoringminer/test/TestParameterizeTestRefactoring.java uses unchecked or unsafe operations.` warning