### PR TITLE
Re-add `.github-oauth.properties`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -56,3 +56,15 @@ docker run -p 6789:6789 -e OAuthToken=ghp_Tz... tsantalis/refactoringminer diff 
 ```
 Replace `ghp_Tz...` with your own personal OAuth token.
 This is a [generated classic personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+
+In case you want to store your token in a file (instead of having it in the bash history):
+
+```
+docker run -p 6789:6789  -v c:\users\{login}\.refactoringminer:/diff tsantalis/refactoringminer diff --url https://github.com/JabRef/jabref/pull/14138
+```
+
+In `c:\users\{login}\.refactoringminer` (`~/.refactoringminer` on Linux/macOS), you need to create a file `github-oauth.properties` where your personal GitHub OAuth resides:
+
+```properties
+OAuthToken=ghp_Tz...
+```


### PR DESCRIPTION
Follow-up to https://github.com/tsantalis/RefactoringMiner/pull/1002

I got `github-oauth.properties` working again - and I think, its more "secret" to store it in the file than in bash history.