### PR TITLE
Default MCP repository path to the server working directory

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -94,7 +94,7 @@ claude --mcp-config .mcp.json --strict-mcp-config
 Then ask Claude Code to call a browser tool, for example:
 
 ```text
-Call refactoringminer_diff_worktree for repositoryPath "/absolute/path/to/repo", baseRef "HEAD", includeUntracked false, port 6789. Return only the URL and keep this session open.
+Call refactoringminer_diff_worktree with baseRef "HEAD", includeUntracked false, port 6789. Return only the URL and keep this session open.
 ```
 
 ## Docker
@@ -118,6 +118,8 @@ docker run --rm -i \
   -e OAuthToken=$OAuthToken \
   tsantalis/refactoringminer:latest mcp
 ```
+
+For the command above, worktree and commit tools default to `/workspace` because Docker starts the MCP process there with `-w /workspace`. If you pass `repositoryPath` explicitly, use the container path, not the host path. For example, use `/workspace`, not `C:/RefactoringMiner` or `/Users/me/RefactoringMiner`.
 
 For AST diff browser tools, publish the WebDiff port:
 
@@ -169,12 +171,14 @@ Analysis tools report the refactorings RefactoringMiner detects. They return `st
 | Tool | Required inputs | Optional inputs |
 |------|-----------------|-----------------|
 | `refactoringminer_analyze_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
-| `refactoringminer_analyze_worktree` | `repositoryPath` | `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
-| `refactoringminer_analyze_commit` | `repositoryPath`, `commitId` | `parentIndex`, `maxRefactorings` |
+| `refactoringminer_analyze_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
+| `refactoringminer_analyze_commit` | `commitId` | `repositoryPath`, `parentIndex`, `maxRefactorings` |
 | `refactoringminer_analyze_pull_request` | `cloneUrl`, `pullRequestId` | `timeoutSeconds`, `maxRefactorings` |
 | `refactoringminer_analyze_directories` | `beforePath`, `afterPath` | `maxRefactorings` |
 
-Local paths must be absolute. File-content maps use repository-relative paths as keys and file contents as values. Explicit file-content tools default to `maxFiles=100` and `maxBytesPerFile=200000` to keep calls small. Analysis tools default to `maxRefactorings=20`; set a higher value when the agent needs more returned detail, or `0` when counts and warnings are enough.
+Local paths must be absolute when provided. Worktree and commit tools default `repositoryPath` to the MCP server working directory, which is usually the directory where the agent was started. File-content maps use repository-relative paths as keys and file contents as values. Explicit file-content tools default to `maxFiles=100` and `maxBytesPerFile=200000` to keep calls small. Analysis tools default to `maxRefactorings=20`; set a higher value when the agent needs more returned detail, or `0` when counts and warnings are enough.
+
+Commit tools first try the GitHub API when the working tree has a GitHub `origin` remote. If the commit is not available from GitHub, they fall back to the local repository. This keeps pushed commits small for MCP clients while still supporting local-only commits.
 
 ## Intent validation tools
 
@@ -183,8 +187,8 @@ Validation tools let an agent state the refactoring it intended and ask Refactor
 | Tool | Required inputs | Optional inputs |
 |------|-----------------|-----------------|
 | `refactoringminer_validate_file_contents` | `beforeFiles`, `afterFiles`, `intent` | `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
-| `refactoringminer_validate_worktree` | `repositoryPath`, `intent` | `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
-| `refactoringminer_validate_commit` | `repositoryPath`, `commitId`, `intent` | `parentIndex`, `maxCandidates` |
+| `refactoringminer_validate_worktree` | `intent` | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
+| `refactoringminer_validate_commit` | `commitId`, `intent` | `repositoryPath`, `parentIndex`, `maxCandidates` |
 | `refactoringminer_validate_pull_request` | `cloneUrl`, `pullRequestId`, `intent` | `timeoutSeconds`, `maxCandidates` |
 | `refactoringminer_validate_directories` | `beforePath`, `afterPath`, `intent` | `maxCandidates` |
 
@@ -230,8 +234,8 @@ Diff browser tools generate a RefactoringMiner AST diff, start the existing loca
 | Tool | Required inputs | Optional inputs |
 |------|-----------------|-----------------|
 | `refactoringminer_diff_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `port` |
-| `refactoringminer_diff_worktree` | `repositoryPath` | `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `port` |
-| `refactoringminer_diff_commit` | `repositoryPath`, `commitId` | `parentIndex`, `port` |
+| `refactoringminer_diff_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `port` |
+| `refactoringminer_diff_commit` | `commitId` | `repositoryPath`, `parentIndex`, `port` |
 | `refactoringminer_diff_pull_request` | `cloneUrl`, `pullRequestId` | `timeoutSeconds`, `port` |
 
 The default port is `6789`. The returned `message` uses the same wording as the WebDiff CLI startup line:
@@ -264,7 +268,6 @@ Example worktree browser request:
 
 ```json
 {
-  "repositoryPath": "/absolute/path/to/repo",
   "baseRef": "HEAD",
   "includeUntracked": false,
   "port": 6789
@@ -275,7 +278,6 @@ Example commit browser request:
 
 ```json
 {
-  "repositoryPath": "/absolute/path/to/repo",
   "commitId": "abc123",
   "parentIndex": 0,
   "port": 6789
@@ -329,10 +331,10 @@ Codex:
 
 Generic MCP clients:
 
-- "Call `refactoringminer_validate_commit` for commit `abc123` in `/path/to/repo` with intent `{ \"type\": \"Rename Class\", \"classNames\": [\"OrderService\"] }`."
+- "Call `refactoringminer_validate_commit` for commit `abc123` with intent `{ \"type\": \"Rename Class\", \"classNames\": [\"OrderService\"] }`."
 - "Call `refactoringminer_validate_pull_request` for PR 1234 in `https://github.com/tsantalis/RefactoringMiner.git` with intent `{ \"type\": \"Move Method\", \"methodNames\": [\"detect\"] }`."
 - "Call `refactoringminer_validate_directories` for `/path/to/before` and `/path/to/after` with intent `{ \"type\": \"Extract Method\" }`."
-- "Call `refactoringminer_diff_worktree` for `/path/to/repo` and return the local URL."
+- "Call `refactoringminer_diff_worktree` and return the local URL."
 - "Call `refactoringminer_diff_pull_request` for PR 1234 in `https://github.com/tsantalis/RefactoringMiner.git` and return the startup message and URL."
 
 ## GitHub pull requests
@@ -368,5 +370,6 @@ This release does not include GitHub Action comments, static hosted HTML reports
 
 - If a returned WebDiff URL refuses the connection, confirm the MCP client session that started it is still running. For manual inspection, use the direct `diff` CLI instead.
 - If port `6789` is already in use, call the MCP browser tool with another `port` value, or stop the existing local WebDiff process.
+- If Docker-based worktree or commit tools use the wrong repository, set `-w /workspace` in the Docker command or pass `repositoryPath: "/workspace"` explicitly. The MCP server cannot resolve host paths from inside the container.
 - If pull-request tools fail on a private repository or after many calls, configure `OAuthToken` through the environment, JVM system property, or `github-oauth.properties`.
 - If file-content validation returns `missing` for tiny snippets, retry with complete parseable Java compilation units so RefactoringMiner can build a full model.

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
@@ -5,12 +5,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jgit.lib.Repository;
 import org.refactoringminer.api.GitHistoryRefactoringMiner;
 import org.refactoringminer.astDiff.models.ProjectASTDiff;
 import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
+import org.refactoringminer.util.GitServiceImpl;
 
 public class RefactoringMinerMcpService {
 	private static final int DEFAULT_MAX_FILES = 100;
@@ -18,6 +21,7 @@ public class RefactoringMinerMcpService {
 
 	private final FileContentDiffer differ;
 	private final CommitDiffer commitDiffer;
+	private final RemoteCommitDiffer remoteCommitDiffer;
 	private final PullRequestDiffer pullRequestDiffer;
 	private final DirectoryDiffer directoryDiffer;
 	private final DiffBrowserLauncher diffBrowserLauncher;
@@ -27,7 +31,10 @@ public class RefactoringMinerMcpService {
 	}
 
 	RefactoringMinerMcpService(GitHistoryRefactoringMiner miner) {
-		this(miner::diffAtFileContents, miner::diffAtMergeCommit, miner::diffAtPullRequest, miner::diffAtDirectories,
+		this(miner::diffAtFileContents, miner::diffAtMergeCommit,
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> miner.diffAtMergeCommit(cloneUrl, commitId,
+						parentIndex, timeoutSeconds),
+				miner::diffAtPullRequest, miner::diffAtDirectories,
 				new WebDiffBrowserLauncher());
 	}
 
@@ -35,6 +42,8 @@ public class RefactoringMinerMcpService {
 		GitHistoryRefactoringMiner miner = new GitHistoryRefactoringMinerImpl();
 		this.differ = differ;
 		this.commitDiffer = miner::diffAtMergeCommit;
+		this.remoteCommitDiffer = (cloneUrl, commitId, parentIndex, timeoutSeconds) -> miner.diffAtMergeCommit(
+				cloneUrl, commitId, parentIndex, timeoutSeconds);
 		this.pullRequestDiffer = miner::diffAtPullRequest;
 		this.directoryDiffer = miner::diffAtDirectories;
 		this.diffBrowserLauncher = new WebDiffBrowserLauncher();
@@ -42,13 +51,24 @@ public class RefactoringMinerMcpService {
 
 	RefactoringMinerMcpService(FileContentDiffer differ, CommitDiffer commitDiffer, PullRequestDiffer pullRequestDiffer,
 			DirectoryDiffer directoryDiffer) {
-		this(differ, commitDiffer, pullRequestDiffer, directoryDiffer, new WebDiffBrowserLauncher());
+		this(differ, commitDiffer, null, pullRequestDiffer, directoryDiffer, new WebDiffBrowserLauncher());
+	}
+
+	RefactoringMinerMcpService(FileContentDiffer differ, CommitDiffer commitDiffer, RemoteCommitDiffer remoteCommitDiffer,
+			PullRequestDiffer pullRequestDiffer, DirectoryDiffer directoryDiffer) {
+		this(differ, commitDiffer, remoteCommitDiffer, pullRequestDiffer, directoryDiffer, new WebDiffBrowserLauncher());
 	}
 
 	RefactoringMinerMcpService(FileContentDiffer differ, CommitDiffer commitDiffer, PullRequestDiffer pullRequestDiffer,
 			DirectoryDiffer directoryDiffer, DiffBrowserLauncher diffBrowserLauncher) {
+		this(differ, commitDiffer, null, pullRequestDiffer, directoryDiffer, diffBrowserLauncher);
+	}
+
+	RefactoringMinerMcpService(FileContentDiffer differ, CommitDiffer commitDiffer, RemoteCommitDiffer remoteCommitDiffer,
+			PullRequestDiffer pullRequestDiffer, DirectoryDiffer directoryDiffer, DiffBrowserLauncher diffBrowserLauncher) {
 		this.differ = differ;
 		this.commitDiffer = commitDiffer;
+		this.remoteCommitDiffer = remoteCommitDiffer;
 		this.pullRequestDiffer = pullRequestDiffer;
 		this.directoryDiffer = directoryDiffer;
 		this.diffBrowserLauncher = diffBrowserLauncher;
@@ -137,8 +157,9 @@ public class RefactoringMinerMcpService {
 					List.of("maxCandidates=" + maxCandidates));
 		}
 		try {
+			Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
 			WorktreeChangeCollector.WorktreeChanges changes = new WorktreeChangeCollector()
-					.collect(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile);
+					.collect(resolvedRepositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile);
 			ProjectASTDiff diff = differ.diffAtFileContents(changes.beforeFiles(), changes.afterFiles());
 			return new McpIntentValidator().validate(diff, intent, maxCandidates, changes.warnings());
 		} catch (Exception e) {
@@ -167,9 +188,7 @@ public class RefactoringMinerMcpService {
 		}
 
 		try {
-			requireExistingAbsolutePath(repositoryPath, "repositoryPath");
-			Path analysisRepositoryPath = resolveCommitRepositoryPath(repositoryPath);
-			ProjectASTDiff diff = commitDiffer.diffAtMergeCommit(analysisRepositoryPath, commitId, resolvedParentIndex);
+			ProjectASTDiff diff = diffCommit(repositoryPath, commitId, resolvedParentIndex, 300);
 			return new McpIntentValidator().validate(diff, intent, maxCandidates);
 		} catch (Exception e) {
 			return McpValidationResult.error("Commit validation failed: " + e.getMessage(), intent,
@@ -236,8 +255,9 @@ public class RefactoringMinerMcpService {
 					List.of("maxRefactorings=" + maxRefactorings));
 		}
 		try {
+			Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
 			WorktreeChangeCollector.WorktreeChanges changes = new WorktreeChangeCollector()
-					.collect(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile);
+					.collect(resolvedRepositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile);
 			ProjectASTDiff diff = differ.diffAtFileContents(changes.beforeFiles(), changes.afterFiles());
 			if (diff == null) {
 				return McpAnalysisResult.error("Worktree analysis did not produce a diff.",
@@ -265,9 +285,7 @@ public class RefactoringMinerMcpService {
 		}
 
 		try {
-			requireExistingAbsolutePath(repositoryPath, "repositoryPath");
-			Path analysisRepositoryPath = resolveCommitRepositoryPath(repositoryPath);
-			ProjectASTDiff diff = commitDiffer.diffAtMergeCommit(analysisRepositoryPath, commitId, resolvedParentIndex);
+			ProjectASTDiff diff = diffCommit(repositoryPath, commitId, resolvedParentIndex, 300);
 			return toResult(diff, maxRefactorings, "Commit");
 		} catch (Exception e) {
 			return McpAnalysisResult.error("Commit analysis failed: " + e.getMessage(), List.of(e.getClass().getName()));
@@ -355,10 +373,11 @@ public class RefactoringMinerMcpService {
 	public McpDiffBrowserResult diffWorktree(Path repositoryPath, String baseRef, boolean includeUntracked,
 			int maxFiles, int maxBytesPerFile, int port) {
 		String resolvedBaseRef = baseRef == null || baseRef.isBlank() ? "HEAD" : baseRef;
-		String inputSummary = "Worktree changes in " + repositoryPath + " against " + resolvedBaseRef + ".";
+		Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
+		String inputSummary = "Worktree changes in " + resolvedRepositoryPath + " against " + resolvedBaseRef + ".";
 		try {
 			WorktreeChangeCollector.WorktreeChanges changes = new WorktreeChangeCollector()
-					.collect(repositoryPath, resolvedBaseRef, includeUntracked, maxFiles, maxBytesPerFile);
+					.collect(resolvedRepositoryPath, resolvedBaseRef, includeUntracked, maxFiles, maxBytesPerFile);
 			ProjectASTDiff diff = differ.diffAtFileContents(changes.beforeFiles(), changes.afterFiles());
 			return launchDiffBrowser(diff, port, inputSummary, changes.warnings());
 		} catch (Exception e) {
@@ -381,10 +400,10 @@ public class RefactoringMinerMcpService {
 		String inputSummary = String.format("Commit %s in %s against parent index %d.", commitId, repositoryPath,
 				resolvedParentIndex);
 		try {
-			requireExistingAbsolutePath(repositoryPath, "repositoryPath");
-			Path analysisRepositoryPath = resolveCommitRepositoryPath(repositoryPath);
-			ProjectASTDiff diff = commitDiffer.diffAtMergeCommit(analysisRepositoryPath, commitId,
+			Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
+			inputSummary = String.format("Commit %s in %s against parent index %d.", commitId, resolvedRepositoryPath,
 					resolvedParentIndex);
+			ProjectASTDiff diff = diffCommit(resolvedRepositoryPath, commitId, resolvedParentIndex, 300);
 			return launchDiffBrowser(diff, port, inputSummary, List.of());
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Commit diff browser failed: " + e.getMessage(), port, inputSummary,
@@ -416,6 +435,26 @@ public class RefactoringMinerMcpService {
 		}
 	}
 
+	private ProjectASTDiff diffCommit(Path repositoryPath, String commitId, int parentIndex, int timeoutSeconds)
+			throws Exception {
+		Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
+		requireExistingAbsolutePath(resolvedRepositoryPath, "repositoryPath");
+		Path analysisRepositoryPath = resolveCommitRepositoryPath(resolvedRepositoryPath);
+		String cloneUrl = gitHubCloneUrl(analysisRepositoryPath);
+		if (cloneUrl != null && remoteCommitDiffer != null) {
+			try {
+				ProjectASTDiff remoteDiff = remoteCommitDiffer.diffAtMergeCommit(cloneUrl, commitId, parentIndex,
+						timeoutSeconds);
+				if (remoteDiff != null) {
+					return remoteDiff;
+				}
+			} catch (Exception ignored) {
+				// The commit may be local-only, or GitHub may be unreachable. Fall back to the mounted repository.
+			}
+		}
+		return commitDiffer.diffAtMergeCommit(analysisRepositoryPath, commitId, parentIndex);
+	}
+
 	private static void requireExistingAbsolutePath(Path path, String name) {
 		if (path == null) {
 			throw new IllegalArgumentException(name + " is required.");
@@ -426,6 +465,42 @@ public class RefactoringMinerMcpService {
 		if (!Files.exists(path)) {
 			throw new IllegalArgumentException(name + " does not exist: " + path);
 		}
+	}
+
+	private static Path resolveRepositoryPath(Path repositoryPath) {
+		if (repositoryPath != null) {
+			return repositoryPath;
+		}
+		return Path.of(System.getProperty("user.dir"));
+	}
+
+	static String gitHubCloneUrl(Path repositoryPath) {
+		try (Repository repository = new GitServiceImpl().openRepository(repositoryPath.toString())) {
+			return normalizeGitHubCloneUrl(repository.getConfig().getString("remote", "origin", "url"));
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	static String normalizeGitHubCloneUrl(String cloneUrl) {
+		if (cloneUrl == null || cloneUrl.isBlank()) {
+			return null;
+		}
+		String trimmed = cloneUrl.trim();
+		String lower = trimmed.toLowerCase(Locale.ROOT);
+		if (lower.startsWith("https://github.com/")) {
+			return trimmed;
+		}
+		if (lower.startsWith("http://github.com/")) {
+			return "https://" + trimmed.substring("http://".length());
+		}
+		if (lower.startsWith("git@github.com:")) {
+			return "https://github.com/" + trimmed.substring("git@github.com:".length());
+		}
+		if (lower.startsWith("ssh://git@github.com/")) {
+			return "https://github.com/" + trimmed.substring("ssh://git@github.com/".length());
+		}
+		return null;
 	}
 
 	static Path resolveCommitRepositoryPath(Path repositoryPath) throws Exception {
@@ -517,6 +592,12 @@ public class RefactoringMinerMcpService {
 	@FunctionalInterface
 	interface CommitDiffer {
 		ProjectASTDiff diffAtMergeCommit(Path repositoryPath, String commitId, int parentIndex) throws Exception;
+	}
+
+	@FunctionalInterface
+	interface RemoteCommitDiffer {
+		ProjectASTDiff diffAtMergeCommit(String cloneUrl, String commitId, int parentIndex, int timeoutSeconds)
+				throws Exception;
 	}
 
 	@FunctionalInterface

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
@@ -293,7 +293,7 @@ public final class RefactoringMinerMcpTools {
 			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
 		}
 		try {
-			String repositoryPath = stringValue(arguments.get("repositoryPath"), "repositoryPath");
+			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
 			String baseRef = optionalStringValue(arguments.get("baseRef"), "HEAD");
 			boolean includeUntracked = booleanValue(arguments.get("includeUntracked"), false);
 			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
@@ -301,7 +301,7 @@ public final class RefactoringMinerMcpTools {
 					"maxBytesPerFile");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			return service.analyzeWorktree(Path.of(repositoryPath), baseRef, includeUntracked, maxFiles,
+			return service.analyzeWorktree(repositoryPath, baseRef, includeUntracked, maxFiles,
 					maxBytesPerFile, maxRefactorings);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
@@ -318,12 +318,12 @@ public final class RefactoringMinerMcpTools {
 			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
 		}
 		try {
-			String repositoryPath = stringValue(arguments.get("repositoryPath"), "repositoryPath");
+			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
 			String commitId = stringValue(arguments.get("commitId"), "commitId");
 			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			return service.analyzeCommit(Path.of(repositoryPath), commitId, parentIndex, maxRefactorings);
+			return service.analyzeCommit(repositoryPath, commitId, parentIndex, maxRefactorings);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
@@ -405,7 +405,7 @@ public final class RefactoringMinerMcpTools {
 			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
 		}
 		try {
-			String repositoryPath = stringValue(arguments.get("repositoryPath"), "repositoryPath");
+			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
 			String baseRef = optionalStringValue(arguments.get("baseRef"), "HEAD");
 			boolean includeUntracked = booleanValue(arguments.get("includeUntracked"), false);
 			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
@@ -413,7 +413,7 @@ public final class RefactoringMinerMcpTools {
 					"maxBytesPerFile");
 			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
 			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			return service.validateWorktree(Path.of(repositoryPath), baseRef, includeUntracked, maxFiles,
+			return service.validateWorktree(repositoryPath, baseRef, includeUntracked, maxFiles,
 					maxBytesPerFile, intent, maxCandidates);
 		} catch (IllegalArgumentException e) {
 			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
@@ -430,12 +430,12 @@ public final class RefactoringMinerMcpTools {
 			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
 		}
 		try {
-			String repositoryPath = stringValue(arguments.get("repositoryPath"), "repositoryPath");
+			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
 			String commitId = stringValue(arguments.get("commitId"), "commitId");
 			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
 			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
 			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			return service.validateCommit(Path.of(repositoryPath), commitId, parentIndex, intent, maxCandidates);
+			return service.validateCommit(repositoryPath, commitId, parentIndex, intent, maxCandidates);
 		} catch (IllegalArgumentException e) {
 			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
 		}
@@ -519,14 +519,14 @@ public final class RefactoringMinerMcpTools {
 					List.of("arguments=null"));
 		}
 		try {
-			String repositoryPath = stringValue(arguments.get("repositoryPath"), "repositoryPath");
+			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
 			String baseRef = optionalStringValue(arguments.get("baseRef"), "HEAD");
 			boolean includeUntracked = booleanValue(arguments.get("includeUntracked"), false);
 			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
 			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
 					"maxBytesPerFile");
 			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffWorktree(Path.of(repositoryPath), baseRef, includeUntracked, maxFiles, maxBytesPerFile,
+			return service.diffWorktree(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile,
 					port);
 		} catch (IllegalArgumentException e) {
 			return McpDiffBrowserResult.error(e.getMessage(), null, "Worktree changes",
@@ -545,11 +545,11 @@ public final class RefactoringMinerMcpTools {
 					List.of("arguments=null"));
 		}
 		try {
-			String repositoryPath = stringValue(arguments.get("repositoryPath"), "repositoryPath");
+			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
 			String commitId = stringValue(arguments.get("commitId"), "commitId");
 			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
 			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffCommit(Path.of(repositoryPath), commitId, parentIndex, port);
+			return service.diffCommit(repositoryPath, commitId, parentIndex, port);
 		} catch (IllegalArgumentException e) {
 			return McpDiffBrowserResult.error(e.getMessage(), null, "Commit diff", List.of("Invalid tool arguments."));
 		}
@@ -710,6 +710,13 @@ public final class RefactoringMinerMcpTools {
 		throw new IllegalArgumentException(name + " must be a non-empty string.");
 	}
 
+	private static Path repositoryPath(Object value) {
+		if (value == null) {
+			return Path.of(System.getProperty("user.dir"));
+		}
+		return Path.of(stringValue(value, "repositoryPath"));
+	}
+
 	private static String optionalStringValue(Object value, String defaultValue) {
 		if (value == null) {
 			return defaultValue;
@@ -738,22 +745,22 @@ public final class RefactoringMinerMcpTools {
 
 	private static JsonSchema worktreeInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("repositoryPath", Map.of("type", "string"));
+		putRepositoryPathProperty(properties);
 		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
 		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
 		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
 		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
-		return new JsonSchema("object", properties, List.of("repositoryPath"), false, null, null);
+		return new JsonSchema("object", properties, List.of(), false, null, null);
 	}
 
 	private static JsonSchema commitInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("repositoryPath", Map.of("type", "string"));
+		putRepositoryPathProperty(properties);
 		properties.put("commitId", Map.of("type", "string"));
 		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
-		return new JsonSchema("object", properties, List.of("repositoryPath", "commitId"), false, null, null);
+		return new JsonSchema("object", properties, List.of("commitId"), false, null, null);
 	}
 
 	private static JsonSchema pullRequestInputSchema() {
@@ -784,23 +791,22 @@ public final class RefactoringMinerMcpTools {
 
 	private static JsonSchema validateWorktreeInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("repositoryPath", Map.of("type", "string"));
+		putRepositoryPathProperty(properties);
 		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
 		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
 		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
 		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
 		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("repositoryPath", "intent"), false, null, null);
+		return new JsonSchema("object", properties, List.of("intent"), false, null, null);
 	}
 
 	private static JsonSchema validateCommitInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("repositoryPath", Map.of("type", "string"));
+		putRepositoryPathProperty(properties);
 		properties.put("commitId", Map.of("type", "string"));
 		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
 		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("repositoryPath", "commitId", "intent"), false, null,
-				null);
+		return new JsonSchema("object", properties, List.of("commitId", "intent"), false, null, null);
 	}
 
 	private static JsonSchema validatePullRequestInputSchema() {
@@ -831,22 +837,22 @@ public final class RefactoringMinerMcpTools {
 
 	private static JsonSchema diffWorktreeInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("repositoryPath", Map.of("type", "string"));
+		putRepositoryPathProperty(properties);
 		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
 		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
 		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
 		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
 		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of("repositoryPath"), false, null, null);
+		return new JsonSchema("object", properties, List.of(), false, null, null);
 	}
 
 	private static JsonSchema diffCommitInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("repositoryPath", Map.of("type", "string"));
+		putRepositoryPathProperty(properties);
 		properties.put("commitId", Map.of("type", "string"));
 		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
 		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of("repositoryPath", "commitId"), false, null, null);
+		return new JsonSchema("object", properties, List.of("commitId"), false, null, null);
 	}
 
 	private static JsonSchema diffPullRequestInputSchema() {
@@ -862,6 +868,12 @@ public final class RefactoringMinerMcpTools {
 		properties.put("port", Map.of("type", "integer", "minimum", 1, "maximum", 65535,
 				"default", DEFAULT_WEB_DIFF_PORT,
 				"description", "Local WebDiff port. Defaults to 6789."));
+	}
+
+	private static void putRepositoryPathProperty(Map<String, Object> properties) {
+		properties.put("repositoryPath", Map.of(
+				"type", "string",
+				"description", "Absolute repository path. Defaults to the MCP server working directory."));
 	}
 
 	private static void putFileContentBoundsProperties(Map<String, Object> properties) {

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceRepositoryTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceRepositoryTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -128,5 +129,70 @@ class RefactoringMinerMcpServiceRepositoryTest {
 
 		assertEquals("error", result.status());
 		assertTrue(result.summary().contains("pullRequestId must be greater than 0"));
+	}
+
+	@Test
+	void analyzeCommitPrefersGitHubOriginWhenAvailable() throws Exception {
+		Path repositoryPath = tempDir.resolve("remote-first-repo");
+		try (Git git = Git.init().setDirectory(repositoryPath.toFile()).call()) {
+			git.remoteAdd()
+					.setName("origin")
+					.setUri(new org.eclipse.jgit.transport.URIish("git@github.com:tsantalis/RefactoringMiner.git"))
+					.call();
+		}
+		AtomicBoolean remoteCalled = new AtomicBoolean(false);
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> new ProjectASTDiff(before, after),
+				(localRepositoryPath, commitId, parentIndex) -> {
+					throw new AssertionError("local commit differ should not run when GitHub succeeds");
+				},
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> {
+					remoteCalled.set(true);
+					assertEquals("https://github.com/tsantalis/RefactoringMiner.git", cloneUrl);
+					return new ProjectASTDiff(
+							Map.of("src/main/java/A.java", "class A {}"),
+							Map.of("src/main/java/A.java", "class A { int x; }"));
+				},
+				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()));
+
+		McpAnalysisResult result = service.analyzeCommit(repositoryPath.toAbsolutePath(), "abc123", null, 20);
+
+		assertEquals("ok", result.status());
+		assertTrue(remoteCalled.get());
+		assertEquals(1, result.filesBefore());
+		assertEquals(1, result.filesAfter());
+	}
+
+	@Test
+	void analyzeCommitFallsBackToLocalWhenGitHubLookupFails() throws Exception {
+		Path repositoryPath = tempDir.resolve("local-fallback-repo");
+		try (Git git = Git.init().setDirectory(repositoryPath.toFile()).call()) {
+			git.remoteAdd()
+					.setName("origin")
+					.setUri(new org.eclipse.jgit.transport.URIish("https://github.com/tsantalis/RefactoringMiner.git"))
+					.call();
+		}
+		AtomicBoolean localCalled = new AtomicBoolean(false);
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> new ProjectASTDiff(before, after),
+				(localRepositoryPath, commitId, parentIndex) -> {
+					localCalled.set(true);
+					return new ProjectASTDiff(
+							Map.of("src/main/java/A.java", "class A {}"),
+							Map.of("src/main/java/A.java", "class A { int x; }"));
+				},
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> {
+					throw new IllegalArgumentException("commit was not found on GitHub");
+				},
+				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()));
+
+		McpAnalysisResult result = service.analyzeCommit(repositoryPath.toAbsolutePath(), "local-only", null, 20);
+
+		assertEquals("ok", result.status());
+		assertTrue(localCalled.get());
+		assertEquals(1, result.filesBefore());
+		assertEquals(1, result.filesAfter());
 	}
 }

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
@@ -44,7 +44,7 @@ class RefactoringMinerMcpToolsTest {
 	}
 
 	@Test
-	void worktreeToolMetadataIsReadOnlyAndRequiresRepositoryPath() {
+	void worktreeToolMetadataIsReadOnlyAndDefaultsRepositoryPath() {
 		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeWorktreeTool(
 				new RefactoringMinerMcpService((before, after) -> new ProjectASTDiff(before, after)));
 
@@ -52,7 +52,7 @@ class RefactoringMinerMcpToolsTest {
 		assertTrue(tool.tool().description().contains("local modified, added, deleted"));
 		assertTrue(tool.tool().annotations().readOnlyHint());
 		assertFalse(tool.tool().annotations().destructiveHint());
-		assertTrue(tool.tool().inputSchema().required().contains("repositoryPath"));
+		assertFalse(tool.tool().inputSchema().required().contains("repositoryPath"));
 	}
 
 	@Test
@@ -100,7 +100,7 @@ class RefactoringMinerMcpToolsTest {
 		SyncToolSpecification directoriesTool = RefactoringMinerMcpTools.analyzeDirectoriesTool(service);
 
 		assertTrue(commitTool.tool().annotations().readOnlyHint());
-		assertTrue(commitTool.tool().inputSchema().required().contains("repositoryPath"));
+		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
 		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
 		assertTrue(pullRequestTool.tool().annotations().readOnlyHint());
 		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
@@ -129,8 +129,8 @@ class RefactoringMinerMcpToolsTest {
 		}
 		assertTrue(fileTool.tool().inputSchema().required().contains("beforeFiles"));
 		assertTrue(fileTool.tool().inputSchema().required().contains("afterFiles"));
-		assertTrue(worktreeTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertTrue(commitTool.tool().inputSchema().required().contains("repositoryPath"));
+		assertFalse(worktreeTool.tool().inputSchema().required().contains("repositoryPath"));
+		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
 		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
 		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
 		assertTrue(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
@@ -153,8 +153,8 @@ class RefactoringMinerMcpToolsTest {
 		}
 		assertTrue(fileTool.tool().inputSchema().required().contains("beforeFiles"));
 		assertTrue(fileTool.tool().inputSchema().required().contains("afterFiles"));
-		assertTrue(worktreeTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertTrue(commitTool.tool().inputSchema().required().contains("repositoryPath"));
+		assertFalse(worktreeTool.tool().inputSchema().required().contains("repositoryPath"));
+		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
 		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
 		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
 		assertTrue(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
@@ -470,6 +470,36 @@ class RefactoringMinerMcpToolsTest {
 		assertEquals("ok", json.get("status").asText());
 		assertEquals("http://127.0.0.1:6793", json.get("url").asText());
 		assertEquals("src/main/java/A.java", json.get("affectedFiles").get(0).asText());
+	}
+
+	@Test
+	void worktreeDiffToolDefaultsRepositoryPathToUserDir(@TempDir Path tempDir) throws Exception {
+		Path repo = tempDir.resolve("repo");
+		try (Git git = Git.init().setDirectory(repo.toFile()).call()) {
+			write(repo, "src/main/java/A.java", "class A { void f() {} }");
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("initial").setAuthor("Test", "test@example.com")
+					.setCommitter("Test", "test@example.com").call();
+			write(repo, "src/main/java/A.java", "class A { void g() {} }");
+		}
+		String previousUserDir = System.getProperty("user.dir");
+		try {
+			System.setProperty("user.dir", repo.toString());
+			SyncToolSpecification tool = RefactoringMinerMcpTools.diffWorktreeTool(fakeDiffBrowserService());
+			CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF_WORKTREE, Map.of(
+					"baseRef", "HEAD",
+					"port", 6793));
+
+			CallToolResult result = tool.callHandler().apply(null, request);
+
+			assertFalse(result.isError());
+			TextContent content = (TextContent) result.content().get(0);
+			JsonNode json = OBJECT_MAPPER.readTree(content.text());
+			assertEquals("ok", json.get("status").asText());
+			assertEquals("src/main/java/A.java", json.get("affectedFiles").get(0).asText());
+		} finally {
+			System.setProperty("user.dir", previousUserDir);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

This follows up on the Docker path discussion in #1058.

The worktree and commit MCP tools no longer require agents to pass `repositoryPath`. If it is omitted, the server uses its own working directory. That matches the common setup where the agent starts in the repository, and it also works cleanly with Docker configs that mount the repo at `/workspace` and set `-w /workspace`.

For commit tools, the MCP service now derives the GitHub origin from the local repository. When the origin is a GitHub repository, it tries the GitHub-backed commit diff first. If that fails, for example because the commit is local-only or GitHub is unavailable, it falls back to the local repository path.

## Changes

- Make `repositoryPath` optional for worktree and commit analysis, validation, and diff-browser MCP tools.
- Default omitted `repositoryPath` to `System.getProperty("user.dir")`.
- Normalize GitHub origins from HTTPS, HTTP, `git@github.com:...`, and `ssh://git@github.com/...` forms.
- Prefer GitHub-backed commit analysis when a GitHub origin is available, with local fallback.
- Update MCP docs and focused tests for the new defaults.

## Verification

- `./gradlew test --tests 'org.refactoringminer.mcp.*' --no-daemon --console=plain`
- `./gradlew mcpSmoke --no-daemon --console=plain`
- `git diff --check`
- ASCII scan on changed MCP source, tests, and docs
