### PR TITLE
Support Docker-based MCP WebDiff usage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,8 @@ RUN apk add --no-cache openjdk17-jre
 # Set environment variables for Java
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH="$JAVA_HOME/bin:${PATH}"
+ENV REFACTORINGMINER_WEBDIFF_BIND_HOST=0.0.0.0
+ENV REFACTORINGMINER_WEBDIFF_PUBLIC_HOST=127.0.0.1
 
 RUN apk add --no-cache libc6-compat libgcc
 RUN mkdir -p /diff/left /diff/right

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,13 +10,51 @@ In addition to this image which relies on JDK, you can try our native-image whic
 
 ## Usage
 
-To use the Docker `refactoringminer` image, you need to bind the port `6789` of the container to access web interface and run the 
+To use the Docker `refactoringminer` image with the WebDiff browser, publish the container port `6789`.
 
 The classical way to run the container is the command `docker run --pull always -v /my/original-folder:/diff/left -v /my/modified-folder:/diff/right -p 6789:6789 tsantalis/refactoringminer diff --src left/ --dst right/`. You can consult the diff at the URL `http://localhost:6789`.
 
 Of course, all other RefactoringMiner's commands are available.
 
 > **Note:** `--pull always` ensures Docker always pulls the latest image from Docker Hub before running. Since RefactoringMiner is actively developed and the image is regularly updated, this guarantees you benefit from the latest features and fixes without having to manually run `docker pull`.
+
+## MCP server
+
+The Docker image can also run RefactoringMiner's stdio MCP server. This keeps MCP updates on the same Docker Hub path as the command-line tool.
+
+```terminal
+docker run --rm -i --pull always -e OAuthToken=$OAuthToken tsantalis/refactoringminer:latest mcp
+```
+
+For local worktree or commit tools, mount the repository into the container:
+
+```terminal
+docker run --rm -i \
+  --pull always \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+For MCP AST diff browser tools, also publish the WebDiff port:
+
+```terminal
+docker run --rm -i \
+  --pull always \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  -p 6789:6789 \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+The Docker image binds WebDiff inside the container to `0.0.0.0`, but returned links still use `http://127.0.0.1:<port>` for the host browser. Override these only if your Docker setup needs a different address:
+
+```terminal
+-e REFACTORINGMINER_WEBDIFF_BIND_HOST=0.0.0.0
+-e REFACTORINGMINER_WEBDIFF_PUBLIC_HOST=localhost
+```
 
 ## Git integration
 

--- a/docker/native/Dockerfile-native
+++ b/docker/native/Dockerfile-native
@@ -46,6 +46,8 @@ RUN ln -s /opt/refactoringminer /usr/bin/refactoringminer
 
 RUN apk add gcompat
 ENV LANG C.UTF-8
+ENV REFACTORINGMINER_WEBDIFF_BIND_HOST=0.0.0.0
+ENV REFACTORINGMINER_WEBDIFF_PUBLIC_HOST=127.0.0.1
 EXPOSE 6789
 
 WORKDIR /diff

--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -97,6 +97,71 @@ Then ask Claude Code to call a browser tool, for example:
 Call refactoringminer_diff_worktree for repositoryPath "/absolute/path/to/repo", baseRef "HEAD", includeUntracked false, port 6789. Return only the URL and keep this session open.
 ```
 
+## Docker
+
+The Docker image can run the MCP server over stdio:
+
+```bash
+docker run --rm -i \
+  --pull always \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+Mount a repository when using local worktree or commit tools:
+
+```bash
+docker run --rm -i \
+  --pull always \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+For AST diff browser tools, publish the WebDiff port:
+
+```bash
+docker run --rm -i \
+  --pull always \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  -p 6789:6789 \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+The Docker image sets `REFACTORINGMINER_WEBDIFF_BIND_HOST=0.0.0.0` so the published port is reachable from the host. The URL returned to the user still uses `127.0.0.1`.
+
+A Claude Code config can use Docker as the stdio command:
+
+```json
+{
+  "mcpServers": {
+    "refactoringminer": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i", "--pull", "always",
+        "-v", "/absolute/path/to/repo:/workspace",
+        "-w", "/workspace",
+        "-p", "6789:6789",
+        "-e", "OAuthToken",
+        "tsantalis/refactoringminer:latest",
+        "mcp"
+      ]
+    }
+  }
+}
+```
+
+Outside Docker, WebDiff binds to `127.0.0.1` by default. These settings can be overridden with environment variables or JVM system properties:
+
+| Setting | Environment variable | JVM system property | Default |
+|---------|----------------------|---------------------|---------|
+| WebDiff bind host | `REFACTORINGMINER_WEBDIFF_BIND_HOST` | `refactoringminer.webdiff.bindHost` | `127.0.0.1` |
+| Returned URL host | `REFACTORINGMINER_WEBDIFF_PUBLIC_HOST` | `refactoringminer.webdiff.publicHost` | `127.0.0.1` |
+
 ## Analysis tools
 
 Analysis tools report the refactorings RefactoringMiner detects. They return `status`, `summary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `refactorings` list, and `warnings`.
@@ -175,7 +240,7 @@ The default port is `6789`. The returned `message` uses the same wording as the 
 Starting server: http://127.0.0.1:6789
 ```
 
-MCP tools do not auto-open the desktop browser. They bind WebDiff to `127.0.0.1` and return the URL in the tool result so the user or client can decide when to open it.
+MCP tools do not auto-open the desktop browser. They bind WebDiff to `127.0.0.1` by default and return the URL in the tool result so the user or client can decide when to open it.
 
 The returned URL is only available while the MCP server process is still running. If an MCP client starts RefactoringMiner for a single command and immediately exits, the local WebDiff server can disappear before the user opens the URL. Use an interactive client session for browser tools, or use the direct WebDiff CLI when the goal is only manual browser inspection.
 

--- a/src/main/java/gui/webdiff/WebDiff.java
+++ b/src/main/java/gui/webdiff/WebDiff.java
@@ -51,7 +51,10 @@ public class WebDiff  {
     public static final String HIGHLIGHT_JS_URL = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js";
     public static final String HIGHLIGHT_JAVA_URL = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/java.min.js";
     public static final String LOCAL_HOST = "127.0.0.1";
-    public static final String LOCAL_URL_PREFIX = "http://" + LOCAL_HOST;
+    public static final String BIND_HOST_PROPERTY = "refactoringminer.webdiff.bindHost";
+    public static final String PUBLIC_HOST_PROPERTY = "refactoringminer.webdiff.publicHost";
+    public static final String BIND_HOST_ENV = "REFACTORINGMINER_WEBDIFF_BIND_HOST";
+    public static final String PUBLIC_HOST_ENV = "REFACTORINGMINER_WEBDIFF_PUBLIC_HOST";
     public static final int DEFAULT_PORT = 6789;
     public int port = DEFAULT_PORT;
     private static final AtomicInteger DIFF_LOADER_THREAD_SEQUENCE = new AtomicInteger();
@@ -59,9 +62,19 @@ public class WebDiff  {
     private String toolName = "RefactoringMiner";
     private boolean staticExport;
     private boolean exitJvmOnQuit = true;
+    private String bindHost = configuredBindHost();
+    private String publicHost = configuredPublicHost();
 
     public void setPort(int port) {
         this.port = port;
+    }
+
+    public void setBindHost(String bindHost) {
+        this.bindHost = normalizeHost(bindHost, "bindHost");
+    }
+
+    public void setPublicHost(String publicHost) {
+        this.publicHost = normalizeHost(publicHost, "publicHost");
     }
 
     public void setToolName(String toolName) {
@@ -186,15 +199,50 @@ public class WebDiff  {
     }
 
     public String localUrl() {
-        return localUrl(this.port);
+        return localUrl(this.publicHost, this.port);
     }
 
     public static String localUrl(int port) {
-        return LOCAL_URL_PREFIX + ":" + port;
+        return localUrl(LOCAL_HOST, port);
+    }
+
+    public static String localUrl(String publicHost, int port) {
+        return "http://" + normalizeHost(publicHost, "publicHost") + ":" + port;
     }
 
     public static String startupMessage(int port) {
         return "Starting server: " + localUrl(port);
+    }
+
+    public static String startupMessage(String publicHost, int port) {
+        return "Starting server: " + localUrl(publicHost, port);
+    }
+
+    public static String configuredBindHost() {
+        return configuredHost(BIND_HOST_PROPERTY, BIND_HOST_ENV, LOCAL_HOST);
+    }
+
+    public static String configuredPublicHost() {
+        return configuredHost(PUBLIC_HOST_PROPERTY, PUBLIC_HOST_ENV, LOCAL_HOST);
+    }
+
+    private static String configuredHost(String propertyName, String envName, String defaultValue) {
+        String propertyValue = System.getProperty(propertyName);
+        if (propertyValue != null && !propertyValue.isBlank()) {
+            return normalizeHost(propertyValue, propertyName);
+        }
+        String envValue = System.getenv(envName);
+        if (envValue != null && !envValue.isBlank()) {
+            return normalizeHost(envValue, envName);
+        }
+        return defaultValue;
+    }
+
+    private static String normalizeHost(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must be a non-empty host.");
+        }
+        return value.trim();
     }
 
     public String start() {
@@ -202,7 +250,7 @@ public class WebDiff  {
         configureSpark(this.port);
         warmUpMergeParents();
         awaitInitialization();
-        return startupMessage(this.port);
+        return startupMessage(this.publicHost, this.port);
     }
 
     public void run() {
@@ -247,7 +295,7 @@ public class WebDiff  {
     }
 
     public void configureSpark(int port) {
-        ipAddress(LOCAL_HOST);
+        ipAddress(bindHost);
         port(port);
         staticFiles.location(getResources());
         get("/", (request, response) -> {

--- a/src/main/java/org/refactoringminer/mcp/McpDiffBrowserResult.java
+++ b/src/main/java/org/refactoringminer/mcp/McpDiffBrowserResult.java
@@ -27,6 +27,11 @@ public record McpDiffBrowserResult(String status, String summary, String message
 
 	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String inputSummary,
 			List<String> additionalWarnings) {
+		return ok(diff, port, WebDiff.LOCAL_HOST, inputSummary, additionalWarnings);
+	}
+
+	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String publicHost, String inputSummary,
+			List<String> additionalWarnings) {
 		List<Refactoring> refactorings = diff.getRefactorings() == null ? Collections.emptyList() : diff.getRefactorings();
 		int astDiffCount = diff.getDiffSet() == null ? 0 : diff.getDiffSet().size();
 		int moveAstDiffCount = diff.getMoveDiffSet() == null ? 0 : diff.getMoveDiffSet().size();
@@ -38,11 +43,11 @@ public record McpDiffBrowserResult(String status, String summary, String message
 			warnings.addAll(additionalWarnings);
 		}
 		List<String> affectedFiles = affectedFiles(diff, warnings);
-		String url = WebDiff.localUrl(port);
+		String url = WebDiff.localUrl(publicHost, port);
 		String summary = String.format("Started local AST diff browser with %d refactorings, %d AST diffs, %d moved AST diffs across %d before files and %d after files.",
 				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter);
 
-		return new McpDiffBrowserResult(OK, summary, WebDiff.startupMessage(port), url, port, inputSummary,
+		return new McpDiffBrowserResult(OK, summary, WebDiff.startupMessage(publicHost, port), url, port, inputSummary,
 				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter, affectedFiles, warnings);
 	}
 

--- a/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
@@ -12,16 +12,28 @@ import org.refactoringminer.astDiff.models.ProjectASTDiff;
 final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 	private final WebDiffViewFactory factory;
 	private final PortProbe portProbe;
+	private final String bindHost;
+	private final String publicHost;
 	private WebDiffView activeView;
 	private Integer activePort;
 
 	WebDiffBrowserLauncher() {
-		this(WebDiffBrowserLauncher::defaultView, WebDiffBrowserLauncher::requireAvailablePort);
+		this(WebDiff.configuredBindHost(), WebDiff.configuredPublicHost());
+	}
+
+	private WebDiffBrowserLauncher(String bindHost, String publicHost) {
+		this(WebDiffBrowserLauncher::defaultView, port -> requireAvailablePort(bindHost, port), bindHost, publicHost);
 	}
 
 	WebDiffBrowserLauncher(WebDiffViewFactory factory, PortProbe portProbe) {
+		this(factory, portProbe, WebDiff.LOCAL_HOST, WebDiff.LOCAL_HOST);
+	}
+
+	WebDiffBrowserLauncher(WebDiffViewFactory factory, PortProbe portProbe, String bindHost, String publicHost) {
 		this.factory = factory;
 		this.portProbe = portProbe;
+		this.bindHost = bindHost;
+		this.publicHost = publicHost;
 	}
 
 	@Override
@@ -41,6 +53,8 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 
 		WebDiffView view = factory.create(diff);
+		view.setBindHost(bindHost);
+		view.setPublicHost(publicHost);
 		view.setPort(port);
 		try {
 			view.start();
@@ -50,7 +64,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 		activeView = view;
 		activePort = port;
-		return McpDiffBrowserResult.ok(diff, port, inputSummary, warnings);
+		return McpDiffBrowserResult.ok(diff, port, publicHost, inputSummary, warnings);
 	}
 
 	private void stopActiveView() {
@@ -67,10 +81,10 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 	}
 
-	private static void requireAvailablePort(int port) throws IOException {
+	private static void requireAvailablePort(String bindHost, int port) throws IOException {
 		try (ServerSocket socket = new ServerSocket()) {
 			socket.setReuseAddress(false);
-			socket.bind(new InetSocketAddress("127.0.0.1", port));
+			socket.bind(new InetSocketAddress(bindHost, port));
 		} catch (BindException e) {
 			throw new IllegalArgumentException("port is already in use: " + port, e);
 		}
@@ -93,6 +107,12 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 	}
 
 	interface WebDiffView {
+		default void setBindHost(String bindHost) {
+		}
+
+		default void setPublicHost(String publicHost) {
+		}
+
 		void setPort(int port);
 		String start();
 		void terminate();
@@ -108,6 +128,16 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		@Override
 		public void setPort(int port) {
 			webDiff.setPort(port);
+		}
+
+		@Override
+		public void setBindHost(String bindHost) {
+			webDiff.setBindHost(bindHost);
+		}
+
+		@Override
+		public void setPublicHost(String publicHost) {
+			webDiff.setPublicHost(publicHost);
 		}
 
 		@Override

--- a/src/test/java/org/refactoringminer/mcp/WebDiffBrowserLauncherTest.java
+++ b/src/test/java/org/refactoringminer/mcp/WebDiffBrowserLauncherTest.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.refactoringminer.astDiff.models.ProjectASTDiff;
 
+import gui.webdiff.WebDiff;
+
 class WebDiffBrowserLauncherTest {
 	@Test
 	void launchStartsViewWithoutWritingStartupMessageToStdout() throws Exception {
@@ -132,15 +134,71 @@ class WebDiffBrowserLauncherTest {
 		assertSame(diff, received.get(0));
 	}
 
+	@Test
+	void launchUsesConfiguredBindAndPublicHosts() throws Exception {
+		List<FakeWebDiffView> views = new ArrayList<>();
+		WebDiffBrowserLauncher launcher = new WebDiffBrowserLauncher(diff -> {
+			FakeWebDiffView view = new FakeWebDiffView();
+			views.add(view);
+			return view;
+		}, port -> {
+		}, "0.0.0.0", "localhost");
+
+		McpDiffBrowserResult result = launcher.launch(projectDiff(), 6790, "input", List.of());
+
+		assertEquals("http://localhost:6790", result.url());
+		assertEquals("Starting server: http://localhost:6790", result.message());
+		assertEquals("0.0.0.0", views.get(0).bindHost);
+		assertEquals("localhost", views.get(0).publicHost);
+	}
+
+	@Test
+	void webDiffReadsSystemPropertyHostDefaults() {
+		String originalBindHost = System.getProperty(WebDiff.BIND_HOST_PROPERTY);
+		String originalPublicHost = System.getProperty(WebDiff.PUBLIC_HOST_PROPERTY);
+		try {
+			System.setProperty(WebDiff.BIND_HOST_PROPERTY, "0.0.0.0");
+			System.setProperty(WebDiff.PUBLIC_HOST_PROPERTY, "localhost");
+
+			assertEquals("0.0.0.0", WebDiff.configuredBindHost());
+			assertEquals("localhost", WebDiff.configuredPublicHost());
+			assertEquals("http://localhost:6790", WebDiff.localUrl(WebDiff.configuredPublicHost(), 6790));
+			assertEquals("Starting server: http://localhost:6790", WebDiff.startupMessage("localhost", 6790));
+		} finally {
+			restoreProperty(WebDiff.BIND_HOST_PROPERTY, originalBindHost);
+			restoreProperty(WebDiff.PUBLIC_HOST_PROPERTY, originalPublicHost);
+		}
+	}
+
 	private static ProjectASTDiff projectDiff() {
 		return new ProjectASTDiff(Map.of("src/main/java/A.java", "class A {}"),
 				Map.of("src/main/java/A.java", "class A { int x; }"));
+	}
+
+	private static void restoreProperty(String name, String value) {
+		if (value == null) {
+			System.clearProperty(name);
+		} else {
+			System.setProperty(name, value);
+		}
 	}
 
 	private static final class FakeWebDiffView implements WebDiffBrowserLauncher.WebDiffView {
 		private boolean started;
 		private boolean terminated;
 		private boolean failOnStart;
+		private String bindHost;
+		private String publicHost;
+
+		@Override
+		public void setBindHost(String bindHost) {
+			this.bindHost = bindHost;
+		}
+
+		@Override
+		public void setPublicHost(String publicHost) {
+			this.publicHost = publicHost;
+		}
 
 		@Override
 		public void setPort(int port) {


### PR DESCRIPTION
This follows the MCP work that is now on master. The remaining Docker problem is small but important: the browser tools need WebDiff to listen inside the container, while the URL returned to the user should still be something the host browser can open.

Refs #1058.

## what changed
- WebDiff now has separate bind-host and public-host settings. Docker sets the bind host to `0.0.0.0`, and the returned URL stays on `127.0.0.1` by default.
- The MCP browser launcher passes those settings through to WebDiff and uses the public host in the tool result.
- The Docker and MCP docs now show the Docker stdio setup, mounted worktree usage, browser port publishing, and `--pull always` for getting the current image.

## checked
- `JAVA_HOME=/Users/romel/Library/Java/JavaVirtualMachines/temurin-17.0.17/Contents/Home ./gradlew test --tests org.refactoringminer.mcp.WebDiffBrowserLauncherTest --tests org.refactoringminer.mcp.RefactoringMinerMcpServiceTest --tests org.refactoringminer.mcp.RefactoringMinerMcpToolsTest --no-daemon --console=plain`
- `JAVA_HOME=/Users/romel/Library/Java/JavaVirtualMachines/temurin-17.0.17/Contents/Home ./gradlew mcpSmoke --no-daemon --console=plain`
- `git diff --check upstream/master...HEAD`

## not included
The hosted GitHub Action, PR or issue comment, and static HTML report work from #1058 is still separate. This PR only covers Docker-based MCP use.