### PR TITLE
Add robust MCP docker container management commands

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -2,7 +2,102 @@
 
 RefactoringMiner can also run as a local stdio MCP server. Coding agents can ask it for detected refactorings, intent checks, and local AST diff pages. Results come back as small JSON objects built from the existing RefactoringMiner APIs.
 
-## Setup
+## Build
+
+Use Java 17 or newer, then build the packaged jar:
+
+```bash
+./gradlew shadowJar --no-daemon --console=plain
+```
+
+The MCP server entrypoint is available from the fat jar:
+
+```bash
+java -jar build/libs/RM-fat.jar mcp
+```
+
+For a startup-only smoke check:
+
+```bash
+java -jar build/libs/RM-fat.jar mcp --smoke
+```
+
+To verify tool discovery with MCP Inspector CLI:
+
+```bash
+npx -y @modelcontextprotocol/inspector --cli --method tools/list --transport stdio \
+  java -jar build/libs/RM-fat.jar mcp
+```
+
+## Manual WebDiff browser check
+
+If you only want to inspect the browser output yourself, run the existing WebDiff CLI directly. The WebDiff server stays attached to that terminal while you use the browser.
+
+```bash
+java -jar build/libs/RM-fat.jar diff --url https://github.com/tsantalis/RefactoringMiner/pull/1234
+```
+
+For a local repository commit:
+
+```bash
+java -jar build/libs/RM-fat.jar diff --repo /absolute/path/to/repo --commit abc123
+```
+
+Open the printed URL, usually:
+
+```text
+http://127.0.0.1:6789
+```
+
+Keep the terminal process alive while inspecting the page. Use the browser's Quit button or stop the terminal process when finished.
+
+## Claude Code and stdio clients
+
+Create `.mcp.json` in the project that should use RefactoringMiner. Use the absolute path to the built RefactoringMiner jar.
+
+```json
+{
+  "mcpServers": {
+    "refactoringminer": {
+      "type": "stdio",
+      "command": "java",
+      "args": [
+        "-jar",
+        "/absolute/path/to/RefactoringMiner/build/libs/RM-fat.jar",
+        "mcp"
+      ]
+    }
+  }
+}
+```
+
+Generic stdio MCP clients should use the same command and arguments:
+
+```text
+command: java
+args: -jar /absolute/path/to/RefactoringMiner/build/libs/RM-fat.jar mcp
+```
+
+Claude Code can load the same file:
+
+```bash
+claude -p --mcp-config .mcp.json --strict-mcp-config \
+  "Use RefactoringMiner to validate whether my current worktree contains the Rename Method refactoring I intended."
+```
+
+One-shot `claude -p` calls work well for analysis and validation tools that only return JSON. For AST diff browser tools, use an interactive Claude Code session so the MCP process, and the local WebDiff server it started, stays alive while you open the returned URL:
+
+```bash
+claude --mcp-config .mcp.json --strict-mcp-config
+```
+
+Then ask Claude Code to call a browser tool, for example:
+
+```text
+Call refactoringminer_diff_worktree with baseRef "HEAD", includeUntracked false, port 6789. Return only the URL and keep this session open.
+```
+
+## Docker
 
 RefactoringMiner is recommended to run via Docker to avoid local environment setup and ensure stability.
 

--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -103,7 +103,7 @@ RefactoringMiner is recommended to run via Docker to avoid local environment set
 
 ### Linux and macOS
 
-Use the provided [wrapper script template](./scripts/mcp-wrapper-template.sh). This script ensures a shared container runs in the background, avoiding the overhead of restarting the container on every call.
+Use the provided [wrapper script template](../scripts/mcp-wrapper-template.sh). This script ensures a shared container runs in the background, avoiding the overhead of restarting the container on every call.
 
 1. Copy the template to your local machine:
    ```bash

--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -99,133 +99,33 @@ Call refactoringminer_diff_worktree with baseRef "HEAD", includeUntracked false,
 
 ## Docker
 
-The Docker image can run the MCP server over stdio:
+To run the MCP server via Docker, use the provided [wrapper script template](./scripts/mcp-wrapper-template.sh). This script is the recommended way to run RefactoringMiner in Docker as it ensures a shared container runs in the background, avoiding the overhead of restarting the container on every call.
 
-```bash
-docker run --rm -i \
-  --pull always \
-  -e OAuthToken=$OAuthToken \
-  tsantalis/refactoringminer:latest mcp
-```
+1. Copy the template to your local machine:
+   ```bash
+   cp scripts/mcp-wrapper-template.sh mcp-wrapper.sh
+   ```
+2. Edit `mcp-wrapper.sh` to populate the user configuration variables:
+   - `HOST_VOLUME_PATH`: Absolute path to the repository you want to analyze.
+   - `TOKEN`: Your GitHub OAuth token for private repositories and higher rate limits.
+   - Optional: Adjust `CONTAINER_NAME` or `PORT_MAPPING` as needed.
+3. Make the script executable:
+   ```bash
+   chmod +x mcp-wrapper.sh
+   ```
+4. Use the script as the command for your MCP client. For example, in a `.mcp.json` config:
+   ```json
+   {
+     "mcpServers": {
+       "refactoringminer": {
+         "type": "stdio",
+         "command": "/absolute/path/to/mcp-wrapper.sh"
+       }
+     }
+   }
+   ```
 
-Mount a repository when using local worktree or commit tools:
-
-```bash
-docker run --rm -i \
-  --pull always \
-  -v "$PWD:/workspace" \
-  -w /workspace \
-  -e OAuthToken=$OAuthToken \
-  tsantalis/refactoringminer:latest mcp
-```
-
-For the command above, worktree and commit tools default to `/workspace` because Docker starts the MCP process there with `-w /workspace`. If you pass `repositoryPath` explicitly, use the container path, not the host path. For example, use `/workspace`, not `C:/RefactoringMiner` or `/Users/me/RefactoringMiner`.
-
-For AST diff browser tools, publish the WebDiff port:
-
-```bash
-docker run --rm -i \
-  --pull always \
-  -v "$PWD:/workspace" \
-  -w /workspace \
-  -p 6789:6789 \
-  -e OAuthToken=$OAuthToken \
-  tsantalis/refactoringminer:latest mcp
-```
-
-If you intend to use multiple simultaneous browsers on different ports, you must publish each port from the container. For example, to support ports 6789 and 6790:
-
-```bash
-docker run --rm -i \
-  --pull always \
-  -v "$PWD:/workspace" \
-  -w /workspace \
-  -p 6789:6789 \
-  -p 6790:6790 \
-  -e OAuthToken=$OAuthToken \
-  tsantalis/refactoringminer:latest mcp
-```
-
-Alternatively, you can publish a range of ports (e.g., 6785 to 6795) to support many simultaneous browsers:
-
-```bash
-docker run --rm -i \
-  --pull always \
-  -v "$PWD:/workspace" \
-  -w /workspace \
-  -p 6785-6795:6785-6795 \
-  -e OAuthToken=$OAuthToken \
-  tsantalis/refactoringminer:latest mcp
-```
-
-The Docker image sets `REFACTORINGMINER_WEBDIFF_BIND_HOST=0.0.0.0` so the published port is reachable from the host. The URL returned to the user still uses `127.0.0.1`.
-
-A Claude Code config can use Docker as the stdio command:
-
-```json
-{
-  "mcpServers": {
-    "refactoringminer": {
-      "type": "stdio",
-      "command": "docker",
-      "args": [
-        "run", "--rm", "-i", "--pull", "always",
-        "-v", "/absolute/path/to/repo:/workspace",
-        "-w", "/workspace",
-        "-p", "6789:6789",
-        "-e", "OAuthToken",
-        "tsantalis/refactoringminer:latest",
-        "mcp"
-      ]
-    }
-  }
-}
-```
-
-To enable multiple simultaneous browsers in Docker, add additional `-p` arguments to publish the required ports:
-
-```json
-{
-  "mcpServers": {
-    "refactoringminer": {
-      "type": "stdio",
-      "command": "docker",
-      "args": [
-        "run", "--rm", "-i", "--pull", "always",
-        "-v", "/absolute/path/to/repo:/workspace",
-        "-w", "/workspace",
-        "-p", "6789:6789",
-        "-p", "6790:6790",
-        "-e", "OAuthToken",
-        "tsantalis/refactoringminer:latest",
-        "mcp"
-      ]
-    }
-  }
-}
-```
-
-Or publish a port range:
-
-```json
-{
-  "mcpServers": {
-    "refactoringminer": {
-      "type": "stdio",
-      "command": "docker",
-      "args": [
-        "run", "--rm", "-i", "--pull", "always",
-        "-v", "/absolute/path/to/repo:/workspace",
-        "-w", "/workspace",
-        "-p", "6785-6795:6785-6795",
-        "-e", "OAuthToken",
-        "tsantalis/refactoringminer:latest",
-        "mcp"
-      ]
-    }
-  }
-}
-```
+When using this wrapper, any tool that requires a `repositoryPath` should use the container path (usually `/workspace`), not the host path.
 
 Outside Docker, WebDiff binds to `127.0.0.1` by default. These settings can be overridden with environment variables or JVM system properties:
 
@@ -320,7 +220,7 @@ MCP tools do not auto-open the desktop browser. They bind WebDiff to `127.0.0.1`
 
 The returned URL is only available while the MCP server process is still running. If an MCP client starts RefactoringMiner for a single command and immediately exits, the local WebDiff server can disappear before the user opens the URL. Use an interactive client session for browser tools, or use the direct WebDiff CLI when the goal is only manual browser inspection.
 
-Repeated browser-tool calls replace the active local WebDiff view in the MCP server process. MCP-managed WebDiff pages hide the WebDiff Quit button so the MCP server can keep serving later browser-tool calls on the same port. If the requested port is invalid or already occupied by another process, the tool returns an `error` result with a summary and warnings. It does not corrupt stdio output or discard the previous view on another port.
+Repeated browser-tool calls replace the active local WebDiff view in the MCP server process. MCP-managed WebDiff pages hide the WebDiff Quit button so the MCP server can keep serving later browser-tool calls. If the requested port is invalid or already occupied by another process, the tool returns an `error` result with a summary and warnings. Each new browser view terminates the previous one, regardless of whether they use the same port.
 
 Example file-content browser request:
 

--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -2,104 +2,13 @@
 
 RefactoringMiner can also run as a local stdio MCP server. Coding agents can ask it for detected refactorings, intent checks, and local AST diff pages. Results come back as small JSON objects built from the existing RefactoringMiner APIs.
 
-## Build
+## Setup
 
-Use Java 17 or newer, then build the packaged jar:
+RefactoringMiner is recommended to run via Docker to avoid local environment setup and ensure stability.
 
-```bash
-./gradlew shadowJar --no-daemon --console=plain
-```
+### Linux and macOS
 
-The MCP server entrypoint is available from the fat jar:
-
-```bash
-java -jar build/libs/RM-fat.jar mcp
-```
-
-For a startup-only smoke check:
-
-```bash
-java -jar build/libs/RM-fat.jar mcp --smoke
-```
-
-To verify tool discovery with MCP Inspector CLI:
-
-```bash
-npx -y @modelcontextprotocol/inspector --cli --method tools/list --transport stdio \
-  java -jar build/libs/RM-fat.jar mcp
-```
-
-## Manual WebDiff browser check
-
-If you only want to inspect the browser output yourself, run the existing WebDiff CLI directly. The WebDiff server stays attached to that terminal while you use the browser.
-
-```bash
-java -jar build/libs/RM-fat.jar diff --url https://github.com/tsantalis/RefactoringMiner/pull/1234
-```
-
-For a local repository commit:
-
-```bash
-java -jar build/libs/RM-fat.jar diff --repo /absolute/path/to/repo --commit abc123
-```
-
-Open the printed URL, usually:
-
-```text
-http://127.0.0.1:6789
-```
-
-Keep the terminal process alive while inspecting the page. Use the browser's Quit button or stop the terminal process when finished.
-
-## Claude Code and stdio clients
-
-Create `.mcp.json` in the project that should use RefactoringMiner. Use the absolute path to the built RefactoringMiner jar.
-
-```json
-{
-  "mcpServers": {
-    "refactoringminer": {
-      "type": "stdio",
-      "command": "java",
-      "args": [
-        "-jar",
-        "/absolute/path/to/RefactoringMiner/build/libs/RM-fat.jar",
-        "mcp"
-      ]
-    }
-  }
-}
-```
-
-Generic stdio MCP clients should use the same command and arguments:
-
-```text
-command: java
-args: -jar /absolute/path/to/RefactoringMiner/build/libs/RM-fat.jar mcp
-```
-
-Claude Code can load the same file:
-
-```bash
-claude -p --mcp-config .mcp.json --strict-mcp-config \
-  "Use RefactoringMiner to validate whether my current worktree contains the Rename Method refactoring I intended."
-```
-
-One-shot `claude -p` calls work well for analysis and validation tools that only return JSON. For AST diff browser tools, use an interactive Claude Code session so the MCP process, and the local WebDiff server it started, stays alive while you open the returned URL:
-
-```bash
-claude --mcp-config .mcp.json --strict-mcp-config
-```
-
-Then ask Claude Code to call a browser tool, for example:
-
-```text
-Call refactoringminer_diff_worktree with baseRef "HEAD", includeUntracked false, port 6789. Return only the URL and keep this session open.
-```
-
-## Docker
-
-To run the MCP server via Docker, use the provided [wrapper script template](./scripts/mcp-wrapper-template.sh). This script is the recommended way to run RefactoringMiner in Docker as it ensures a shared container runs in the background, avoiding the overhead of restarting the container on every call.
+Use the provided [wrapper script template](./scripts/mcp-wrapper-template.sh). This script ensures a shared container runs in the background, avoiding the overhead of restarting the container on every call.
 
 1. Copy the template to your local machine:
    ```bash
@@ -125,7 +34,27 @@ To run the MCP server via Docker, use the provided [wrapper script template](./s
    }
    ```
 
-When using this wrapper, any tool that requires a `repositoryPath` should use the container path (usually `/workspace`), not the host path.
+### Windows
+
+For Windows, you can use a lighter functional config directly in your MCP client configuration without needing a wrapper script:
+
+```json
+ {
+   "mcpServers": {
+     "refactoringminer": {
+       "type": "stdio",
+       "command": "cmd",
+       "args": [
+         "/c",
+         "docker rm -f refactoringminer-server 2>nul && docker run --rm -i --name refactoringminer-server --pull always -v \"C:/absolute/path/to/your/repo:/workspace\" -w /workspace -p 6785-6795:6785-6795 -e OAuthToken=%OAuthToken% tsantalis/refactoringminer:latest mcp"
+       ]
+     }
+   }
+ }
+```
+Replace `C:/absolute/path/to/your/repo` and `%OAuthToken%` with your actual path and token.
+
+When using the Docker setup, any tool that requires a `repositoryPath` should use the container path (usually `/workspace`), not the host path.
 
 Outside Docker, WebDiff binds to `127.0.0.1` by default. These settings can be overridden with environment variables or JVM system properties:
 

--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -103,7 +103,7 @@ RefactoringMiner is recommended to run via Docker to avoid local environment set
 
 ### Linux and macOS
 
-Use the provided [wrapper script template](../scripts/mcp-wrapper-template.sh). This script ensures a shared container runs in the background, avoiding the overhead of restarting the container on every call.
+Use the provided [wrapper script template](../scripts/mcp-wrapper-template.sh). This script ensures a shared container runs in the background:
 
 1. Copy the template to your local machine:
    ```bash

--- a/scripts/mcp-wrapper-template.sh
+++ b/scripts/mcp-wrapper-template.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Template: Wrapper script to ensure a shared RefactoringMiner container is running and execute MCP.
+# Populated variables should point to your local environment.
+
+# --- USER CONFIGURATION ---
+# Name of the shared container.
+CONTAINER_NAME="refactoringminer-server"
+
+# Port mapping for the WebDiff server. 
+# Example: 6789:6789. If you want to be able to use different custom ports, 
+# you can map a range like 6785-6795:6785-6795.
+PORT_MAPPING="6789:6789"
+
+# Path on host to mount inside the container. Use absolute path.
+# This is the repository you want the MCP server to analyze.
+HOST_VOLUME_PATH="/absolute/path/to/your/repository"
+
+# Path inside the container. Usually /workspace.
+# When using tools, use this path as 'repositoryPath' instead of the host path.
+CONTAINER_WORKDIR="/workspace"
+
+# Your GitHub OAuth token for private repos and higher rate limits.
+# Can be obtained from GitHub Developer Settings.
+TOKEN="your_github_pat_here"
+# --------------------------
+
+# Check if container exists and is running
+if ! docker ps --filter "name=^${CONTAINER_NAME}$" --filter "status=running" | grep -q ${CONTAINER_NAME}; then
+    echo "Starting shared RefactoringMiner container..." >&2
+    # Remove old container if it exists but is stopped
+    docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1
+    
+    # Start the container in the background with a command that keeps it alive
+    docker run -d \
+        --name ${CONTAINER_NAME} \
+        -p ${PORT_MAPPING} \
+        -v "${HOST_VOLUME_PATH}:${CONTAINER_WORKDIR}" \
+        -w ${CONTAINER_WORKDIR} \
+        -e OAuthToken=${TOKEN} \
+        --entrypoint tail \
+        tsantalis/refactoringminer:latest -f /dev/null >/dev/null 2>&1
+fi
+
+# Execute the MCP command in the running container
+docker exec -i ${CONTAINER_NAME} refactoringminer mcp

--- a/scripts/mcp-wrapper-template.sh
+++ b/scripts/mcp-wrapper-template.sh
@@ -7,9 +7,7 @@
 CONTAINER_NAME="refactoringminer-server"
 
 # Port mapping for the WebDiff server. 
-# Example: 6789:6789. If you want to be able to use different custom ports, 
-# you can map a range like 6785-6795:6785-6795.
-PORT_MAPPING="6789:6789"
+PORT_MAPPING="6785-6795:6785-6795"
 
 # Path on host to mount inside the container. Use absolute path.
 # This is the repository you want the MCP server to analyze.
@@ -39,6 +37,12 @@ if ! docker ps --filter "name=^${CONTAINER_NAME}$" --filter "status=running" | g
         -e OAuthToken=${TOKEN} \
         --entrypoint tail \
         tsantalis/refactoringminer:latest -f /dev/null >/dev/null 2>&1
+fi
+
+# Only clean up orphans if no other active sessions are using the MCP server on the host
+if ! pgrep -f "docker exec .*${CONTAINER_NAME}.*refactoringminer mcp" > /dev/null; then
+    echo "No active sessions found on host. Cleaning up orphans in container..." >&2
+    docker exec ${CONTAINER_NAME} pkill -f "RefactoringMiner-DockerBuild.jar" || true
 fi
 
 # Execute the MCP command in the running container

--- a/scripts/mcp-wrapper-template.sh
+++ b/scripts/mcp-wrapper-template.sh
@@ -31,9 +31,10 @@ if ! docker ps --filter "name=^${CONTAINER_NAME}$" --filter "status=running" | g
     # Start the container in the background with a command that keeps it alive
     docker run -d \
         --name ${CONTAINER_NAME} \
-        -p ${PORT_MAPPING} \
+        --pull always \
         -v "${HOST_VOLUME_PATH}:${CONTAINER_WORKDIR}" \
         -w ${CONTAINER_WORKDIR} \
+        -p ${PORT_MAPPING} \
         -e OAuthToken=${TOKEN} \
         --entrypoint tail \
         tsantalis/refactoringminer:latest -f /dev/null >/dev/null 2>&1

--- a/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
@@ -22,7 +22,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 	}
 
 	private WebDiffBrowserLauncher(String bindHost, String publicHost) {
-		this(WebDiffBrowserLauncher::defaultView, port -> requireAvailablePort(bindHost, port, false), bindHost, publicHost);
+		this(WebDiffBrowserLauncher::defaultView, port -> requireAvailablePort(bindHost, port), bindHost, publicHost);
 	}
 
 	WebDiffBrowserLauncher(WebDiffViewFactory factory, PortProbe portProbe) {
@@ -49,7 +49,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 		stopActiveView();
 		if (replacingSamePort) {
-			requireAvailablePort(bindHost, port, true);
+			requireAvailablePort(bindHost, port);
 		}
 
 		WebDiffView view = factory.create(diff);
@@ -81,9 +81,9 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 	}
 
-	private static void requireAvailablePort(String bindHost, int port, boolean reuseAddress) throws IOException {
+	private static void requireAvailablePort(String bindHost, int port) throws IOException {
 		try (ServerSocket socket = new ServerSocket()) {
-			socket.setReuseAddress(reuseAddress);
+			socket.setReuseAddress(true);
 			socket.bind(new InetSocketAddress(bindHost, port));
 		} catch (BindException e) {
 			throw new IllegalArgumentException("port is already in use: " + port, e);


### PR DESCRIPTION
In this PR, we added a robust bash command which implements sidecar pattern on MCP server container management. This command runs a background container that each MCP client executes an instance of `refactoringminer mcp`. In this way, each MCP client can in parallel launch WebDiff browsers. The command also implements a port garbage collection of previous MCP clients on running a new one. We also update `mcp.md` to reflect this new flow for configuring RefactoringMiner MCP servers both in Linux and Windows.