### PR TITLE
Recommend ENV variables for running on Docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,11 +52,9 @@ Note: Ensure your Docker setup includes access to virtual file shares, particula
 
 You can execute RefactoringMiner's container on a GitHub Pull Request as follows:
 
+```terminal
+docker run -p 6789:6789 -e GITHUB_LOGIN={login} GITHUB_OAUTH={pat} tsantalis/refactoringminer diff --url https://github.com/JabRef/jabref/pull/11845
 ```
-docker run -p 6789:6789  -v c:\users\user\rmc:/diff tsantalis/refactoringminer diff --url https://github.com/JabRef/jabref/pull/11845
-```
-In `rmc` there is a file `github-oauth.properties` where you should edit to enter your personal GitHub OAuth token.
 
-    OAuthToken=ghp_Tz...
-
+Thereby, `login` is your GitHub login and `pat` is a personal GitHub personal access token token.
 This is a [generated classic personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)


### PR DESCRIPTION
I couldn't get the miner running with the proposed mount point.

I checked the [source of Hub4J](https://github.dev/hub4j/github-api/blob/main/src/main/java/org/kohsuke/github/authorization/UserAuthorizationProvider.java) and tried the environment variables - worked 💪.

Sharing this - maybe, it helps others, too.