### PR TITLE
Fix HTTP server silent failure at timeout

### DIFF
--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,8 @@ import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+
+import javax.annotation.Nonnull;
 
 public class RefactoringMinerHttpServer implements RefactoringHandler {
 
@@ -76,7 +79,7 @@ public class RefactoringMinerHttpServer implements RefactoringHandler {
 		api.detectRefactorings(this, gitURL, commitId);
 	}
 
-	private void prepareResponse() {
+	void prepareResponse() {
 		try {
 			future.get(timeout, TimeUnit.SECONDS);
 		} catch (InterruptedException e) {
@@ -112,16 +115,8 @@ public class RefactoringMinerHttpServer implements RefactoringHandler {
 	}
 
 	public static void main(String[] args) throws Exception {
-		Properties prop = new Properties();
-		try {
-			InputStream input = new FileInputStream("server.properties");
-			prop.load(input);
-		} catch (Exception ignored) {}
-		String hostName = prop.getProperty("hostname", System.getenv("hostname"));
-		int port = Integer.parseInt(prop.getProperty("port", System.getenv("port")));
-		
-		InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getByName(hostName), port);
-		HttpServer server = HttpServer.create(inetSocketAddress, 0);
+		Properties prop = getProperties();
+        HttpServer server = HttpServer.create(setupSocket(prop), 0);
 		server.createContext("/RefactoringMiner", (HttpExchange exchange) -> {
 			exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
 			RefactoringMinerHttpServer miner = RefactoringMinerHttpServer.from(exchange);
@@ -131,6 +126,25 @@ public class RefactoringMinerHttpServer implements RefactoringHandler {
 		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.CallerRunsPolicy()));
 		server.start();
 		System.out.println(InetAddress.getLocalHost());
+	}
+
+	@Nonnull
+	public static InetSocketAddress setupSocket(Properties prop) throws UnknownHostException {
+		String hostName = prop.getProperty("hostname", System.getenv("hostname"));
+		int port = Integer.parseInt(prop.getProperty("port", System.getenv("port")));
+
+		InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getByName(hostName), port);
+		return inetSocketAddress;
+	}
+
+	@Nonnull
+	public static Properties getProperties() {
+		Properties prop = new Properties();
+		try {
+			InputStream input = new FileInputStream("server.properties");
+			prop.load(input);
+		} catch (Exception ignored) {}
+		return prop;
 	}
 
 	private static Map<String, String> queryToMap(String query) {

--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
@@ -89,7 +89,7 @@ public class RefactoringMinerHttpServer {
 				exchange.close();
 			}
 		});
-		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100)));
+		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.CallerRunsPolicy()));
 		server.start();
 		System.out.println(InetAddress.getLocalHost());
 	}

--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
@@ -1,6 +1,7 @@
 package org.refactoringminer;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -12,27 +13,104 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.refactoringminer.api.GitHistoryRefactoringMiner;
 import org.refactoringminer.api.Refactoring;
+import org.refactoringminer.api.RefactoringHandler;
+import org.refactoringminer.api.RefactoringMinerTimedOutException;
 import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
 
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 
-public class RefactoringMinerHttpServer {
+public class RefactoringMinerHttpServer implements RefactoringHandler {
 
 	private static final ExecutorService MINER_POOL = new ThreadPoolExecutor(
 			4, 16, 60L, TimeUnit.SECONDS,
 			new ArrayBlockingQueue<>(200),
 			new ThreadPoolExecutor.CallerRunsPolicy()
 	);
+	private final GitHistoryRefactoringMinerImpl api = new GitHistoryRefactoringMinerImpl();
+	private final List<Refactoring> detectedRefactorings = new ArrayList<>();
+	private final Future<?> future;
+	private final String gitURL, commitId;
+	private final int timeout;
+	private Throwable error = null;
+	private int responseCode = 0;
+	private String responseMessage;
+
+	RefactoringMinerHttpServer(String url, String sha, int timeout, String token) {
+		gitURL = url;
+		commitId = sha;
+		this.timeout = timeout;
+		if (!token.isEmpty()) {
+			api.connectToGitHub(token);
+		}
+		future = MINER_POOL.submit(this::act);
+	}
+
+	static RefactoringMinerHttpServer from(HttpExchange exchange) {
+		printRequestInfo(exchange);
+		URI requestURI = exchange.getRequestURI();
+		String query = requestURI.getQuery();
+		Map<String, String> queryToMap = queryToMap(query);
+
+		return new RefactoringMinerHttpServer(queryToMap.get("gitURL"), queryToMap.get("commitId"), Integer.parseInt(queryToMap.get("timeout")), queryToMap.getOrDefault("token", ""));
+	}
+
+	public void sendResponse(HttpExchange exchange) throws IOException {
+		assert responseCode != 0 : "Please, invoke prepareResponse before sending a response";
+		exchange.sendResponseHeaders(responseCode, responseMessage.length());
+		OutputStream os = exchange.getResponseBody();
+		os.write(responseMessage.getBytes());
+		os.close();
+	}
+
+	private void act() {
+		api.detectRefactorings(this, gitURL, commitId);
+	}
+
+	private void prepareResponse() {
+		try {
+			future.get(timeout, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			error = e;
+		} catch (ExecutionException e) {
+			error = e.getCause();
+		} catch (Exception e) {
+			error = e;
+		}
+		if (error == null) {
+			responseMessage = JSON(gitURL, commitId, detectedRefactorings);
+			responseCode = 200;
+		} else {
+			responseMessage = "{\"error\":\"" + error.getMessage().replace("\"", "'") + "\"}";
+			if (error instanceof RefactoringMinerTimedOutException || error instanceof TimeoutException) {
+				future.cancel(true);
+				responseCode = 503;
+			} else {
+				responseCode = 500;
+			}
+		}
+	}
+
+	@Override
+	public void handle(String commitId, List<Refactoring> refactorings) {
+		detectedRefactorings.addAll(refactorings);
+	}
+
+	@Override
+	public void handleException(String commitId, Exception e) {
+		error = e;
+	}
+
 	public static void main(String[] args) throws Exception {
 		Properties prop = new Properties();
 		try {
@@ -45,51 +123,10 @@ public class RefactoringMinerHttpServer {
 		InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getByName(hostName), port);
 		HttpServer server = HttpServer.create(inetSocketAddress, 0);
 		server.createContext("/RefactoringMiner", (HttpExchange exchange) -> {
-			printRequestInfo(exchange);
-			URI requestURI = exchange.getRequestURI();
-			String query = requestURI.getQuery();
-			Map<String, String> queryToMap = queryToMap(query);
-
-			String gitURL = queryToMap.get("gitURL");
-			String commitId = queryToMap.get("commitId");
-			String oAuthToken = queryToMap.getOrDefault("token", "");
-			int timeout = Integer.parseInt(queryToMap.get("timeout"));
-			List<Refactoring> detectedRefactorings = new ArrayList<Refactoring>();
-
-			GitHistoryRefactoringMiner miner = new GitHistoryRefactoringMinerImpl();
-			if (!oAuthToken.isEmpty()) {
-				miner.connectToGitHub(oAuthToken);
-			}
-			Future<?> future = MINER_POOL.submit(() -> miner.detectAtCommit(gitURL, commitId, (commitId1, refactorings) -> detectedRefactorings.addAll(refactorings), timeout));
-			int responseStatusCode = 200;
-			try {
-				try {
-					future.get(Math.max(timeout, 30L), TimeUnit.SECONDS);
-				} catch (InterruptedException e) {
-					responseStatusCode = 503;
-					Thread.currentThread().interrupt();
-					throw new RuntimeException("Handler interrupted");
-				} catch (TimeoutException te) {
-					responseStatusCode = 503;
-					future.cancel(true);
-					throw new RuntimeException("Server-side timeout");
-				}
-				String response = JSON(gitURL, commitId, detectedRefactorings);
-				System.out.println(response);
-				exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
-				exchange.sendResponseHeaders(200, response.length());
-				OutputStream os = exchange.getResponseBody();
-				os.write(response.getBytes());
-				os.close();
-			} catch (Exception e) {
-				String error = "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}";
-				exchange.sendResponseHeaders(responseStatusCode == 200 ? 500 : responseStatusCode, error.length());
-				OutputStream os = exchange.getResponseBody();
-				os.write(error.getBytes());
-				os.close();
-			} finally {
-				exchange.close();
-			}
+			exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
+			RefactoringMinerHttpServer miner = RefactoringMinerHttpServer.from(exchange);
+			miner.prepareResponse();
+			miner.sendResponse(exchange);
 		});
 		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.CallerRunsPolicy()));
 		server.start();

--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
@@ -50,15 +50,24 @@ public class RefactoringMinerHttpServer {
 			if (!oAuthToken.isEmpty()) {
 				miner.connectToGitHub(oAuthToken);
 			}
-			miner.detectAtCommit(gitURL, commitId, (commitId1, refactorings) -> detectedRefactorings.addAll(refactorings), timeout);
-
-			String response = JSON(gitURL, commitId, detectedRefactorings);
-			System.out.println(response);
-			exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
-			exchange.sendResponseHeaders(200, response.length());
-			OutputStream os = exchange.getResponseBody();
-			os.write(response.getBytes());
-			os.close();
+            try {
+				miner.detectAtCommit(gitURL, commitId, (commitId1, refactorings) -> detectedRefactorings.addAll(refactorings), timeout);
+				String response = JSON(gitURL, commitId, detectedRefactorings);
+				System.out.println(response);
+				exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
+				exchange.sendResponseHeaders(200, response.length());
+				OutputStream os = exchange.getResponseBody();
+				os.write(response.getBytes());
+				os.close();
+			} catch (Exception e) {
+				String error = "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}";
+				exchange.sendResponseHeaders(500, error.length());
+				OutputStream os = exchange.getResponseBody();
+				os.write(error.getBytes());
+				os.close();
+			} finally {
+				exchange.close();
+			}
 		});
 		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100)));
 		server.start();

--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
@@ -35,10 +35,12 @@ public class RefactoringMinerHttpServer {
 	);
 	public static void main(String[] args) throws Exception {
 		Properties prop = new Properties();
-		InputStream input = new FileInputStream("server.properties");
-		prop.load(input);
-		String hostName = prop.getProperty("hostname");
-		int port = Integer.parseInt(prop.getProperty("port"));
+		try {
+			InputStream input = new FileInputStream("server.properties");
+			prop.load(input);
+		} catch (Exception ignored) {}
+		String hostName = prop.getProperty("hostname", System.getenv("hostname"));
+		int port = Integer.parseInt(prop.getProperty("port", System.getenv("port")));
 		
 		InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getByName(hostName), port);
 		HttpServer server = HttpServer.create(inetSocketAddress, 0);

--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpServer.java
@@ -12,8 +12,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.refactoringminer.api.GitHistoryRefactoringMiner;
 import org.refactoringminer.api.Refactoring;
@@ -25,6 +28,11 @@ import com.sun.net.httpserver.HttpServer;
 
 public class RefactoringMinerHttpServer {
 
+	private static final ExecutorService MINER_POOL = new ThreadPoolExecutor(
+			4, 16, 60L, TimeUnit.SECONDS,
+			new ArrayBlockingQueue<>(200),
+			new ThreadPoolExecutor.CallerRunsPolicy()
+	);
 	public static void main(String[] args) throws Exception {
 		Properties prop = new Properties();
 		InputStream input = new FileInputStream("server.properties");
@@ -50,8 +58,20 @@ public class RefactoringMinerHttpServer {
 			if (!oAuthToken.isEmpty()) {
 				miner.connectToGitHub(oAuthToken);
 			}
-            try {
-				miner.detectAtCommit(gitURL, commitId, (commitId1, refactorings) -> detectedRefactorings.addAll(refactorings), timeout);
+			Future<?> future = MINER_POOL.submit(() -> miner.detectAtCommit(gitURL, commitId, (commitId1, refactorings) -> detectedRefactorings.addAll(refactorings), timeout));
+			int responseStatusCode = 200;
+			try {
+				try {
+					future.get(Math.max(timeout, 30L), TimeUnit.SECONDS);
+				} catch (InterruptedException e) {
+					responseStatusCode = 503;
+					Thread.currentThread().interrupt();
+					throw new RuntimeException("Handler interrupted");
+				} catch (TimeoutException te) {
+					responseStatusCode = 503;
+					future.cancel(true);
+					throw new RuntimeException("Server-side timeout");
+				}
 				String response = JSON(gitURL, commitId, detectedRefactorings);
 				System.out.println(response);
 				exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
@@ -61,7 +81,7 @@ public class RefactoringMinerHttpServer {
 				os.close();
 			} catch (Exception e) {
 				String error = "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}";
-				exchange.sendResponseHeaders(500, error.length());
+				exchange.sendResponseHeaders(responseStatusCode == 200 ? 500 : responseStatusCode, error.length());
 				OutputStream os = exchange.getResponseBody();
 				os.write(error.getBytes());
 				os.close();

--- a/src/main/java/org/refactoringminer/RefactoringMinerHttpsServer.java
+++ b/src/main/java/org/refactoringminer/RefactoringMinerHttpsServer.java
@@ -1,68 +1,42 @@
 package org.refactoringminer;
 
 import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.URI;
+import java.security.KeyManagementException;
 import java.security.KeyStore;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManagerFactory;
 
-import org.refactoringminer.api.GitHistoryRefactoringMiner;
-import org.refactoringminer.api.Refactoring;
-import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
-
-import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsParameters;
 import com.sun.net.httpserver.HttpsServer;
 
-public class RefactoringMinerHttpsServer {
+public class RefactoringMinerHttpsServer extends RefactoringMinerHttpServer {
+
+	// Constructor required to match the superclass
+	RefactoringMinerHttpsServer(String url, String sha, int timeout, String token) {
+		super(url, sha, timeout, token);
+	}
 
 	public static void main(String[] args) throws Exception {
-		Properties prop = new Properties();
-		InputStream input = new FileInputStream("server.properties");
-		prop.load(input);
-		String hostName = prop.getProperty("hostname");
-		int port = Integer.parseInt(prop.getProperty("port"));
-		String keystore = prop.getProperty("keystore");
-		String keyStorePass = prop.getProperty("keystore-password");
-		
-		InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getByName(hostName), port);
-		HttpsServer server = HttpsServer.create(inetSocketAddress, 0);
-		SSLContext sslContext = SSLContext.getInstance("TLS");
-
-		// initialize the keystore
-		char[] password = keyStorePass.toCharArray();
-		KeyStore ks = KeyStore.getInstance("JKS");
-		FileInputStream fis = new FileInputStream(keystore);
-		ks.load(fis, password);
-
-		// setup the key manager factory
-		KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-		kmf.init(ks, password);
-
-		// setup the trust manager factory
-		TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-		tmf.init(ks);
-
-		// setup the HTTPS context and parameters
-		sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+		Properties prop = getProperties();
+		SSLContext sslContext = setupSSL(prop);
+		HttpsServer server = HttpsServer.create(setupSocket(prop), 0);
 		server.setHttpsConfigurator(new HttpsConfigurator(sslContext) {
 			public void configure(HttpsParameters params) {
 				try {
@@ -84,90 +58,38 @@ public class RefactoringMinerHttpsServer {
 		});
 		
 		server.createContext("/RefactoringMiner", (HttpExchange exchange) -> {
-			printRequestInfo(exchange);
-			URI requestURI = exchange.getRequestURI();
-			String query = requestURI.getQuery();
-			Map<String, String> queryToMap = queryToMap(query);
-
-			String gitURL = queryToMap.get("gitURL");
-			String commitId = queryToMap.get("commitId");
-			String oAuthToken = queryToMap.getOrDefault("token", "");
-			int timeout = Integer.parseInt(queryToMap.get("timeout"));
-			List<Refactoring> detectedRefactorings = new ArrayList<Refactoring>();
-
-			GitHistoryRefactoringMiner miner = new GitHistoryRefactoringMinerImpl();
-			if (!oAuthToken.isEmpty()) {
-				miner.connectToGitHub(oAuthToken);
-			}
-			miner.detectAtCommit(gitURL, commitId, (commitId1, refactorings) -> detectedRefactorings.addAll(refactorings), timeout);
-
-			String response = JSON(gitURL, commitId, detectedRefactorings);
-			System.out.println(response);
 			exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
-			exchange.sendResponseHeaders(200, response.length());
-			OutputStream os = exchange.getResponseBody();
-			os.write(response.getBytes());
-			os.close();
+			RefactoringMinerHttpServer miner = RefactoringMinerHttpServer.from(exchange);
+			miner.prepareResponse();
+			miner.sendResponse(exchange);
 		});
-		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(100)));
+
+		server.setExecutor(new ThreadPoolExecutor(4, 8, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(100), new ThreadPoolExecutor.CallerRunsPolicy()));
 		server.start();
 		System.out.println(InetAddress.getLocalHost());
 	}
 
-	private static Map<String, String> queryToMap(String query) {
-		Map<String, String> result = new HashMap<>();
-		for (String param : query.split("&")) {
-			String[] entry = param.split("=");
-			if (entry.length > 1) {
-				result.put(entry[0], entry[1]);
-			}
-			else {
-				result.put(entry[0], "");
-			}
-		}
-		return result;
-	}
+	@Nonnull
+	private static SSLContext setupSSL(Properties prop) throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, UnrecoverableKeyException, KeyManagementException {
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		// initialize the keystore
+		String keystore = prop.getProperty("keystore", System.getenv("keystore"));
+		String keyStorePass = prop.getProperty("keystore-password", System.getenv("keystore-password"));
+		char[] password = keyStorePass.toCharArray();
+		KeyStore ks = KeyStore.getInstance("JKS");
+		FileInputStream fis = new FileInputStream(keystore);
+		ks.load(fis, password);
 
-	private static String JSON(String gitURL, String currentCommitId, List<Refactoring> refactoringsAtRevision) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("{").append("\n");
-		sb.append("\"").append("commits").append("\"").append(": ");
-		sb.append("[");
-		sb.append("{");
-		sb.append("\t").append("\"").append("repository").append("\"").append(": ").append("\"").append(gitURL).append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("sha1").append("\"").append(": ").append("\"").append(currentCommitId).append("\"").append(",").append("\n");
-		String url = GitHistoryRefactoringMinerImpl.extractCommitURL(gitURL, currentCommitId);
-		sb.append("\t").append("\"").append("url").append("\"").append(": ").append("\"").append(url).append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("refactorings").append("\"").append(": ");
-		sb.append("[");
-		int counter = 0;
-		for(Refactoring refactoring : refactoringsAtRevision) {
-			sb.append(refactoring.toJSON());
-			if(counter < refactoringsAtRevision.size()-1) {
-				sb.append(",");
-			}
-			sb.append("\n");
-			counter++;
-		}
-		sb.append("]");
-		sb.append("}");
-		sb.append("]").append("\n");
-		sb.append("}");
-		return sb.toString();
-	}
+		// setup the key manager factory
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+		kmf.init(ks, password);
 
-	private static void printRequestInfo(HttpExchange exchange) {
-		System.out.println("-- headers --");
-		Headers requestHeaders = exchange.getRequestHeaders();
-		requestHeaders.entrySet().forEach(System.out::println);
+		// setup the trust manager factory
+		TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+		tmf.init(ks);
 
-		System.out.println("-- HTTP method --");
-		String requestMethod = exchange.getRequestMethod();
-		System.out.println(requestMethod);
-
-		System.out.println("-- query --");
-		URI requestURI = exchange.getRequestURI();
-		String query = requestURI.getQuery();
-		System.out.println(query);
+		// setup the HTTPS context and parameters
+		sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+		return sslContext;
 	}
 }

--- a/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
+++ b/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
@@ -1265,7 +1265,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 		}
 	}
 
-	protected List<Refactoring> detectRefactorings(final RefactoringHandler handler, String gitURL, String currentCommitId) {
+	public List<Refactoring> detectRefactorings(final RefactoringHandler handler, String gitURL, String currentCommitId) {
 		return detectRefactorings(handler, gitURL, currentCommitId, 0);
 	}
 


### PR DESCRIPTION
Main contribution: HTTP server returns code 500/503 when time limit is exceeded
Minor contributions: 
- Attempt retrieving (hostname and port) environment variables whenever properties is unavailable.
- When more than 100 requests are queued, delegate the mining task to the main thread instead of failing the request
