### PR TITLE
Make MCP pull request clone URL optional

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -173,12 +173,14 @@ Analysis tools report the refactorings RefactoringMiner detects. They return `st
 | `refactoringminer_analyze_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
 | `refactoringminer_analyze_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
 | `refactoringminer_analyze_commit` | `commitId` | `repositoryPath`, `parentIndex`, `maxRefactorings` |
-| `refactoringminer_analyze_pull_request` | `cloneUrl`, `pullRequestId` | `timeoutSeconds`, `maxRefactorings` |
+| `refactoringminer_analyze_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `maxRefactorings` |
 | `refactoringminer_analyze_directories` | `beforePath`, `afterPath` | `maxRefactorings` |
 
 Local paths must be absolute when provided. Worktree and commit tools default `repositoryPath` to the MCP server working directory, which is usually the directory where the agent was started. File-content maps use repository-relative paths as keys and file contents as values. Explicit file-content tools default to `maxFiles=100` and `maxBytesPerFile=200000` to keep calls small. Analysis tools default to `maxRefactorings=20`; set a higher value when the agent needs more returned detail, or `0` when counts and warnings are enough.
 
 Commit tools first try the GitHub API when the working tree has a GitHub `origin` remote. If the commit is not available from GitHub, they fall back to the local repository. This keeps pushed commits small for MCP clients while still supporting local-only commits.
+
+Pull-request tools also default `cloneUrl` from the MCP server working directory's GitHub `origin` remote. In a Docker config that mounts the repository at `/workspace` and starts the MCP process with `-w /workspace`, agents can usually pass only `pullRequestId`. Keep using an explicit `cloneUrl` when the MCP server is launched outside the target repository, or when the PR belongs to a different repository than the current working directory.
 
 ## Intent validation tools
 
@@ -189,7 +191,7 @@ Validation tools let an agent state the refactoring it intended and ask Refactor
 | `refactoringminer_validate_file_contents` | `beforeFiles`, `afterFiles`, `intent` | `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
 | `refactoringminer_validate_worktree` | `intent` | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
 | `refactoringminer_validate_commit` | `commitId`, `intent` | `repositoryPath`, `parentIndex`, `maxCandidates` |
-| `refactoringminer_validate_pull_request` | `cloneUrl`, `pullRequestId`, `intent` | `timeoutSeconds`, `maxCandidates` |
+| `refactoringminer_validate_pull_request` | `pullRequestId`, `intent` | `cloneUrl`, `timeoutSeconds`, `maxCandidates` |
 | `refactoringminer_validate_directories` | `beforePath`, `afterPath`, `intent` | `maxCandidates` |
 
 Validation tools default to `maxCandidates=20`. This only limits what comes back to the MCP client; it does not change the RefactoringMiner detection pass.
@@ -236,7 +238,7 @@ Diff browser tools generate a RefactoringMiner AST diff, start the existing loca
 | `refactoringminer_diff_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `port` |
 | `refactoringminer_diff_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `port` |
 | `refactoringminer_diff_commit` | `commitId` | `repositoryPath`, `parentIndex`, `port` |
-| `refactoringminer_diff_pull_request` | `cloneUrl`, `pullRequestId` | `timeoutSeconds`, `port` |
+| `refactoringminer_diff_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `port` |
 
 The default port is `6789`. The returned `message` uses the same wording as the WebDiff CLI startup line:
 
@@ -288,12 +290,13 @@ Example pull-request browser request:
 
 ```json
 {
-  "cloneUrl": "https://github.com/tsantalis/RefactoringMiner.git",
   "pullRequestId": 1234,
   "timeoutSeconds": 300,
   "port": 6789
 }
 ```
+
+Add `cloneUrl` to the request when the MCP process is not running from the repository that owns the pull request.
 
 ## Example validation request
 
@@ -332,10 +335,10 @@ Codex:
 Generic MCP clients:
 
 - "Call `refactoringminer_validate_commit` for commit `abc123` with intent `{ \"type\": \"Rename Class\", \"classNames\": [\"OrderService\"] }`."
-- "Call `refactoringminer_validate_pull_request` for PR 1234 in `https://github.com/tsantalis/RefactoringMiner.git` with intent `{ \"type\": \"Move Method\", \"methodNames\": [\"detect\"] }`."
+- "Call `refactoringminer_validate_pull_request` for PR 1234 with intent `{ \"type\": \"Move Method\", \"methodNames\": [\"detect\"] }`."
 - "Call `refactoringminer_validate_directories` for `/path/to/before` and `/path/to/after` with intent `{ \"type\": \"Extract Method\" }`."
 - "Call `refactoringminer_diff_worktree` and return the local URL."
-- "Call `refactoringminer_diff_pull_request` for PR 1234 in `https://github.com/tsantalis/RefactoringMiner.git` and return the startup message and URL."
+- "Call `refactoringminer_diff_pull_request` for PR 1234 and return the startup message and URL."
 
 ## GitHub pull requests
 
@@ -347,7 +350,7 @@ Pull-request analysis and validation read GitHub data through the existing Refac
 
 The MCP tool only reads pull-request data. It does not post comments, mark files viewed, edit pull requests, or change repository state.
 
-Use a GitHub number that identifies a pull request, not a plain issue. For pull-request diff browser tools, the returned WebDiff URL is local to the machine running the MCP server. It is not a hosted report link.
+Use a GitHub number that identifies a pull request, not a plain issue. If `cloneUrl` is omitted, the MCP server reads the GitHub `origin` remote from its working directory. If there is no GitHub `origin`, pass `cloneUrl` explicitly. For pull-request diff browser tools, the returned WebDiff URL is local to the machine running the MCP server. It is not a hosted report link.
 
 ## What the server does not do
 

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
@@ -205,10 +205,6 @@ public class RefactoringMinerMcpService {
 			return McpValidationResult.error("maxCandidates must be greater than or equal to 0.", intent,
 					List.of("maxCandidates=" + maxCandidates));
 		}
-		if (cloneUrl == null || cloneUrl.isBlank()) {
-			return McpValidationResult.error("cloneUrl must be a non-empty string.", intent,
-					List.of("cloneUrl is required."));
-		}
 		if (pullRequestId <= 0) {
 			return McpValidationResult.error("pullRequestId must be greater than 0.", intent,
 					List.of("pullRequestId=" + pullRequestId));
@@ -218,8 +214,15 @@ public class RefactoringMinerMcpService {
 					List.of("timeoutSeconds=" + timeoutSeconds));
 		}
 
+		String resolvedCloneUrl;
 		try {
-			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(cloneUrl, pullRequestId, timeoutSeconds);
+			resolvedCloneUrl = resolvePullRequestCloneUrl(cloneUrl);
+		} catch (IllegalArgumentException e) {
+			return McpValidationResult.error(e.getMessage(), intent, List.of("cloneUrl is not available."));
+		}
+
+		try {
+			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(resolvedCloneUrl, pullRequestId, timeoutSeconds);
 			return new McpIntentValidator().validate(diff, intent, maxCandidates);
 		} catch (Exception e) {
 			return McpValidationResult.error("Pull-request validation failed: " + e.getMessage(), intent,
@@ -298,9 +301,6 @@ public class RefactoringMinerMcpService {
 			return McpAnalysisResult.error("maxRefactorings must be greater than or equal to 0.",
 					List.of("maxRefactorings=" + maxRefactorings));
 		}
-		if (cloneUrl == null || cloneUrl.isBlank()) {
-			return McpAnalysisResult.error("cloneUrl must be a non-empty string.", List.of("cloneUrl is required."));
-		}
 		if (pullRequestId <= 0) {
 			return McpAnalysisResult.error("pullRequestId must be greater than 0.",
 					List.of("pullRequestId=" + pullRequestId));
@@ -310,8 +310,15 @@ public class RefactoringMinerMcpService {
 					List.of("timeoutSeconds=" + timeoutSeconds));
 		}
 
+		String resolvedCloneUrl;
 		try {
-			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(cloneUrl, pullRequestId, timeoutSeconds);
+			resolvedCloneUrl = resolvePullRequestCloneUrl(cloneUrl);
+		} catch (IllegalArgumentException e) {
+			return McpAnalysisResult.error(e.getMessage(), List.of("cloneUrl is not available."));
+		}
+
+		try {
+			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(resolvedCloneUrl, pullRequestId, timeoutSeconds);
 			return toResult(diff, maxRefactorings, "Pull-request");
 		} catch (Exception e) {
 			return McpAnalysisResult.error("Pull-request analysis failed: " + e.getMessage(),
@@ -412,10 +419,6 @@ public class RefactoringMinerMcpService {
 	}
 
 	public McpDiffBrowserResult diffPullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds, int port) {
-		if (cloneUrl == null || cloneUrl.isBlank()) {
-			return McpDiffBrowserResult.error("cloneUrl must be a non-empty string.", port, "Pull-request diff",
-					List.of("cloneUrl is required."));
-		}
 		if (pullRequestId <= 0) {
 			return McpDiffBrowserResult.error("pullRequestId must be greater than 0.", port, "Pull-request diff",
 					List.of("pullRequestId=" + pullRequestId));
@@ -425,9 +428,18 @@ public class RefactoringMinerMcpService {
 					List.of("timeoutSeconds=" + timeoutSeconds));
 		}
 
-		String inputSummary = String.format("Pull request #%d in %s.", pullRequestId, cloneUrl);
+		String inputSummary = "Pull request #" + pullRequestId + ".";
+		String resolvedCloneUrl;
 		try {
-			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(cloneUrl, pullRequestId, timeoutSeconds);
+			resolvedCloneUrl = resolvePullRequestCloneUrl(cloneUrl);
+		} catch (IllegalArgumentException e) {
+			return McpDiffBrowserResult.error(e.getMessage(), port, inputSummary,
+					List.of("cloneUrl is not available."));
+		}
+
+		inputSummary = String.format("Pull request #%d in %s.", pullRequestId, resolvedCloneUrl);
+		try {
+			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(resolvedCloneUrl, pullRequestId, timeoutSeconds);
 			return launchDiffBrowser(diff, port, inputSummary, List.of());
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Pull-request diff browser failed: " + e.getMessage(), port,
@@ -472,6 +484,18 @@ public class RefactoringMinerMcpService {
 			return repositoryPath;
 		}
 		return Path.of(System.getProperty("user.dir"));
+	}
+
+	private static String resolvePullRequestCloneUrl(String cloneUrl) {
+		if (cloneUrl != null && !cloneUrl.isBlank()) {
+			return cloneUrl;
+		}
+		String discoveredCloneUrl = gitHubCloneUrl(resolveRepositoryPath(null));
+		if (discoveredCloneUrl == null) {
+			throw new IllegalArgumentException(
+					"cloneUrl is required unless the MCP server working directory has a GitHub origin remote.");
+		}
+		return discoveredCloneUrl;
 	}
 
 	static String gitHubCloneUrl(Path repositoryPath) {

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
@@ -339,7 +339,7 @@ public final class RefactoringMinerMcpTools {
 			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
 		}
 		try {
-			String cloneUrl = stringValue(arguments.get("cloneUrl"), "cloneUrl");
+			String cloneUrl = optionalCloneUrlValue(arguments.get("cloneUrl"));
 			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
 			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
@@ -452,7 +452,7 @@ public final class RefactoringMinerMcpTools {
 			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
 		}
 		try {
-			String cloneUrl = stringValue(arguments.get("cloneUrl"), "cloneUrl");
+			String cloneUrl = optionalCloneUrlValue(arguments.get("cloneUrl"));
 			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
 			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
 			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
@@ -566,7 +566,7 @@ public final class RefactoringMinerMcpTools {
 					List.of("arguments=null"));
 		}
 		try {
-			String cloneUrl = stringValue(arguments.get("cloneUrl"), "cloneUrl");
+			String cloneUrl = optionalCloneUrlValue(arguments.get("cloneUrl"));
 			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
 			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
 			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
@@ -710,6 +710,16 @@ public final class RefactoringMinerMcpTools {
 		throw new IllegalArgumentException(name + " must be a non-empty string.");
 	}
 
+	private static String optionalCloneUrlValue(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof String stringValue && !stringValue.isBlank()) {
+			return stringValue;
+		}
+		throw new IllegalArgumentException("cloneUrl must be a non-empty string when provided.");
+	}
+
 	private static Path repositoryPath(Object value) {
 		if (value == null) {
 			return Path.of(System.getProperty("user.dir"));
@@ -765,11 +775,11 @@ public final class RefactoringMinerMcpTools {
 
 	private static JsonSchema pullRequestInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("cloneUrl", Map.of("type", "string"));
+		putCloneUrlProperty(properties);
 		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
 		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
-		return new JsonSchema("object", properties, List.of("cloneUrl", "pullRequestId"), false, null, null);
+		return new JsonSchema("object", properties, List.of("pullRequestId"), false, null, null);
 	}
 
 	private static JsonSchema directoriesInputSchema() {
@@ -811,11 +821,11 @@ public final class RefactoringMinerMcpTools {
 
 	private static JsonSchema validatePullRequestInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("cloneUrl", Map.of("type", "string"));
+		putCloneUrlProperty(properties);
 		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
 		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
 		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("cloneUrl", "pullRequestId", "intent"), false, null, null);
+		return new JsonSchema("object", properties, List.of("pullRequestId", "intent"), false, null, null);
 	}
 
 	private static JsonSchema validateDirectoriesInputSchema() {
@@ -857,11 +867,11 @@ public final class RefactoringMinerMcpTools {
 
 	private static JsonSchema diffPullRequestInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("cloneUrl", Map.of("type", "string"));
+		putCloneUrlProperty(properties);
 		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
 		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
 		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of("cloneUrl", "pullRequestId"), false, null, null);
+		return new JsonSchema("object", properties, List.of("pullRequestId"), false, null, null);
 	}
 
 	private static void putDiffBrowserProperties(Map<String, Object> properties) {
@@ -874,6 +884,12 @@ public final class RefactoringMinerMcpTools {
 		properties.put("repositoryPath", Map.of(
 				"type", "string",
 				"description", "Absolute repository path. Defaults to the MCP server working directory."));
+	}
+
+	private static void putCloneUrlProperty(Map<String, Object> properties) {
+		properties.put("cloneUrl", Map.of(
+				"type", "string",
+				"description", "GitHub repository clone URL. Defaults to the MCP server working directory's origin remote."));
 	}
 
 	private static void putFileContentBoundsProperties(Map<String, Object> properties) {

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceRepositoryTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceRepositoryTest.java
@@ -116,6 +116,64 @@ class RefactoringMinerMcpServiceRepositoryTest {
 	}
 
 	@Test
+	void analyzePullRequestDerivesCloneUrlFromWorkingDirectoryOrigin() throws Exception {
+		Path repositoryPath = tempDir.resolve("pull-request-origin-repo");
+		try (Git git = Git.init().setDirectory(repositoryPath.toFile()).call()) {
+			git.remoteAdd()
+					.setName("origin")
+					.setUri(new org.eclipse.jgit.transport.URIish("git@github.com:tsantalis/RefactoringMiner.git"))
+					.call();
+		}
+		AtomicBoolean pullRequestCalled = new AtomicBoolean(false);
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> new ProjectASTDiff(before, after),
+				(localRepositoryPath, commitId, parentIndex) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(cloneUrl, pullRequestId, timeoutSeconds) -> {
+					pullRequestCalled.set(true);
+					assertEquals("https://github.com/tsantalis/RefactoringMiner.git", cloneUrl);
+					return new ProjectASTDiff(
+							Map.of("src/main/java/A.java", "class A {}"),
+							Map.of("src/main/java/A.java", "class A { int x; }"));
+				},
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()));
+
+		String previousUserDir = System.getProperty("user.dir");
+		try {
+			System.setProperty("user.dir", repositoryPath.toString());
+			McpAnalysisResult result = service.analyzePullRequest(null, 1, 30, 20);
+
+			assertEquals("ok", result.status());
+			assertTrue(pullRequestCalled.get());
+			assertEquals(1, result.filesBefore());
+			assertEquals(1, result.filesAfter());
+		} finally {
+			System.setProperty("user.dir", previousUserDir);
+		}
+	}
+
+	@Test
+	void analyzePullRequestReportsMissingCloneUrlWhenWorkingDirectoryHasNoGitHubOrigin() {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> new ProjectASTDiff(before, after),
+				(repositoryPath, commitId, parentIndex) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(cloneUrl, pullRequestId, timeoutSeconds) -> {
+					throw new AssertionError("pull request differ should not run without a clone URL");
+				},
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()));
+
+		String previousUserDir = System.getProperty("user.dir");
+		try {
+			System.setProperty("user.dir", tempDir.toString());
+			McpAnalysisResult result = service.analyzePullRequest(null, 1, 30, 20);
+
+			assertEquals("error", result.status());
+			assertTrue(result.summary().contains("cloneUrl is required"));
+		} finally {
+			System.setProperty("user.dir", previousUserDir);
+		}
+	}
+
+	@Test
 	void analyzePullRequestValidatesBeforeNetworkCapablePath() {
 		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
 				(before, after) -> new ProjectASTDiff(before, after),

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
@@ -104,7 +104,7 @@ class RefactoringMinerMcpToolsTest {
 		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
 		assertTrue(pullRequestTool.tool().annotations().readOnlyHint());
 		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
-		assertTrue(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
+		assertFalse(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
 		assertTrue(pullRequestTool.tool().inputSchema().required().contains("pullRequestId"));
 		assertTrue(directoriesTool.tool().annotations().readOnlyHint());
 		assertTrue(directoriesTool.tool().inputSchema().required().contains("beforePath"));
@@ -133,7 +133,7 @@ class RefactoringMinerMcpToolsTest {
 		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
 		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
 		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
-		assertTrue(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
+		assertFalse(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
 		assertTrue(pullRequestTool.tool().inputSchema().required().contains("pullRequestId"));
 	}
 
@@ -157,7 +157,7 @@ class RefactoringMinerMcpToolsTest {
 		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
 		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
 		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
-		assertTrue(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
+		assertFalse(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
 		assertTrue(pullRequestTool.tool().inputSchema().required().contains("pullRequestId"));
 		assertTrue(directoriesTool.tool().inputSchema().required().contains("beforePath"));
 		assertTrue(directoriesTool.tool().inputSchema().required().contains("afterPath"));


### PR DESCRIPTION
## Summary

Follow-up to #1066 and the MCP API discussion in #1058.

This makes `cloneUrl` optional for the pull-request MCP tools:

- `refactoringminer_analyze_pull_request`
- `refactoringminer_validate_pull_request`
- `refactoringminer_diff_pull_request`

When `cloneUrl` is omitted, the MCP service reads the GitHub `origin` remote from the server working directory. This matches the Docker flow where the repository is mounted at `/workspace` and the MCP process starts with `-w /workspace`.

An explicit `cloneUrl` still works as an override for clients that launch the MCP server outside the target repository, or when the PR belongs to a different repository than the MCP working directory.

## Validation

- `./gradlew test --tests org.refactoringminer.mcp.RefactoringMinerMcpToolsTest --tests org.refactoringminer.mcp.RefactoringMinerMcpServiceRepositoryTest --no-daemon --console=plain`
- `./gradlew shadowJar mcpSmoke --no-daemon --console=plain`
- `git diff --check`
- Packaged MCP schema check confirmed the PR tools now require only:
  - `refactoringminer_analyze_pull_request`: `pullRequestId`
  - `refactoringminer_validate_pull_request`: `pullRequestId`, `intent`
  - `refactoringminer_diff_pull_request`: `pullRequestId`
