### PR TITLE
Hide WebDiff quit action in MCP mode

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -250,7 +250,7 @@ MCP tools do not auto-open the desktop browser. They bind WebDiff to `127.0.0.1`
 
 The returned URL is only available while the MCP server process is still running. If an MCP client starts RefactoringMiner for a single command and immediately exits, the local WebDiff server can disappear before the user opens the URL. Use an interactive client session for browser tools, or use the direct WebDiff CLI when the goal is only manual browser inspection.
 
-Repeated browser-tool calls replace the active local WebDiff view in the MCP server process. The WebDiff Quit button stops the active local WebDiff view but does not exit the MCP JVM. If the requested port is invalid or already occupied by another process, the tool returns an `error` result with a summary and warnings. It does not corrupt stdio output or discard the previous view on another port.
+Repeated browser-tool calls replace the active local WebDiff view in the MCP server process. MCP-managed WebDiff pages hide the WebDiff Quit button so the MCP server can keep serving later browser-tool calls on the same port. If the requested port is invalid or already occupied by another process, the tool returns an `error` result with a summary and warnings. It does not corrupt stdio output or discard the previous view on another port.
 
 Example file-content browser request:
 

--- a/src/main/java/gui/webdiff/WebDiff.java
+++ b/src/main/java/gui/webdiff/WebDiff.java
@@ -62,6 +62,7 @@ public class WebDiff  {
     private String toolName = "RefactoringMiner";
     private boolean staticExport;
     private boolean exitJvmOnQuit = true;
+    private boolean quitEnabled = true;
     private String bindHost = configuredBindHost();
     private String publicHost = configuredPublicHost();
 
@@ -87,6 +88,10 @@ public class WebDiff  {
 
     public void setExitJvmOnQuit(boolean exitJvmOnQuit) {
         this.exitJvmOnQuit = exitJvmOnQuit;
+    }
+
+    public void setQuitEnabled(boolean quitEnabled) {
+        this.quitEnabled = quitEnabled;
     }
 
     private final String resourcesPath = "/web/";
@@ -319,7 +324,8 @@ public class WebDiff  {
         });
         get("/list", (request, response) -> {
             DiffViewState state = currentState;
-            Renderable view = new DirectoryDiffView(state.comparator(), false, state.projectASTDiff().getMetaInfo(), !staticExport);
+            Renderable view = new DirectoryDiffView(state.comparator(), false, state.projectASTDiff().getMetaInfo(),
+                    !staticExport, quitEnabled);
             return render(view);
         });
         get("/vanilla-diff/:id", (request, response) -> {
@@ -383,6 +389,10 @@ public class WebDiff  {
             return render(new SinglePageView(state.comparator(), state.projectASTDiff().getMetaInfo(), !staticExport, !staticExport));
         });
         get("/quit", (request, response) -> {
+            if (!quitEnabled) {
+                response.status(403);
+                return "WebDiff quit is disabled.";
+            }
             if (exitJvmOnQuit) {
                 System.exit(0);
                 return "";

--- a/src/main/java/gui/webdiff/dir/DirectoryDiffView.java
+++ b/src/main/java/gui/webdiff/dir/DirectoryDiffView.java
@@ -39,6 +39,7 @@ public class DirectoryDiffView implements Renderable {
     private final boolean external;
     protected final DiffMetaInfo metaInfo;
     protected final boolean showMergeParentBar;
+    private final boolean showQuitButton;
 
     public DirectoryDiffView(DirComparator comparator, DiffMetaInfo metaInfo) {
         this(comparator, false, metaInfo, true);
@@ -49,10 +50,16 @@ public class DirectoryDiffView implements Renderable {
     }
 
     public DirectoryDiffView(DirComparator comparator, boolean external, DiffMetaInfo metaInfo, boolean showMergeParentBar) {
+        this(comparator, external, metaInfo, showMergeParentBar, true);
+    }
+
+    public DirectoryDiffView(DirComparator comparator, boolean external, DiffMetaInfo metaInfo,
+                             boolean showMergeParentBar, boolean showQuitButton) {
         this.comparator = comparator;
         this.external = external;
         this.metaInfo = metaInfo;
         this.showMergeParentBar = showMergeParentBar;
+        this.showQuitButton = showQuitButton;
     }
 
     protected boolean isMovedCode(TreeNodeInfo info) {
@@ -75,7 +82,7 @@ public class DirectoryDiffView implements Renderable {
             .body()
                 .div(class_("container-fluid"))
                     .div(class_("row"))
-                        .render(new MenuBar(external, metaInfo))
+                        .render(new MenuBar(external, metaInfo, showQuitButton))
                     ._div()
                     .render_if(new MergeParentBar(metaInfo), showMergeParentBar && metaInfo != null && metaInfo.supportsParentSelection())
                     .if_(!external)
@@ -445,11 +452,17 @@ public class DirectoryDiffView implements Renderable {
     private static class MenuBar implements Renderable {
         private final boolean external;
         private final DiffMetaInfo metaInfo;
+        private final boolean showQuitButton;
 
 
         public MenuBar(boolean external, DiffMetaInfo metaInfo) {
+            this(external, metaInfo, true);
+        }
+
+        public MenuBar(boolean external, DiffMetaInfo metaInfo, boolean showQuitButton) {
             this.external = external;
             this.metaInfo = metaInfo;
+            this.showQuitButton = showQuitButton;
         }
 
         @Override
@@ -476,7 +489,9 @@ public class DirectoryDiffView implements Renderable {
                         .onClick("handleCompareClick()")
                             )
                         .content("Compare Selected Files")
+                        .if_(showQuitButton)
                         .a(class_("btn btn-default btn-sm btn-danger").href("/quit")).content("Quit")
+                        ._if()
                         ._if()
                         .if_(external)
                         .a(class_("btn btn-default btn-sm btn-danger").href("/list")).content("Back")

--- a/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
@@ -93,6 +93,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 	private static WebDiffView defaultView(ProjectASTDiff diff) {
 		WebDiff webDiff = new WebDiff(diff);
 		webDiff.setExitJvmOnQuit(false);
+		webDiff.setQuitEnabled(false);
 		return new ManagedWebDiffView(webDiff);
 	}
 

--- a/src/test/java/gui/webdiff/dir/DirectoryDiffViewTest.java
+++ b/src/test/java/gui/webdiff/dir/DirectoryDiffViewTest.java
@@ -1,0 +1,69 @@
+package gui.webdiff.dir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.refactoringminer.astDiff.models.DiffMetaInfo;
+import org.refactoringminer.astDiff.models.ProjectASTDiff;
+import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
+import org.rendersnake.HtmlCanvas;
+
+class DirectoryDiffViewTest {
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void rendersQuitButtonByDefault() throws Exception {
+		DirectoryDiffView view = new DirectoryDiffView(createComparator(), false, new DiffMetaInfo("Local diff", null),
+				true);
+
+		String html = render(view);
+
+		assertTrue(html.contains("href=\"/quit\""));
+		assertTrue(html.contains(">Quit<"));
+	}
+
+	@Test
+	void canHideQuitButtonForManagedWebDiffSessions() throws Exception {
+		DirectoryDiffView view = new DirectoryDiffView(createComparator(), false, new DiffMetaInfo("Local diff", null),
+				true, false);
+
+		String html = render(view);
+
+		assertFalse(html.contains("href=\"/quit\""));
+		assertFalse(html.contains(">Quit<"));
+	}
+
+	private DirComparator createComparator() throws Exception {
+		Path beforeDir = Files.createDirectories(tempDir.resolve("before/src/main/java/example"));
+		Path afterDir = Files.createDirectories(tempDir.resolve("after/src/main/java/example"));
+		Files.writeString(beforeDir.resolve("Sample.java"), """
+				package example;
+				class Sample {
+					int value() { return 1; }
+				}
+				""");
+		Files.writeString(afterDir.resolve("Sample.java"), """
+				package example;
+				class Sample {
+					int value() { return 2; }
+				}
+				""");
+		ProjectASTDiff projectASTDiff = new GitHistoryRefactoringMinerImpl()
+				.diffAtDirectories(tempDir.resolve("before"), tempDir.resolve("after"));
+		projectASTDiff.setMetaInfo(new DiffMetaInfo("Local diff", null));
+		return new DirComparator(projectASTDiff, diffs -> diffs);
+	}
+
+	private static String render(DirectoryDiffView view) throws IOException {
+		HtmlCanvas canvas = new HtmlCanvas();
+		view.renderOn(canvas);
+		return canvas.toHtml();
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the MCP WebDiff issue reported in #1058 where clicking the WebDiff `Quit` button can stop the active Spark server and make later diff-browser MCP calls on the same port fail.

This keeps the normal WebDiff CLI behavior unchanged, but changes MCP-managed WebDiff sessions to:

- hide the `Quit` button from the WebDiff list page
- return `403` from `/quit` instead of stopping Spark
- keep repeated MCP browser-tool calls responsible for replacing the active WebDiff view

## Validation

- `./gradlew test --tests gui.webdiff.dir.DirectoryDiffViewTest --tests org.refactoringminer.mcp.WebDiffBrowserLauncherTest --no-daemon --console=plain`
- `./gradlew shadowJar mcpSmoke --no-daemon --console=plain`
- `git diff --check`
- Live packaged MCP check with `refactoringminer_diff_file_contents` on port `6794`:
  - tool returned `ok`
  - `GET /list` returned `200`
  - `/list` did not contain `href="/quit"`
  - `GET /quit` returned `403 WebDiff quit is disabled.`
