### PR TITLE
Expose bounded AST diff summaries in MCP results

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -166,17 +166,21 @@ Outside Docker, WebDiff binds to `127.0.0.1` by default. These settings can be o
 
 ## Analysis tools
 
-Analysis tools report the refactorings RefactoringMiner detects. They return `status`, `summary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `refactorings` list, and `warnings`.
+Analysis tools report the refactorings RefactoringMiner detects. They return `status`, `summary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `refactorings` list, bounded `astDiffs` summaries, and `warnings`.
 
 | Tool | Required inputs | Optional inputs |
 |------|-----------------|-----------------|
-| `refactoringminer_analyze_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
-| `refactoringminer_analyze_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
-| `refactoringminer_analyze_commit` | `commitId` | `repositoryPath`, `parentIndex`, `maxRefactorings` |
-| `refactoringminer_analyze_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `maxRefactorings` |
-| `refactoringminer_analyze_directories` | `beforePath`, `afterPath` | `maxRefactorings` |
+| `refactoringminer_analyze_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `maxRefactorings`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_analyze_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxRefactorings`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_analyze_commit` | `commitId` | `repositoryPath`, `parentIndex`, `maxRefactorings`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_analyze_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `maxRefactorings`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_analyze_directories` | `beforePath`, `afterPath` | `maxRefactorings`, `maxAstDiffs`, `maxActionsPerAstDiff` |
 
 Local paths must be absolute when provided. Worktree and commit tools default `repositoryPath` to the MCP server working directory, which is usually the directory where the agent was started. File-content maps use repository-relative paths as keys and file contents as values. Explicit file-content tools default to `maxFiles=100` and `maxBytesPerFile=200000` to keep calls small. Analysis tools default to `maxRefactorings=20`; set a higher value when the agent needs more returned detail, or `0` when counts and warnings are enough.
+
+Analysis tools also return compact AST diff summaries by default. `maxAstDiffs` controls how many file-pair summaries are returned, and `maxActionsPerAstDiff` controls how many edit actions are sampled per summary. Set `maxAstDiffs=0` when an agent only needs refactoring counts and warnings.
+
+Each `astDiffs` entry includes `kind` (`standard` or `moved`), before/after file paths, mapping and action counts, per-action counts, and sampled action ranges. Sampled actions include the source-side `filePath`, a real `targetFilePath` when the action points to another file or the destination side, and `moveGroupId` for grouped multi-move actions. Missing node positions use `-1` for offsets and lines. This is intended for agent triage of moved, renamed, extracted, or inlined code without relying only on ordinary Git diff delete/add blocks.
 
 Commit tools first try the GitHub API when the working tree has a GitHub `origin` remote. If the commit is not available from GitHub, they fall back to the local repository. This keeps pushed commits small for MCP clients while still supporting local-only commits.
 
@@ -231,14 +235,14 @@ Use `maxCandidates` to limit returned matches and candidates. If the result is t
 
 ## AST diff browser tools
 
-Diff browser tools generate a RefactoringMiner AST diff, start the existing local WebDiff server, and return a localhost URL that the user can open in a browser. They return `status`, `summary`, `message`, `url`, `port`, `inputSummary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `affectedFiles` list, and `warnings`.
+Diff browser tools generate a RefactoringMiner AST diff, start the existing local WebDiff server, and return a localhost URL that the user can open in a browser. They return `status`, `summary`, `message`, `url`, `port`, `inputSummary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `affectedFiles` list, bounded `astDiffs` summaries, and `warnings`.
 
 | Tool | Required inputs | Optional inputs |
 |------|-----------------|-----------------|
-| `refactoringminer_diff_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `port` |
-| `refactoringminer_diff_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `port` |
-| `refactoringminer_diff_commit` | `commitId` | `repositoryPath`, `parentIndex`, `port` |
-| `refactoringminer_diff_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `port` |
+| `refactoringminer_diff_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `port`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_diff_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `port`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_diff_commit` | `commitId` | `repositoryPath`, `parentIndex`, `port`, `maxAstDiffs`, `maxActionsPerAstDiff` |
+| `refactoringminer_diff_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `port`, `maxAstDiffs`, `maxActionsPerAstDiff` |
 
 The default port is `6789`. The returned `message` uses the same wording as the WebDiff CLI startup line:
 
@@ -247,6 +251,8 @@ Starting server: http://127.0.0.1:6789
 ```
 
 MCP tools do not auto-open the desktop browser. They bind WebDiff to `127.0.0.1` by default and return the URL in the tool result so the user or client can decide when to open it.
+
+Diff browser tools return the same compact `astDiffs` summaries as analysis tools, with the same `maxAstDiffs` and `maxActionsPerAstDiff` controls. Set `maxAstDiffs=0` when the client only needs the WebDiff URL and counts.
 
 The returned URL is only available while the MCP server process is still running. If an MCP client starts RefactoringMiner for a single command and immediately exits, the local WebDiff server can disappear before the user opens the URL. Use an interactive client session for browser tools, or use the direct WebDiff CLI when the goal is only manual browser inspection.
 

--- a/src/main/java/org/refactoringminer/mcp/DiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/DiffBrowserLauncher.java
@@ -6,5 +6,11 @@ import org.refactoringminer.astDiff.models.ProjectASTDiff;
 
 @FunctionalInterface
 interface DiffBrowserLauncher {
-	McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary, List<String> warnings) throws Exception;
+	McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary, List<String> warnings,
+			int maxAstDiffs, int maxActionsPerAstDiff) throws Exception;
+
+	default McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary, List<String> warnings)
+			throws Exception {
+		return launch(diff, port, inputSummary, warnings, 20, 20);
+	}
 }

--- a/src/main/java/org/refactoringminer/mcp/McpAnalysisResult.java
+++ b/src/main/java/org/refactoringminer/mcp/McpAnalysisResult.java
@@ -9,13 +9,23 @@ import org.refactoringminer.astDiff.models.ProjectASTDiff;
 
 public record McpAnalysisResult(String status, String summary, int refactoringCount, int astDiffCount,
 		int moveAstDiffCount, int filesBefore, int filesAfter, List<McpRefactoringResult> refactorings,
-		List<String> warnings) {
+		List<McpAstDiffResult> astDiffs, List<String> warnings) {
 
 	public static McpAnalysisResult ok(ProjectASTDiff diff, int maxRefactorings) {
-		return ok(diff, maxRefactorings, Collections.emptyList());
+		return ok(diff, maxRefactorings, 0, 0, Collections.emptyList());
+	}
+
+	public static McpAnalysisResult ok(ProjectASTDiff diff, int maxRefactorings, int maxAstDiffs,
+			int maxActionsPerAstDiff) {
+		return ok(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff, Collections.emptyList());
 	}
 
 	public static McpAnalysisResult ok(ProjectASTDiff diff, int maxRefactorings, List<String> additionalWarnings) {
+		return ok(diff, maxRefactorings, 0, 0, additionalWarnings);
+	}
+
+	public static McpAnalysisResult ok(ProjectASTDiff diff, int maxRefactorings, int maxAstDiffs,
+			int maxActionsPerAstDiff, List<String> additionalWarnings) {
 		List<Refactoring> sourceRefactorings = diff.getRefactorings() == null
 				? Collections.emptyList() : diff.getRefactorings();
 		int boundedSize = Math.min(sourceRefactorings.size(), maxRefactorings);
@@ -30,6 +40,7 @@ public record McpAnalysisResult(String status, String summary, int refactoringCo
 			warnings.add(String.format("Refactorings truncated to %d of %d.", boundedSize, sourceRefactorings.size()));
 		}
 
+		List<McpAstDiffResult> astDiffs = McpAstDiffResult.from(diff, maxAstDiffs, maxActionsPerAstDiff, warnings);
 		int astDiffCount = diff.getDiffSet() == null ? 0 : diff.getDiffSet().size();
 		int moveAstDiffCount = diff.getMoveDiffSet() == null ? 0 : diff.getMoveDiffSet().size();
 		int filesBefore = diff.getFileContentsBefore() == null ? 0 : diff.getFileContentsBefore().size();
@@ -38,10 +49,11 @@ public record McpAnalysisResult(String status, String summary, int refactoringCo
 				sourceRefactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter);
 
 		return new McpAnalysisResult("ok", summary, sourceRefactorings.size(), astDiffCount, moveAstDiffCount,
-				filesBefore, filesAfter, boundedRefactorings, warnings);
+				filesBefore, filesAfter, boundedRefactorings, astDiffs, warnings);
 	}
 
 	public static McpAnalysisResult error(String summary, List<String> warnings) {
-		return new McpAnalysisResult("error", summary, 0, 0, 0, 0, 0, Collections.emptyList(), warnings);
+		return new McpAnalysisResult("error", summary, 0, 0, 0, 0, 0, Collections.emptyList(),
+				Collections.emptyList(), warnings);
 	}
 }

--- a/src/main/java/org/refactoringminer/mcp/McpAstDiffResult.java
+++ b/src/main/java/org/refactoringminer/mcp/McpAstDiffResult.java
@@ -1,0 +1,197 @@
+package org.refactoringminer.mcp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.gumtreediff.actions.model.Action;
+import com.github.gumtreediff.actions.model.Delete;
+import com.github.gumtreediff.actions.model.Insert;
+import com.github.gumtreediff.actions.model.TreeAddition;
+import com.github.gumtreediff.actions.model.TreeDelete;
+import com.github.gumtreediff.actions.model.TreeInsert;
+import com.github.gumtreediff.actions.model.Update;
+import com.github.gumtreediff.tree.Tree;
+import org.refactoringminer.astDiff.actions.model.MoveIn;
+import org.refactoringminer.astDiff.actions.model.MoveOut;
+import org.refactoringminer.astDiff.actions.model.MultiMove;
+import org.refactoringminer.astDiff.models.ASTDiff;
+import org.refactoringminer.astDiff.models.ProjectASTDiff;
+
+public record McpAstDiffResult(String kind, String beforeFilePath, String afterFilePath, int mappingCount,
+		int actionCount, Map<String, Integer> actionCounts, List<ActionSummary> sampleActions) {
+	private static final String STANDARD = "standard";
+	private static final String MOVED = "moved";
+
+	public McpAstDiffResult {
+		actionCounts = actionCounts == null ? Collections.emptyMap()
+				: Collections.unmodifiableMap(new LinkedHashMap<>(actionCounts));
+		sampleActions = sampleActions == null ? Collections.emptyList() : List.copyOf(sampleActions);
+	}
+
+	static List<McpAstDiffResult> from(ProjectASTDiff diff, int maxAstDiffs, int maxActionsPerAstDiff,
+			List<String> warnings) {
+		if (maxAstDiffs <= 0) {
+			return Collections.emptyList();
+		}
+		List<DiffEntry> entries = entries(diff);
+		int boundedSize = Math.min(entries.size(), maxAstDiffs);
+		List<McpAstDiffResult> results = new ArrayList<>();
+		for (int i = 0; i < boundedSize; i++) {
+			DiffEntry entry = entries.get(i);
+			results.add(from(entry.diff(), entry.kind(), diff.getFileContentsBefore(), diff.getFileContentsAfter(),
+					maxActionsPerAstDiff, warnings));
+		}
+		if (boundedSize < entries.size()) {
+			warnings.add(String.format("AST diffs truncated to %d of %d.", boundedSize, entries.size()));
+		}
+		return List.copyOf(results);
+	}
+
+	private static McpAstDiffResult from(ASTDiff astDiff, String kind, Map<String, String> beforeFiles,
+			Map<String, String> afterFiles, int maxActionsPerAstDiff, List<String> warnings) {
+		Map<String, Integer> actionCounts = new LinkedHashMap<>();
+		List<ActionSummary> sampleActions = new ArrayList<>();
+		int actionCount = 0;
+		for (Action action : astDiff.editScript) {
+			actionCount++;
+			actionCounts.merge(action.getName(), 1, Integer::sum);
+			if (sampleActions.size() < maxActionsPerAstDiff) {
+				sampleActions.add(ActionSummary.from(action, astDiff, beforeFiles, afterFiles));
+			}
+		}
+		if (maxActionsPerAstDiff > 0 && sampleActions.size() < actionCount) {
+			warnings.add(String.format("Actions for %s -> %s truncated to %d of %d.", astDiff.getSrcPath(),
+					astDiff.getDstPath(), sampleActions.size(), actionCount));
+		}
+		int mappingCount = astDiff.getAllMappings() == null ? 0 : astDiff.getAllMappings().size();
+		return new McpAstDiffResult(kind, astDiff.getSrcPath(), astDiff.getDstPath(), mappingCount, actionCount,
+				actionCounts, sampleActions);
+	}
+
+	private static List<DiffEntry> entries(ProjectASTDiff diff) {
+		List<DiffEntry> entries = new ArrayList<>();
+		Set<ASTDiff> moved = diff.getMoveDiffSet() == null ? Collections.emptySet() : diff.getMoveDiffSet();
+		Set<ASTDiff> seen = new LinkedHashSet<>();
+		if (diff.getDiffSet() != null) {
+			for (ASTDiff astDiff : diff.getDiffSet()) {
+				entries.add(new DiffEntry(astDiff, moved.contains(astDiff) ? MOVED : STANDARD));
+				seen.add(astDiff);
+			}
+		}
+		for (ASTDiff astDiff : moved) {
+			if (seen.add(astDiff)) {
+				entries.add(new DiffEntry(astDiff, MOVED));
+			}
+		}
+		return entries;
+	}
+
+	private record DiffEntry(ASTDiff diff, String kind) {
+	}
+
+	public record ActionSummary(String name, String side, String filePath, String targetFilePath, Integer moveGroupId,
+			String nodeType, String nodeLabel, int startOffset, int endOffset, int startLine, int endLine,
+			String newValue, Integer parentPosition, String parentType) {
+		private static ActionSummary from(Action action, ASTDiff astDiff, Map<String, String> beforeFiles,
+				Map<String, String> afterFiles) {
+			Tree node = action.getNode();
+			String side = side(action);
+			String filePath = filePath(action, astDiff, side);
+			String content = "after".equals(side) ? get(afterFiles, filePath) : get(beforeFiles, filePath);
+			LineRange lineRange = LineRange.from(content, node);
+			String targetFilePath = targetFilePath(action, astDiff);
+			Integer moveGroupId = action instanceof MultiMove multiMove ? multiMove.getGroupId() : null;
+			String newValue = action instanceof Update update ? update.getValue() : null;
+			Integer parentPosition = action instanceof TreeAddition addition ? addition.getPosition() : null;
+			String parentType = action instanceof TreeAddition addition && addition.getParent() != null
+					? addition.getParent().getType().toString() : null;
+			return new ActionSummary(action.getName(), side, filePath, targetFilePath, moveGroupId, type(node),
+					label(node), position(node), endPosition(node), lineRange.startLine(), lineRange.endLine(),
+					newValue, parentPosition, parentType);
+		}
+
+		private static String side(Action action) {
+			if (action instanceof Insert || action instanceof TreeInsert || action instanceof MoveIn) {
+				return "after";
+			}
+			if (action instanceof Delete || action instanceof TreeDelete || action instanceof MoveOut) {
+				return "before";
+			}
+			return "before";
+		}
+
+		private static String filePath(Action action, ASTDiff astDiff, String side) {
+			if (action instanceof MoveIn) {
+				return astDiff.getDstPath();
+			}
+			if (action instanceof MoveOut) {
+				return astDiff.getSrcPath();
+			}
+			return "after".equals(side) ? astDiff.getDstPath() : astDiff.getSrcPath();
+		}
+
+		private static String targetFilePath(Action action, ASTDiff astDiff) {
+			if (action instanceof MoveIn moveIn) {
+				return moveIn.getSrcFile();
+			}
+			if (action instanceof MoveOut moveOut) {
+				return moveOut.getDstFile();
+			}
+			if (action instanceof MultiMove) {
+				return astDiff.getDstPath();
+			}
+			return null;
+		}
+
+		private static String get(Map<String, String> files, String filePath) {
+			return files == null ? null : files.get(filePath);
+		}
+
+		private static String type(Tree node) {
+			return node == null || node.getType() == null ? null : node.getType().toString();
+		}
+
+		private static String label(Tree node) {
+			if (node == null || !node.hasLabel()) {
+				return null;
+			}
+			String label = node.getLabel();
+			return label == null || label.isBlank() ? null : label;
+		}
+
+		private static int position(Tree node) {
+			return node == null ? -1 : node.getPos();
+		}
+
+		private static int endPosition(Tree node) {
+			return node == null ? -1 : node.getEndPos();
+		}
+	}
+
+	private record LineRange(int startLine, int endLine) {
+		private static LineRange from(String content, Tree node) {
+			if (content == null || node == null || node.getPos() < 0 || node.getEndPos() < 0) {
+				return new LineRange(-1, -1);
+			}
+			int startOffset = node.getPos();
+			int endOffset = Math.max(startOffset, node.getEndPos() - 1);
+			return new LineRange(lineNumber(content, startOffset), lineNumber(content, endOffset));
+		}
+
+		private static int lineNumber(String content, int offset) {
+			int boundedOffset = Math.max(0, Math.min(offset, content.length()));
+			int line = 1;
+			for (int i = 0; i < boundedOffset; i++) {
+				if (content.charAt(i) == '\n') {
+					line++;
+				}
+			}
+			return line;
+		}
+	}
+}

--- a/src/main/java/org/refactoringminer/mcp/McpDiffBrowserResult.java
+++ b/src/main/java/org/refactoringminer/mcp/McpDiffBrowserResult.java
@@ -14,14 +14,17 @@ import org.refactoringminer.astDiff.models.ProjectASTDiff;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record McpDiffBrowserResult(String status, String summary, String message, String url, Integer port,
 		String inputSummary, int refactoringCount, int astDiffCount, int moveAstDiffCount, int filesBefore,
-		int filesAfter, List<String> affectedFiles, List<String> warnings) {
+		int filesAfter, List<String> affectedFiles, List<McpAstDiffResult> astDiffs, List<String> warnings) {
 	private static final int MAX_AFFECTED_FILES = 50;
+	private static final int DEFAULT_MAX_AST_DIFFS = 20;
+	private static final int DEFAULT_MAX_ACTIONS_PER_AST_DIFF = 20;
 
 	public static final String OK = "ok";
 	public static final String ERROR = "error";
 
 	public McpDiffBrowserResult {
 		affectedFiles = affectedFiles == null ? Collections.emptyList() : List.copyOf(affectedFiles);
+		astDiffs = astDiffs == null ? Collections.emptyList() : List.copyOf(astDiffs);
 		warnings = warnings == null ? Collections.emptyList() : List.copyOf(warnings);
 	}
 
@@ -30,8 +33,20 @@ public record McpDiffBrowserResult(String status, String summary, String message
 		return ok(diff, port, WebDiff.LOCAL_HOST, inputSummary, additionalWarnings);
 	}
 
+	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String inputSummary,
+			List<String> additionalWarnings, int maxAstDiffs, int maxActionsPerAstDiff) {
+		return ok(diff, port, WebDiff.LOCAL_HOST, inputSummary, additionalWarnings, maxAstDiffs,
+				maxActionsPerAstDiff);
+	}
+
 	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String publicHost, String inputSummary,
 			List<String> additionalWarnings) {
+		return ok(diff, port, publicHost, inputSummary, additionalWarnings, DEFAULT_MAX_AST_DIFFS,
+				DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
+	}
+
+	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String publicHost, String inputSummary,
+			List<String> additionalWarnings, int maxAstDiffs, int maxActionsPerAstDiff) {
 		List<Refactoring> refactorings = diff.getRefactorings() == null ? Collections.emptyList() : diff.getRefactorings();
 		int astDiffCount = diff.getDiffSet() == null ? 0 : diff.getDiffSet().size();
 		int moveAstDiffCount = diff.getMoveDiffSet() == null ? 0 : diff.getMoveDiffSet().size();
@@ -43,17 +58,19 @@ public record McpDiffBrowserResult(String status, String summary, String message
 			warnings.addAll(additionalWarnings);
 		}
 		List<String> affectedFiles = affectedFiles(diff, warnings);
+		List<McpAstDiffResult> astDiffs = McpAstDiffResult.from(diff, maxAstDiffs, maxActionsPerAstDiff, warnings);
 		String url = WebDiff.localUrl(publicHost, port);
 		String summary = String.format("Started local AST diff browser with %d refactorings, %d AST diffs, %d moved AST diffs across %d before files and %d after files.",
 				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter);
 
 		return new McpDiffBrowserResult(OK, summary, WebDiff.startupMessage(publicHost, port), url, port, inputSummary,
-				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter, affectedFiles, warnings);
+				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter, affectedFiles, astDiffs,
+				warnings);
 	}
 
 	public static McpDiffBrowserResult error(String summary, Integer port, String inputSummary, List<String> warnings) {
 		return new McpDiffBrowserResult(ERROR, summary, null, null, port, inputSummary, 0, 0, 0, 0, 0,
-				Collections.emptyList(), warnings);
+				Collections.emptyList(), Collections.emptyList(), warnings);
 	}
 
 	private static List<String> affectedFiles(ProjectASTDiff diff, List<String> warnings) {

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
@@ -18,6 +18,8 @@ import org.refactoringminer.util.GitServiceImpl;
 public class RefactoringMinerMcpService {
 	private static final int DEFAULT_MAX_FILES = 100;
 	private static final int DEFAULT_MAX_BYTES_PER_FILE = 200_000;
+	private static final int DEFAULT_MAX_AST_DIFFS = 10;
+	private static final int DEFAULT_MAX_ACTIONS_PER_AST_DIFF = 10;
 
 	private final FileContentDiffer differ;
 	private final CommitDiffer commitDiffer;
@@ -77,14 +79,23 @@ public class RefactoringMinerMcpService {
 	public McpAnalysisResult analyzeFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
 			int maxRefactorings) {
 		return analyzeFileContents(beforeFiles, afterFiles, maxRefactorings, DEFAULT_MAX_FILES,
-				DEFAULT_MAX_BYTES_PER_FILE);
+				DEFAULT_MAX_BYTES_PER_FILE, 0, 0);
 	}
 
 	public McpAnalysisResult analyzeFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
 			int maxRefactorings, int maxFiles, int maxBytesPerFile) {
+		return analyzeFileContents(beforeFiles, afterFiles, maxRefactorings, maxFiles, maxBytesPerFile, 0, 0);
+	}
+
+	public McpAnalysisResult analyzeFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
+			int maxRefactorings, int maxFiles, int maxBytesPerFile, int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (maxRefactorings < 0) {
 			return McpAnalysisResult.error("maxRefactorings must be greater than or equal to 0.",
 					List.of("maxRefactorings=" + maxRefactorings));
+		}
+		McpAnalysisResult limitError = validateAstDiffLimits(maxAstDiffs, maxActionsPerAstDiff);
+		if (limitError != null) {
+			return limitError;
 		}
 		if (beforeFiles == null || afterFiles == null) {
 			return McpAnalysisResult.error("beforeFiles and afterFiles are required.",
@@ -102,7 +113,7 @@ public class RefactoringMinerMcpService {
 
 		try {
 			ProjectASTDiff diff = differ.diffAtFileContents(beforeFiles, afterFiles);
-			return toResult(diff, maxRefactorings, "File-content");
+			return toResult(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff, "File-content");
 		} catch (Exception e) {
 			return McpAnalysisResult.error("File-content analysis failed: " + e.getMessage(),
 					List.of(e.getClass().getName()));
@@ -253,9 +264,19 @@ public class RefactoringMinerMcpService {
 
 	public McpAnalysisResult analyzeWorktree(Path repositoryPath, String baseRef, boolean includeUntracked, int maxFiles,
 			int maxBytesPerFile, int maxRefactorings) {
+		return analyzeWorktree(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile, maxRefactorings,
+				0, 0);
+	}
+
+	public McpAnalysisResult analyzeWorktree(Path repositoryPath, String baseRef, boolean includeUntracked, int maxFiles,
+			int maxBytesPerFile, int maxRefactorings, int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (maxRefactorings < 0) {
 			return McpAnalysisResult.error("maxRefactorings must be greater than or equal to 0.",
 					List.of("maxRefactorings=" + maxRefactorings));
+		}
+		McpAnalysisResult limitError = validateAstDiffLimits(maxAstDiffs, maxActionsPerAstDiff);
+		if (limitError != null) {
+			return limitError;
 		}
 		try {
 			Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
@@ -266,7 +287,7 @@ public class RefactoringMinerMcpService {
 				return McpAnalysisResult.error("Worktree analysis did not produce a diff.",
 						List.of("RefactoringMiner returned null."));
 			}
-			return McpAnalysisResult.ok(diff, maxRefactorings, changes.warnings());
+			return McpAnalysisResult.ok(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff, changes.warnings());
 		} catch (Exception e) {
 			return McpAnalysisResult.error("Worktree analysis failed: " + e.getMessage(), List.of(e.getClass().getName()));
 		}
@@ -274,9 +295,18 @@ public class RefactoringMinerMcpService {
 
 	public McpAnalysisResult analyzeCommit(Path repositoryPath, String commitId, Integer parentIndex,
 			int maxRefactorings) {
+		return analyzeCommit(repositoryPath, commitId, parentIndex, maxRefactorings, 0, 0);
+	}
+
+	public McpAnalysisResult analyzeCommit(Path repositoryPath, String commitId, Integer parentIndex,
+			int maxRefactorings, int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (maxRefactorings < 0) {
 			return McpAnalysisResult.error("maxRefactorings must be greater than or equal to 0.",
 					List.of("maxRefactorings=" + maxRefactorings));
+		}
+		McpAnalysisResult limitError = validateAstDiffLimits(maxAstDiffs, maxActionsPerAstDiff);
+		if (limitError != null) {
+			return limitError;
 		}
 		if (commitId == null || commitId.isBlank()) {
 			return McpAnalysisResult.error("commitId must be a non-empty string.", List.of("commitId is required."));
@@ -289,7 +319,7 @@ public class RefactoringMinerMcpService {
 
 		try {
 			ProjectASTDiff diff = diffCommit(repositoryPath, commitId, resolvedParentIndex, 300);
-			return toResult(diff, maxRefactorings, "Commit");
+			return toResult(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff, "Commit");
 		} catch (Exception e) {
 			return McpAnalysisResult.error("Commit analysis failed: " + e.getMessage(), List.of(e.getClass().getName()));
 		}
@@ -297,9 +327,18 @@ public class RefactoringMinerMcpService {
 
 	public McpAnalysisResult analyzePullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds,
 			int maxRefactorings) {
+		return analyzePullRequest(cloneUrl, pullRequestId, timeoutSeconds, maxRefactorings, 0, 0);
+	}
+
+	public McpAnalysisResult analyzePullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds,
+			int maxRefactorings, int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (maxRefactorings < 0) {
 			return McpAnalysisResult.error("maxRefactorings must be greater than or equal to 0.",
 					List.of("maxRefactorings=" + maxRefactorings));
+		}
+		McpAnalysisResult limitError = validateAstDiffLimits(maxAstDiffs, maxActionsPerAstDiff);
+		if (limitError != null) {
+			return limitError;
 		}
 		if (pullRequestId <= 0) {
 			return McpAnalysisResult.error("pullRequestId must be greater than 0.",
@@ -319,7 +358,7 @@ public class RefactoringMinerMcpService {
 
 		try {
 			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(resolvedCloneUrl, pullRequestId, timeoutSeconds);
-			return toResult(diff, maxRefactorings, "Pull-request");
+			return toResult(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff, "Pull-request");
 		} catch (Exception e) {
 			return McpAnalysisResult.error("Pull-request analysis failed: " + e.getMessage(),
 					List.of(e.getClass().getName()));
@@ -327,16 +366,25 @@ public class RefactoringMinerMcpService {
 	}
 
 	public McpAnalysisResult analyzeDirectories(Path beforePath, Path afterPath, int maxRefactorings) {
+		return analyzeDirectories(beforePath, afterPath, maxRefactorings, 0, 0);
+	}
+
+	public McpAnalysisResult analyzeDirectories(Path beforePath, Path afterPath, int maxRefactorings,
+			int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (maxRefactorings < 0) {
 			return McpAnalysisResult.error("maxRefactorings must be greater than or equal to 0.",
 					List.of("maxRefactorings=" + maxRefactorings));
+		}
+		McpAnalysisResult limitError = validateAstDiffLimits(maxAstDiffs, maxActionsPerAstDiff);
+		if (limitError != null) {
+			return limitError;
 		}
 
 		try {
 			requireExistingAbsolutePath(beforePath, "beforePath");
 			requireExistingAbsolutePath(afterPath, "afterPath");
 			ProjectASTDiff diff = directoryDiffer.diffAtDirectories(beforePath, afterPath);
-			return toResult(diff, maxRefactorings, "Directory");
+			return toResult(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff, "Directory");
 		} catch (Exception e) {
 			return McpAnalysisResult.error("Directory analysis failed: " + e.getMessage(),
 					List.of(e.getClass().getName()));
@@ -345,15 +393,27 @@ public class RefactoringMinerMcpService {
 
 	public McpDiffBrowserResult diffFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
 			int port) {
-		return diffFileContents(beforeFiles, afterFiles, port, DEFAULT_MAX_FILES, DEFAULT_MAX_BYTES_PER_FILE);
+		return diffFileContents(beforeFiles, afterFiles, port, DEFAULT_MAX_FILES, DEFAULT_MAX_BYTES_PER_FILE,
+				DEFAULT_MAX_AST_DIFFS, DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
 	}
 
 	public McpDiffBrowserResult diffFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
 			int port, int maxFiles, int maxBytesPerFile) {
+		return diffFileContents(beforeFiles, afterFiles, port, maxFiles, maxBytesPerFile, DEFAULT_MAX_AST_DIFFS,
+				DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
+	}
+
+	public McpDiffBrowserResult diffFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
+			int port, int maxFiles, int maxBytesPerFile, int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (beforeFiles == null || afterFiles == null) {
 			return McpDiffBrowserResult.error("beforeFiles and afterFiles are required.", port,
 					"Explicit file contents",
 					List.of("beforeFiles and afterFiles must be JSON objects mapping paths to file contents."));
+		}
+		McpDiffBrowserResult invalidAstLimits = validateDiffAstLimits(maxAstDiffs, maxActionsPerAstDiff, port,
+				"Explicit file contents");
+		if (invalidAstLimits != null) {
+			return invalidAstLimits;
 		}
 		if (beforeFiles.isEmpty() && afterFiles.isEmpty()) {
 			return McpDiffBrowserResult.error("At least one before or after file is required.", port,
@@ -370,7 +430,7 @@ public class RefactoringMinerMcpService {
 				beforeFiles.size(), afterFiles.size());
 		try {
 			ProjectASTDiff diff = differ.diffAtFileContents(beforeFiles, afterFiles);
-			return launchDiffBrowser(diff, port, inputSummary, List.of());
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxAstDiffs, maxActionsPerAstDiff);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("File-content diff browser failed: " + e.getMessage(), port,
 					inputSummary, List.of(e.getClass().getName()));
@@ -379,14 +439,26 @@ public class RefactoringMinerMcpService {
 
 	public McpDiffBrowserResult diffWorktree(Path repositoryPath, String baseRef, boolean includeUntracked,
 			int maxFiles, int maxBytesPerFile, int port) {
+		return diffWorktree(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile, port,
+				DEFAULT_MAX_AST_DIFFS, DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
+	}
+
+	public McpDiffBrowserResult diffWorktree(Path repositoryPath, String baseRef, boolean includeUntracked,
+			int maxFiles, int maxBytesPerFile, int port, int maxAstDiffs, int maxActionsPerAstDiff) {
 		String resolvedBaseRef = baseRef == null || baseRef.isBlank() ? "HEAD" : baseRef;
 		Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
 		String inputSummary = "Worktree changes in " + resolvedRepositoryPath + " against " + resolvedBaseRef + ".";
+		McpDiffBrowserResult invalidAstLimits = validateDiffAstLimits(maxAstDiffs, maxActionsPerAstDiff, port,
+				inputSummary);
+		if (invalidAstLimits != null) {
+			return invalidAstLimits;
+		}
 		try {
 			WorktreeChangeCollector.WorktreeChanges changes = new WorktreeChangeCollector()
 					.collect(resolvedRepositoryPath, resolvedBaseRef, includeUntracked, maxFiles, maxBytesPerFile);
 			ProjectASTDiff diff = differ.diffAtFileContents(changes.beforeFiles(), changes.afterFiles());
-			return launchDiffBrowser(diff, port, inputSummary, changes.warnings());
+			return launchDiffBrowser(diff, port, inputSummary, changes.warnings(), maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Worktree diff browser failed: " + e.getMessage(), port,
 					inputSummary, List.of(e.getClass().getName()));
@@ -394,6 +466,12 @@ public class RefactoringMinerMcpService {
 	}
 
 	public McpDiffBrowserResult diffCommit(Path repositoryPath, String commitId, Integer parentIndex, int port) {
+		return diffCommit(repositoryPath, commitId, parentIndex, port, DEFAULT_MAX_AST_DIFFS,
+				DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
+	}
+
+	public McpDiffBrowserResult diffCommit(Path repositoryPath, String commitId, Integer parentIndex, int port,
+			int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (commitId == null || commitId.isBlank()) {
 			return McpDiffBrowserResult.error("commitId must be a non-empty string.", port, "Commit diff",
 					List.of("commitId is required."));
@@ -406,12 +484,17 @@ public class RefactoringMinerMcpService {
 
 		String inputSummary = String.format("Commit %s in %s against parent index %d.", commitId, repositoryPath,
 				resolvedParentIndex);
+		McpDiffBrowserResult invalidAstLimits = validateDiffAstLimits(maxAstDiffs, maxActionsPerAstDiff, port,
+				inputSummary);
+		if (invalidAstLimits != null) {
+			return invalidAstLimits;
+		}
 		try {
 			Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
 			inputSummary = String.format("Commit %s in %s against parent index %d.", commitId, resolvedRepositoryPath,
 					resolvedParentIndex);
 			ProjectASTDiff diff = diffCommit(resolvedRepositoryPath, commitId, resolvedParentIndex, 300);
-			return launchDiffBrowser(diff, port, inputSummary, List.of());
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxAstDiffs, maxActionsPerAstDiff);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Commit diff browser failed: " + e.getMessage(), port, inputSummary,
 					List.of(e.getClass().getName()));
@@ -419,6 +502,12 @@ public class RefactoringMinerMcpService {
 	}
 
 	public McpDiffBrowserResult diffPullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds, int port) {
+		return diffPullRequest(cloneUrl, pullRequestId, timeoutSeconds, port, DEFAULT_MAX_AST_DIFFS,
+				DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
+	}
+
+	public McpDiffBrowserResult diffPullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds, int port,
+			int maxAstDiffs, int maxActionsPerAstDiff) {
 		if (pullRequestId <= 0) {
 			return McpDiffBrowserResult.error("pullRequestId must be greater than 0.", port, "Pull-request diff",
 					List.of("pullRequestId=" + pullRequestId));
@@ -429,6 +518,11 @@ public class RefactoringMinerMcpService {
 		}
 
 		String inputSummary = "Pull request #" + pullRequestId + ".";
+		McpDiffBrowserResult invalidAstLimits = validateDiffAstLimits(maxAstDiffs, maxActionsPerAstDiff, port,
+				inputSummary);
+		if (invalidAstLimits != null) {
+			return invalidAstLimits;
+		}
 		String resolvedCloneUrl;
 		try {
 			resolvedCloneUrl = resolvePullRequestCloneUrl(cloneUrl);
@@ -440,7 +534,7 @@ public class RefactoringMinerMcpService {
 		inputSummary = String.format("Pull request #%d in %s.", pullRequestId, resolvedCloneUrl);
 		try {
 			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(resolvedCloneUrl, pullRequestId, timeoutSeconds);
-			return launchDiffBrowser(diff, port, inputSummary, List.of());
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxAstDiffs, maxActionsPerAstDiff);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Pull-request diff browser failed: " + e.getMessage(), port,
 					inputSummary, List.of(e.getClass().getName()));
@@ -560,21 +654,53 @@ public class RefactoringMinerMcpService {
 		return realPath;
 	}
 
-	private static McpAnalysisResult toResult(ProjectASTDiff diff, int maxRefactorings, String label) {
+	private static McpAnalysisResult toResult(ProjectASTDiff diff, int maxRefactorings, int maxAstDiffs,
+			int maxActionsPerAstDiff, String label) {
 		if (diff == null) {
 			return McpAnalysisResult.error(label + " analysis did not produce a diff.",
 					List.of("RefactoringMiner returned null."));
 		}
-		return McpAnalysisResult.ok(diff, maxRefactorings);
+		return McpAnalysisResult.ok(diff, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff);
+	}
+
+	private static McpAnalysisResult validateAstDiffLimits(int maxAstDiffs, int maxActionsPerAstDiff) {
+		if (maxAstDiffs < 0) {
+			return McpAnalysisResult.error("maxAstDiffs must be greater than or equal to 0.",
+					List.of("maxAstDiffs=" + maxAstDiffs));
+		}
+		if (maxActionsPerAstDiff < 0) {
+			return McpAnalysisResult.error("maxActionsPerAstDiff must be greater than or equal to 0.",
+					List.of("maxActionsPerAstDiff=" + maxActionsPerAstDiff));
+		}
+		return null;
 	}
 
 	private McpDiffBrowserResult launchDiffBrowser(ProjectASTDiff diff, int port, String inputSummary,
 			List<String> warnings) throws Exception {
+		return launchDiffBrowser(diff, port, inputSummary, warnings, DEFAULT_MAX_AST_DIFFS,
+				DEFAULT_MAX_ACTIONS_PER_AST_DIFF);
+	}
+
+	private McpDiffBrowserResult launchDiffBrowser(ProjectASTDiff diff, int port, String inputSummary,
+			List<String> warnings, int maxAstDiffs, int maxActionsPerAstDiff) throws Exception {
 		if (diff == null) {
 			return McpDiffBrowserResult.error("Analysis did not produce a diff.", port, inputSummary,
 					List.of("RefactoringMiner returned null."));
 		}
-		return diffBrowserLauncher.launch(diff, port, inputSummary, warnings);
+		return diffBrowserLauncher.launch(diff, port, inputSummary, warnings, maxAstDiffs, maxActionsPerAstDiff);
+	}
+
+	private static McpDiffBrowserResult validateDiffAstLimits(int maxAstDiffs, int maxActionsPerAstDiff, int port,
+			String inputSummary) {
+		if (maxAstDiffs < 0) {
+			return McpDiffBrowserResult.error("maxAstDiffs must be greater than or equal to 0.", port,
+					inputSummary, List.of("maxAstDiffs=" + maxAstDiffs));
+		}
+		if (maxActionsPerAstDiff < 0) {
+			return McpDiffBrowserResult.error("maxActionsPerAstDiff must be greater than or equal to 0.", port,
+					inputSummary, List.of("maxActionsPerAstDiff=" + maxActionsPerAstDiff));
+		}
+		return null;
 	}
 
 	private static void validateFileContentBounds(Map<String, String> beforeFiles, Map<String, String> afterFiles,

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
@@ -34,6 +34,8 @@ public final class RefactoringMinerMcpTools {
 	static final String DIFF_PULL_REQUEST = "refactoringminer_diff_pull_request";
 	private static final int DEFAULT_MAX_REFACTORINGS = 20;
 	private static final int DEFAULT_MAX_CANDIDATES = 20;
+	private static final int DEFAULT_MAX_AST_DIFFS = 10;
+	private static final int DEFAULT_MAX_ACTIONS_PER_AST_DIFF = 10;
 	private static final int DEFAULT_MAX_FILES = 100;
 	private static final int DEFAULT_MAX_BYTES_PER_FILE = 200_000;
 	private static final int DEFAULT_TIMEOUT_SECONDS = 300;
@@ -273,11 +275,14 @@ public final class RefactoringMinerMcpTools {
 			Map<String, String> afterFiles = stringMap(arguments.get("afterFiles"), "afterFiles");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
 			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
 			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
 					"maxBytesPerFile");
 			return service.analyzeFileContents(beforeFiles, afterFiles, maxRefactorings, maxFiles,
-					maxBytesPerFile);
+					maxBytesPerFile, maxAstDiffs, maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
@@ -301,8 +306,11 @@ public final class RefactoringMinerMcpTools {
 					"maxBytesPerFile");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
 			return service.analyzeWorktree(repositoryPath, baseRef, includeUntracked, maxFiles,
-					maxBytesPerFile, maxRefactorings);
+					maxBytesPerFile, maxRefactorings, maxAstDiffs, maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
@@ -323,7 +331,11 @@ public final class RefactoringMinerMcpTools {
 			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			return service.analyzeCommit(repositoryPath, commitId, parentIndex, maxRefactorings);
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
+			return service.analyzeCommit(repositoryPath, commitId, parentIndex, maxRefactorings, maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
@@ -344,7 +356,11 @@ public final class RefactoringMinerMcpTools {
 			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			return service.analyzePullRequest(cloneUrl, pullRequestId, timeoutSeconds, maxRefactorings);
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
+			return service.analyzePullRequest(cloneUrl, pullRequestId, timeoutSeconds, maxRefactorings, maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
@@ -364,7 +380,11 @@ public final class RefactoringMinerMcpTools {
 			String afterPath = stringValue(arguments.get("afterPath"), "afterPath");
 			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			return service.analyzeDirectories(Path.of(beforePath), Path.of(afterPath), maxRefactorings);
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
+			return service.analyzeDirectories(Path.of(beforePath), Path.of(afterPath), maxRefactorings, maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
@@ -501,7 +521,11 @@ public final class RefactoringMinerMcpTools {
 			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
 			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
 					"maxBytesPerFile");
-			return service.diffFileContents(beforeFiles, afterFiles, port, maxFiles, maxBytesPerFile);
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
+			return service.diffFileContents(beforeFiles, afterFiles, port, maxFiles, maxBytesPerFile, maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpDiffBrowserResult.error(e.getMessage(), null, "Explicit file contents",
 					List.of("Invalid tool arguments."));
@@ -526,8 +550,11 @@ public final class RefactoringMinerMcpTools {
 			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
 					"maxBytesPerFile");
 			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
 			return service.diffWorktree(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile,
-					port);
+					port, maxAstDiffs, maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpDiffBrowserResult.error(e.getMessage(), null, "Worktree changes",
 					List.of("Invalid tool arguments."));
@@ -549,7 +576,11 @@ public final class RefactoringMinerMcpTools {
 			String commitId = stringValue(arguments.get("commitId"), "commitId");
 			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
 			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffCommit(repositoryPath, commitId, parentIndex, port);
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
+			return service.diffCommit(repositoryPath, commitId, parentIndex, port, maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpDiffBrowserResult.error(e.getMessage(), null, "Commit diff", List.of("Invalid tool arguments."));
 		}
@@ -570,7 +601,11 @@ public final class RefactoringMinerMcpTools {
 			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
 			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
 			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffPullRequest(cloneUrl, pullRequestId, timeoutSeconds, port);
+			int maxAstDiffs = integerValue(arguments.get("maxAstDiffs"), DEFAULT_MAX_AST_DIFFS, "maxAstDiffs");
+			int maxActionsPerAstDiff = integerValue(arguments.get("maxActionsPerAstDiff"),
+					DEFAULT_MAX_ACTIONS_PER_AST_DIFF, "maxActionsPerAstDiff");
+			return service.diffPullRequest(cloneUrl, pullRequestId, timeoutSeconds, port, maxAstDiffs,
+					maxActionsPerAstDiff);
 		} catch (IllegalArgumentException e) {
 			return McpDiffBrowserResult.error(e.getMessage(), null, "Pull-request diff",
 					List.of("Invalid tool arguments."));
@@ -675,10 +710,42 @@ public final class RefactoringMinerMcpTools {
 			return defaultValue;
 		}
 		if (value instanceof Number number) {
-			return number.intValue();
+			if (number instanceof Byte || number instanceof Short || number instanceof Integer) {
+				return number.intValue();
+			}
+			if (number instanceof Long longValue) {
+				if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+					throw new IllegalArgumentException(name + " must be an integer.");
+				}
+				return longValue.intValue();
+			}
+			if (number instanceof java.math.BigInteger bigInteger) {
+				try {
+					return bigInteger.intValueExact();
+				} catch (ArithmeticException e) {
+					throw new IllegalArgumentException(name + " must be an integer.", e);
+				}
+			}
+			if (number instanceof java.math.BigDecimal bigDecimal) {
+				try {
+					return bigDecimal.toBigIntegerExact().intValueExact();
+				} catch (ArithmeticException e) {
+					throw new IllegalArgumentException(name + " must be an integer.", e);
+				}
+			}
+			double doubleValue = number.doubleValue();
+			if (!Double.isFinite(doubleValue) || doubleValue % 1 != 0 || doubleValue < Integer.MIN_VALUE
+					|| doubleValue > Integer.MAX_VALUE) {
+				throw new IllegalArgumentException(name + " must be an integer.");
+			}
+			return (int) doubleValue;
 		}
 		if (value instanceof String stringValue) {
-			return Integer.parseInt(stringValue);
+			try {
+				return Integer.parseInt(stringValue);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(name + " must be an integer.", e);
+			}
 		}
 		throw new IllegalArgumentException(name + " must be an integer.");
 	}
@@ -749,6 +816,7 @@ public final class RefactoringMinerMcpTools {
 		properties.put("beforeFiles", fileMapSchema);
 		properties.put("afterFiles", fileMapSchema);
 		properties.put("maxRefactorings", maxRefactoringsSchema);
+		putAstDiffSummaryProperties(properties);
 		putFileContentBoundsProperties(properties);
 		return new JsonSchema("object", properties, List.of("beforeFiles", "afterFiles"), false, null, null);
 	}
@@ -761,6 +829,7 @@ public final class RefactoringMinerMcpTools {
 		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
 		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
+		putAstDiffSummaryProperties(properties);
 		return new JsonSchema("object", properties, List.of(), false, null, null);
 	}
 
@@ -770,6 +839,7 @@ public final class RefactoringMinerMcpTools {
 		properties.put("commitId", Map.of("type", "string"));
 		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
+		putAstDiffSummaryProperties(properties);
 		return new JsonSchema("object", properties, List.of("commitId"), false, null, null);
 	}
 
@@ -779,6 +849,7 @@ public final class RefactoringMinerMcpTools {
 		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
 		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
+		putAstDiffSummaryProperties(properties);
 		return new JsonSchema("object", properties, List.of("pullRequestId"), false, null, null);
 	}
 
@@ -787,6 +858,7 @@ public final class RefactoringMinerMcpTools {
 		properties.put("beforePath", Map.of("type", "string"));
 		properties.put("afterPath", Map.of("type", "string"));
 		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
+		putAstDiffSummaryProperties(properties);
 		return new JsonSchema("object", properties, List.of("beforePath", "afterPath"), false, null, null);
 	}
 
@@ -878,6 +950,7 @@ public final class RefactoringMinerMcpTools {
 		properties.put("port", Map.of("type", "integer", "minimum", 1, "maximum", 65535,
 				"default", DEFAULT_WEB_DIFF_PORT,
 				"description", "Local WebDiff port. Defaults to 6789."));
+		putAstDiffSummaryProperties(properties);
 	}
 
 	private static void putRepositoryPathProperty(Map<String, Object> properties) {
@@ -901,6 +974,19 @@ public final class RefactoringMinerMcpTools {
 	private static void putValidationProperties(Map<String, Object> properties) {
 		properties.put("intent", intentSchema());
 		properties.put("maxCandidates", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_CANDIDATES));
+	}
+
+	private static void putAstDiffSummaryProperties(Map<String, Object> properties) {
+		properties.put("maxAstDiffs", Map.of(
+				"type", "integer",
+				"minimum", 0,
+				"default", DEFAULT_MAX_AST_DIFFS,
+				"description", "Maximum number of AST diff summaries to include. Use 0 to omit astDiffs."));
+		properties.put("maxActionsPerAstDiff", Map.of(
+				"type", "integer",
+				"minimum", 0,
+				"default", DEFAULT_MAX_ACTIONS_PER_AST_DIFF,
+				"description", "Maximum number of sampled edit actions per AST diff summary."));
 	}
 
 	private static Map<String, Object> fileMapSchema() {
@@ -960,12 +1046,13 @@ public final class RefactoringMinerMcpTools {
 		properties.put("filesBefore", Map.of("type", "integer"));
 		properties.put("filesAfter", Map.of("type", "integer"));
 		properties.put("refactorings", Map.of("type", "array"));
+		properties.put("astDiffs", Map.of("type", "array"));
 		properties.put("warnings", Map.of("type", "array", "items", Map.of("type", "string")));
 		return Map.of(
 				"type", "object",
 				"properties", properties,
 				"required", List.of("status", "summary", "refactoringCount", "astDiffCount", "moveAstDiffCount",
-						"filesBefore", "filesAfter", "refactorings", "warnings"));
+						"filesBefore", "filesAfter", "refactorings", "astDiffs", "warnings"));
 	}
 
 	private static Map<String, Object> diffBrowserOutputSchema() {
@@ -982,11 +1069,12 @@ public final class RefactoringMinerMcpTools {
 		properties.put("filesBefore", Map.of("type", "integer"));
 		properties.put("filesAfter", Map.of("type", "integer"));
 		properties.put("affectedFiles", Map.of("type", "array", "items", Map.of("type", "string")));
+		properties.put("astDiffs", Map.of("type", "array"));
 		properties.put("warnings", Map.of("type", "array", "items", Map.of("type", "string")));
 		return Map.of(
 				"type", "object",
 				"properties", properties,
 				"required", List.of("status", "summary", "inputSummary", "refactoringCount", "astDiffCount",
-						"moveAstDiffCount", "filesBefore", "filesAfter", "affectedFiles", "warnings"));
+						"moveAstDiffCount", "filesBefore", "filesAfter", "affectedFiles", "astDiffs", "warnings"));
 	}
 }

--- a/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
@@ -38,7 +38,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 
 	@Override
 	public synchronized McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary,
-			List<String> warnings) throws Exception {
+			List<String> warnings, int maxAstDiffs, int maxActionsPerAstDiff) throws Exception {
 		if (diff == null) {
 			throw new IllegalArgumentException("ProjectASTDiff is required.");
 		}
@@ -64,7 +64,8 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 		activeView = view;
 		activePort = port;
-		return McpDiffBrowserResult.ok(diff, port, publicHost, inputSummary, warnings);
+		return McpDiffBrowserResult.ok(diff, port, publicHost, inputSummary, warnings, maxAstDiffs,
+				maxActionsPerAstDiff);
 	}
 
 	private void stopActiveView() {

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceTest.java
@@ -10,11 +10,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.github.gumtreediff.actions.model.Action;
+import com.github.gumtreediff.actions.model.Update;
+import com.github.gumtreediff.tree.Tree;
+import com.github.gumtreediff.tree.TreeContext;
+import com.github.gumtreediff.tree.TypeSet;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
+import org.refactoringminer.astDiff.actions.model.MultiMove;
+import org.refactoringminer.astDiff.models.ASTDiff;
+import org.refactoringminer.astDiff.models.ExtendedMultiMappingStore;
 import org.refactoringminer.astDiff.models.ProjectASTDiff;
+import org.refactoringminer.astDiff.utils.Constants;
 
 import gr.uom.java.xmi.LocationInfo.CodeElementType;
 import gr.uom.java.xmi.diff.CodeRange;
@@ -77,6 +86,110 @@ class RefactoringMinerMcpServiceTest {
 	}
 
 	@Test
+	void analyzeFileContentsCanReturnBoundedAstDiffSummaries() {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
+			ProjectASTDiff diff = new ProjectASTDiff(before, after);
+			diff.addASTDiff(astDiffWithUpdate());
+			diff.setRefactorings(List.of());
+			return diff;
+		});
+		Map<String, String> before = Map.of("src/main/java/A.java", "class A {\n  void f() {}\n}");
+		Map<String, String> after = Map.of("src/main/java/A.java", "class A {\n  void g() {}\n}");
+
+		McpAnalysisResult result = service.analyzeFileContents(before, after, 20, 100, 200_000, 1, 1);
+
+		assertEquals("ok", result.status());
+		assertEquals(1, result.astDiffs().size());
+		McpAstDiffResult astDiff = result.astDiffs().get(0);
+		assertEquals("standard", astDiff.kind());
+		assertEquals("src/main/java/A.java", astDiff.beforeFilePath());
+		assertEquals("src/main/java/A.java", astDiff.afterFilePath());
+		assertEquals(1, astDiff.mappingCount());
+		assertEquals(1, astDiff.actionCount());
+		assertEquals(1, astDiff.sampleActions().size());
+		assertEquals("update-node", astDiff.sampleActions().get(0).name());
+		assertEquals(2, astDiff.sampleActions().get(0).startLine());
+	}
+
+	@Test
+	void analyzeFileContentsOmitsActionSamplesWithoutTruncationWarningWhenLimitIsZero() {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
+			ProjectASTDiff diff = new ProjectASTDiff(before, after);
+			diff.addASTDiff(astDiffWithUpdate());
+			diff.setRefactorings(List.of());
+			return diff;
+		});
+		Map<String, String> before = Map.of("src/main/java/A.java", "class A {\n  void f() {}\n}");
+		Map<String, String> after = Map.of("src/main/java/A.java", "class A {\n  void g() {}\n}");
+
+		McpAnalysisResult result = service.analyzeFileContents(before, after, 20, 100, 200_000, 1, 0);
+
+		assertEquals("ok", result.status());
+		assertEquals(1, result.astDiffs().size());
+		assertEquals(1, result.astDiffs().get(0).actionCount());
+		assertTrue(result.astDiffs().get(0).sampleActions().isEmpty());
+		assertTrue(result.warnings().stream().noneMatch(warning -> warning.contains("truncated to 0")));
+	}
+
+	@Test
+	void analyzeFileContentsReportsMissingPositionsWithConsistentSentinels() {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
+			ProjectASTDiff diff = new ProjectASTDiff(before, after);
+			diff.addASTDiff(astDiffWithNullNodeAction());
+			diff.setRefactorings(List.of());
+			return diff;
+		});
+		Map<String, String> before = Map.of("src/main/java/A.java", "class A {}");
+		Map<String, String> after = Map.of("src/main/java/A.java", "class A {}");
+
+		McpAnalysisResult result = service.analyzeFileContents(before, after, 20, 100, 200_000, 1, 1);
+
+		McpAstDiffResult.ActionSummary action = result.astDiffs().get(0).sampleActions().get(0);
+		assertEquals(-1, action.startOffset());
+		assertEquals(-1, action.endOffset());
+		assertEquals(-1, action.startLine());
+		assertEquals(-1, action.endLine());
+	}
+
+	@Test
+	void analyzeFileContentsTreatsEndOffsetAsExclusiveForEndLine() {
+		String content = "class A {\n  void f() {}\n}\n";
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
+			ProjectASTDiff diff = new ProjectASTDiff(before, after);
+			diff.addASTDiff(astDiffWithWholeFileUpdate(content));
+			diff.setRefactorings(List.of());
+			return diff;
+		});
+		Map<String, String> before = Map.of("src/main/java/A.java", content);
+		Map<String, String> after = Map.of("src/main/java/A.java", content);
+
+		McpAnalysisResult result = service.analyzeFileContents(before, after, 20, 100, 200_000, 1, 1);
+
+		McpAstDiffResult.ActionSummary action = result.astDiffs().get(0).sampleActions().get(0);
+		assertEquals(1, action.startLine());
+		assertEquals(3, action.endLine());
+	}
+
+	@Test
+	void analyzeFileContentsReportsMultiMoveTargetPathAndGroupSeparately() {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
+			ProjectASTDiff diff = new ProjectASTDiff(before, after);
+			diff.addASTDiff(astDiffWithMultiMove());
+			diff.setRefactorings(List.of());
+			return diff;
+		});
+		Map<String, String> before = Map.of("src/main/java/A.java", "class A {\n  void f() {}\n}");
+		Map<String, String> after = Map.of("src/main/java/A.java", "class A {\n  void f() {}\n}");
+
+		McpAnalysisResult result = service.analyzeFileContents(before, after, 20, 100, 200_000, 1, 1);
+
+		McpAstDiffResult.ActionSummary action = result.astDiffs().get(0).sampleActions().get(0);
+		assertEquals("multi-move-tree", action.name());
+		assertEquals("src/main/java/A.java", action.targetFilePath());
+		assertEquals(42, action.moveGroupId());
+	}
+
+	@Test
 	void diffFileContentsUsesLauncherAndReturnsLocalBrowserResult() {
 		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
 			ProjectASTDiff diff = new ProjectASTDiff(before, after);
@@ -85,7 +198,9 @@ class RefactoringMinerMcpServiceTest {
 		}, (repositoryPath, commitId, parentIndex) -> new ProjectASTDiff(Map.of(), Map.of()),
 				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(Map.of(), Map.of()),
 				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
-				(diff, port, inputSummary, warnings) -> McpDiffBrowserResult.ok(diff, port, inputSummary, warnings));
+				(diff, port, inputSummary, warnings, maxAstDiffs, maxActionsPerAstDiff) ->
+						McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxAstDiffs,
+								maxActionsPerAstDiff));
 		Map<String, String> before = Map.of("src/main/java/A.java", "class A { void f() {} }");
 		Map<String, String> after = Map.of("src/main/java/A.java", "class A { void g() {} }");
 
@@ -107,7 +222,7 @@ class RefactoringMinerMcpServiceTest {
 				(repositoryPath, commitId, parentIndex) -> new ProjectASTDiff(Map.of(), Map.of()),
 				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(Map.of(), Map.of()),
 				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
-				(diff, port, inputSummary, warnings) -> {
+				(diff, port, inputSummary, warnings, maxAstDiffs, maxActionsPerAstDiff) -> {
 					throw new IllegalArgumentException("port must be between 1 and 65535.");
 				});
 
@@ -119,6 +234,101 @@ class RefactoringMinerMcpServiceTest {
 		assertTrue(result.summary().contains("port must be between 1 and 65535"));
 		assertEquals(0, result.refactoringCount());
 		assertFalse(result.warnings().isEmpty());
+	}
+
+	private static ASTDiff astDiffWithUpdate() {
+		TreeContext beforeContext = new TreeContext();
+		Tree beforeRoot = beforeContext.createTree(TypeSet.type("CompilationUnit"), "");
+		Tree beforeMethod = beforeContext.createTree(TypeSet.type("MethodDeclaration"), "f");
+		beforeMethod.setPos(12);
+		beforeMethod.setLength(8);
+		beforeRoot.addChild(beforeMethod);
+		beforeContext.setRoot(beforeRoot);
+
+		TreeContext afterContext = new TreeContext();
+		Tree afterRoot = afterContext.createTree(TypeSet.type("CompilationUnit"), "");
+		Tree afterMethod = afterContext.createTree(TypeSet.type("MethodDeclaration"), "g");
+		afterMethod.setPos(12);
+		afterMethod.setLength(8);
+		afterRoot.addChild(afterMethod);
+		afterContext.setRoot(afterRoot);
+
+		ExtendedMultiMappingStore mappings = new ExtendedMultiMappingStore(beforeRoot, afterRoot,
+				new Constants("src/main/java/A.java"), new Constants("src/main/java/A.java"));
+		mappings.addMapping(beforeMethod, afterMethod);
+		ASTDiff astDiff = new ASTDiff("src/main/java/A.java", "src/main/java/A.java", beforeContext, afterContext,
+				mappings);
+		astDiff.editScript.add(new Update(beforeMethod, "g"));
+		return astDiff;
+	}
+
+	private static ASTDiff astDiffWithNullNodeAction() {
+		TreeContext beforeContext = new TreeContext();
+		Tree beforeRoot = beforeContext.createTree(TypeSet.type("CompilationUnit"), "");
+		beforeContext.setRoot(beforeRoot);
+
+		TreeContext afterContext = new TreeContext();
+		Tree afterRoot = afterContext.createTree(TypeSet.type("CompilationUnit"), "");
+		afterContext.setRoot(afterRoot);
+
+		ExtendedMultiMappingStore mappings = new ExtendedMultiMappingStore(beforeRoot, afterRoot,
+				new Constants("src/main/java/A.java"), new Constants("src/main/java/A.java"));
+		ASTDiff astDiff = new ASTDiff("src/main/java/A.java", "src/main/java/A.java", beforeContext, afterContext,
+				mappings);
+		astDiff.editScript.add(new Action(null) {
+			@Override
+			public String getName() {
+				return "unknown-action";
+			}
+		});
+		return astDiff;
+	}
+
+	private static ASTDiff astDiffWithWholeFileUpdate(String content) {
+		TreeContext beforeContext = new TreeContext();
+		Tree beforeRoot = beforeContext.createTree(TypeSet.type("CompilationUnit"), "");
+		beforeRoot.setPos(0);
+		beforeRoot.setLength(content.length());
+		beforeContext.setRoot(beforeRoot);
+
+		TreeContext afterContext = new TreeContext();
+		Tree afterRoot = afterContext.createTree(TypeSet.type("CompilationUnit"), "");
+		afterRoot.setPos(0);
+		afterRoot.setLength(content.length());
+		afterContext.setRoot(afterRoot);
+
+		ExtendedMultiMappingStore mappings = new ExtendedMultiMappingStore(beforeRoot, afterRoot,
+				new Constants("src/main/java/A.java"), new Constants("src/main/java/A.java"));
+		mappings.addMapping(beforeRoot, afterRoot);
+		ASTDiff astDiff = new ASTDiff("src/main/java/A.java", "src/main/java/A.java", beforeContext, afterContext,
+				mappings);
+		astDiff.editScript.add(new Update(beforeRoot, ""));
+		return astDiff;
+	}
+
+	private static ASTDiff astDiffWithMultiMove() {
+		TreeContext beforeContext = new TreeContext();
+		Tree beforeRoot = beforeContext.createTree(TypeSet.type("CompilationUnit"), "");
+		Tree beforeMethod = beforeContext.createTree(TypeSet.type("MethodDeclaration"), "f");
+		beforeMethod.setPos(12);
+		beforeMethod.setLength(8);
+		beforeRoot.addChild(beforeMethod);
+		beforeContext.setRoot(beforeRoot);
+
+		TreeContext afterContext = new TreeContext();
+		Tree afterRoot = afterContext.createTree(TypeSet.type("CompilationUnit"), "");
+		Tree afterMethod = afterContext.createTree(TypeSet.type("MethodDeclaration"), "f");
+		afterMethod.setPos(12);
+		afterMethod.setLength(8);
+		afterRoot.addChild(afterMethod);
+		afterContext.setRoot(afterRoot);
+
+		ExtendedMultiMappingStore mappings = new ExtendedMultiMappingStore(beforeRoot, afterRoot,
+				new Constants("src/main/java/A.java"), new Constants("src/main/java/A.java"));
+		ASTDiff astDiff = new ASTDiff("src/main/java/A.java", "src/main/java/A.java", beforeContext, afterContext,
+				mappings);
+		astDiff.editScript.add(new MultiMove(beforeMethod, afterRoot, 0, 42, false));
+		return astDiff;
 	}
 
 	private static class FakeRefactoring implements Refactoring {

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -41,6 +42,8 @@ class RefactoringMinerMcpToolsTest {
 		assertFalse(tool.tool().annotations().destructiveHint());
 		assertTrue(tool.tool().inputSchema().required().contains("beforeFiles"));
 		assertTrue(tool.tool().inputSchema().required().contains("afterFiles"));
+		assertTrue(tool.tool().inputSchema().properties().containsKey("maxAstDiffs"));
+		assertTrue(tool.tool().inputSchema().properties().containsKey("maxActionsPerAstDiff"));
 	}
 
 	@Test
@@ -185,6 +188,7 @@ class RefactoringMinerMcpToolsTest {
 		assertEquals("ok", json.get("status").asText());
 		assertEquals(1, json.get("filesBefore").asInt());
 		assertEquals(1, json.get("filesAfter").asInt());
+		assertTrue(json.has("astDiffs"));
 	}
 
 	@Test
@@ -202,6 +206,23 @@ class RefactoringMinerMcpToolsTest {
 		JsonNode json = OBJECT_MAPPER.readTree(content.text());
 		assertEquals("error", json.get("status").asText());
 		assertTrue(json.get("summary").asText().contains("beforeFiles and afterFiles are required"));
+	}
+
+	@Test
+	void numericToolArgumentsRejectFractionalValues() throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeFileContentsTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_FILE_CONTENTS, Map.of(
+				"beforeFiles", Map.of("src/main/java/A.java", "class A {}"),
+				"afterFiles", Map.of("src/main/java/A.java", "class A { int x; }"),
+				"maxRefactorings", new BigDecimal("1.5")));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertTrue(result.isError());
+		TextContent content = (TextContent) result.content().get(0);
+		JsonNode json = OBJECT_MAPPER.readTree(content.text());
+		assertEquals("error", json.get("status").asText());
+		assertTrue(json.get("summary").asText().contains("maxRefactorings must be an integer"));
 	}
 
 	@Test
@@ -587,11 +608,12 @@ class RefactoringMinerMcpToolsTest {
 				(beforePath, afterPath) -> diffWithRefactoring(
 						Map.of("src/main/java/A.java", "class A { void f() {} }"),
 						Map.of("src/main/java/A.java", "class A { void g() {} }")),
-				(diff, port, inputSummary, warnings) -> {
+				(diff, port, inputSummary, warnings, maxAstDiffs, maxActionsPerAstDiff) -> {
 					if (port < 1 || port > 65535) {
 						throw new IllegalArgumentException("port must be between 1 and 65535.");
 					}
-					return McpDiffBrowserResult.ok(diff, port, inputSummary, warnings);
+					return McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxAstDiffs,
+							maxActionsPerAstDiff);
 				});
 	}
 


### PR DESCRIPTION
## Why

The MCP tools can already report detected refactorings, but that is often not enough for an agent reviewing a change. For many refactorings, the Git diff is the wrong first view: moved or extracted code turns into a large delete/add block, and the agent has to read a lot before it knows where the structural edits are.

This PR adds a bounded `astDiffs` field to MCP results. It gives clients a small AST-level index of the change: file pairs, mapping/action counts, counts by action type, sampled actions, line ranges, update values, and move metadata.

## Changes

- Added `McpAstDiffResult`.
- Return `astDiffs` from analysis tools for file contents, worktrees, commits, pull requests, and directories.
- Added `maxAstDiffs` and `maxActionsPerAstDiff`; `maxAstDiffs=0` omits the payload.
- Return the same bounded summaries from WebDiff tools while preserving localhost URL behavior.
- Tightened sampled action details:
  - missing positions use `-1` for offsets and lines
  - GumTree end offsets are treated as exclusive
  - multi-move actions use a real `targetFilePath` plus separate `moveGroupId`
- Reject fractional numeric MCP arguments instead of truncating them.
- Updated `documentation/mcp.md`.

## What this gives MCP clients

A client can use RefactoringMiner as the first pass in review: see which file pairs changed structurally, which action types dominate, and which nodes deserve source inspection. It does not try to prove a refactoring is safe. It gives the agent a better map before it opens files.

## Validation

- `./gradlew test --tests org.refactoringminer.mcp.RefactoringMinerMcpServiceTest --tests org.refactoringminer.mcp.RefactoringMinerMcpToolsTest --tests org.refactoringminer.mcp.WebDiffBrowserLauncherTest --no-daemon --console=plain`
- `./gradlew shadowJar mcpSmoke --no-daemon --console=plain`
- `git diff --check`
- Live Claude Code MCP checks with Sonnet 4.6:
  - file-content analysis returns bounded `astDiffs`
  - worktree analysis uses `astDiffs` on this RefactoringMiner branch
  - all 14 MCP tools were exercised in a real tool sweep
  - WebDiff tools return URLs while respecting `maxAstDiffs=0`
  - fractional `maxRefactorings=1.5` is rejected with an error

Related to #1058.