### PR TITLE
Fix Next/Prev 404 in static --export output (empty routePath to bare-index links)

### DIFF
--- a/src/main/java/gui/webdiff/WebDiff.java
+++ b/src/main/java/gui/webdiff/WebDiff.java
@@ -21,6 +21,7 @@ import org.refactoringminer.astDiff.utils.Constants;
 import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
 import org.rendersnake.HtmlCanvas;
 import org.rendersnake.Renderable;
+import spark.Request;
 
 import java.awt.Desktop;
 import java.io.BufferedReader;
@@ -329,26 +330,20 @@ public class WebDiff  {
             return render(view);
         });
         get("/vanilla-diff/:id", (request, response) -> {
-            DiffViewState state = currentState;
-            int id = Integer.parseInt(request.params(":id"));
-            ASTDiff astDiff = state.comparator().getASTDiff(id);
-            Renderable view = new VanillaDiffView(
-                    toolName, state.projectASTDiff().getMetaInfo(), astDiff.getSrcPath(),  astDiff.getDstPath(),
-                    astDiff, id, state.comparator().getNumOfDiffs(), request.pathInfo().split("/")[0],
-                    state.comparator().isMoveDiff(id),
-                    state.projectASTDiff().getFileContentsBefore().get(astDiff.getSrcPath()),
-                    state.projectASTDiff().getFileContentsAfter().get(astDiff.getDstPath()),
-                    false);
-            return render(view);
+            return getVanillaDiff(request);
         });
+        get("/vanilla-diff/:id/", (request, response) -> {
+            return getVanillaDiff(request);
+        });
+
+
         get("/monaco-page/:id", (request, response) -> {
-            DiffViewState state = currentState;
-            int id = Integer.parseInt(request.params(":id"));
-            Renderable view = new MonacoView(
-                    toolName, state.comparator(), request.pathInfo().split("/")[0], id
-            );
-            return render(view);
+            return returnMonacoView(request);
         });
+        get("/monaco-page/:id/", (request, response) -> {
+            return returnMonacoView(request);
+        });
+
         get("/monaco-minimal/:id", (request, response) -> {
             DiffViewState state = currentState;
             int id = Integer.parseInt(request.params(":id"));
@@ -478,6 +473,49 @@ public class WebDiff  {
             view.setDecorate(true);
             return render(view);
         });
+    }
+
+    private String getVanillaDiff(Request request) throws IOException {
+        DiffViewState state = currentState;
+        int id = Integer.parseInt(request.params(":id"));
+        ASTDiff astDiff = state.comparator().getASTDiff(id);
+        Renderable view = new VanillaDiffView(
+                toolName, state.projectASTDiff().getMetaInfo(), astDiff.getSrcPath(),  astDiff.getDstPath(),
+                astDiff, id, state.comparator().getNumOfDiffs(), routePrefix(request),
+                state.comparator().isMoveDiff(id),
+                state.projectASTDiff().getFileContentsBefore().get(astDiff.getSrcPath()),
+                state.projectASTDiff().getFileContentsAfter().get(astDiff.getDstPath()),
+                false);
+        return render(view);
+    }
+
+    private String returnMonacoView(Request request) throws IOException {
+        DiffViewState state = currentState;
+        int id = Integer.parseInt(request.params(":id"));
+        Renderable view = new MonacoView(
+                toolName, state.comparator(), routePrefix(request), id
+        );
+        return render(view);
+    }
+
+    /**
+     * Returns the folder portion of the current request path, with both slashes
+     * intact, e.g. "/monaco-page/5" or "/monaco-page/5/" -> "/monaco-page/".
+     * Used as the Next/Prev route prefix so those links resolve to a full path
+     * (e.g. /monaco-page/6) instead of a bare index (6), which 404s in the
+     * static export where there is no live server to fill in the route.
+     */
+    private static String routePrefix(Request request) {
+        return routePrefix(request.pathInfo());
+    }
+
+    /** Package-private for testing; see {@link #routePrefix(Request)}. */
+    static String routePrefix(String pathInfo) {
+        String path = pathInfo;
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path.substring(0, path.lastIndexOf('/') + 1);
     }
 
     private static String render(Renderable r) throws IOException {

--- a/src/main/java/gui/webdiff/export/WebExporter.java
+++ b/src/main/java/gui/webdiff/export/WebExporter.java
@@ -116,7 +116,7 @@ public class WebExporter {
 
     }
 
-    private String doProperReplacement(String content, int nestingLevel) {
+    String doProperReplacement(String content, int nestingLevel) {
         String baseAddon = (".." + File.separator).repeat(nestingLevel);
         String baseAddonWithResources = baseAddon + resourceFolderNameInFinalExport + File.separator;
         Pattern pattern = Pattern.compile("(?<=\\b(href|src)=['\"])(/?)(?!https:)([^'\"]+)(?=['\"])");
@@ -132,12 +132,28 @@ public class WebExporter {
                 addon = baseAddonWithResources;
             } else {
                 addon = baseAddon;
+                // Page links target a directory we wrote as <page>/index.html.
+                // Point them straight at the file so navigation also works
+                // offline (file://) and on hosts that don't auto-resolve a
+                // directory to its index.html, not just servers that redirect.
+                if (isExportedPageLink(filePath)) {
+                    filePath = filePath + "/index.html";
+                }
             }
             matcher.appendReplacement(result, addon + filePath);
         }
         matcher.appendTail(result);
         content = result.toString();
         return content;
+    }
+
+    /** True if the link targets a page we export as <page>/index.html. */
+    private boolean isExportedPageLink(String filePath) {
+        if (otherPages.contains(filePath)) return true;          // "list", "singleView"
+        for (String viewer : viewers_path) {                     // "monaco-page/<id>", "vanilla-diff/<id>"
+            if (filePath.matches(Pattern.quote(viewer) + "/\\d+")) return true;
+        }
+        return false;
     }
 
     private void exportResources(String destDir, String resourcesPath) {

--- a/src/test/java/gui/webdiff/WebDiffTest.java
+++ b/src/test/java/gui/webdiff/WebDiffTest.java
@@ -1,0 +1,28 @@
+package gui.webdiff;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class WebDiffTest {
+
+	/**
+	 * Regression test for the Next/Prev 404 in the static export. The route
+	 * prefix must be the viewer folder with both slashes intact (e.g.
+	 * "/monaco-page/") so that {@code AbstractMenuBar} builds full links like
+	 * "/monaco-page/6". The previous implementation used
+	 * {@code request.pathInfo().split("/")[0]}, which is the empty string, and
+	 * produced bare-index links like "6" that 404 once relativized.
+	 */
+	@Test
+	void routePrefixKeepsTheViewerFolderWithBothSlashes() {
+		assertEquals("/monaco-page/", WebDiff.routePrefix("/monaco-page/5"));
+		assertEquals("/vanilla-diff/", WebDiff.routePrefix("/vanilla-diff/3"));
+	}
+
+	@Test
+	void routePrefixHandlesTheTrailingSlashRouteVariant() {
+		assertEquals("/monaco-page/", WebDiff.routePrefix("/monaco-page/5/"));
+		assertEquals("/vanilla-diff/", WebDiff.routePrefix("/vanilla-diff/3/"));
+	}
+}

--- a/src/test/java/gui/webdiff/export/WebExporterTest.java
+++ b/src/test/java/gui/webdiff/export/WebExporterTest.java
@@ -1,0 +1,54 @@
+package gui.webdiff.export;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class WebExporterTest {
+
+	// Nesting depth of a monaco-page/<id>/index.html page (two path segments
+	// below the export root), so relativized links get a "../../" prefix.
+	private static final int MONACO_PAGE_DEPTH = 2;
+
+	@Test
+	void rewritesInterPageLinksToTheIndexHtmlFile() {
+		String html = new WebExporter(null).doProperReplacement(
+				"<a href=\"/monaco-page/5\">m</a>"
+						+ "<a href=\"/vanilla-diff/2\">v</a>"
+						+ "<a href=\"/list\">l</a>",
+				MONACO_PAGE_DEPTH);
+
+		assertTrue(html.contains("href=\"../../monaco-page/5/index.html\""), html);
+		assertTrue(html.contains("href=\"../../vanilla-diff/2/index.html\""), html);
+		assertTrue(html.contains("href=\"../../list/index.html\""), html);
+	}
+
+	@Test
+	void sendsResourceLinksToTheResourcesFolderUntouched() {
+		String html = new WebExporter(null).doProperReplacement(
+				"<link href=\"/dist/monaco.css\">"
+						+ "<script src=\"/monaco/min/vs/loader.js\">",
+				MONACO_PAGE_DEPTH);
+
+		assertTrue(html.contains("href=\"../../resources/dist/monaco.css\""), html);
+		assertTrue(html.contains("src=\"../../resources/monaco/min/vs/loader.js\""), html);
+		// Resources must not get an index.html appended.
+		assertFalse(html.contains("monaco.css/index.html"), html);
+	}
+
+	@Test
+	void leavesNonExportedPageLinksAlone() {
+		String html = new WebExporter(null).doProperReplacement(
+				"<a href=\"/content?side=deleted&path=A.java\">d</a>"
+						+ "<a href=\"/quit\">q</a>",
+				MONACO_PAGE_DEPTH);
+
+		// The deleted/added content endpoint is not exported here (handled by a
+		// follow-up PR), so its link must be left as-is, not pointed at index.html.
+		assertTrue(html.contains("content?side=deleted&path=A.java"), html);
+		assertFalse(html.contains("A.java/index.html"), html);
+		// quit is a server-only endpoint, not an exported page.
+		assertFalse(html.contains("quit/index.html"), html);
+	}
+}


### PR DESCRIPTION
<!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<p>The web-diff exporter (<code>diff --url &#x3C;url> -e</code>) produces a static site whose<br>
<strong>Next/Prev</strong> buttons link to a bare diff index (eg <code>5</code>) instead of a full<br>
route (eg <code>/monaco-page/5</code>). This works on the live preview server by accident<br>
(relative-URL resolution) but <strong>404s in the exported/published site</strong>, where the<br>
link is relativized to a path that drops the <code>monaco-page/</code>/<code>vanilla-diff/</code><br>
segment entirely.</p>
<p>This PR fixes the link generation at its source and (optionally) hardens the<br>
exporter so the output also works offline / from a downloaded artifact.</p>
<h2 data-heading="Problem">Problem</h2>
<p>Navigating an exported diff:</p>

Step | URL | Result
-- | -- | --
Open list | .../<sha>/list/ | works
Click a file → Monaco | .../<sha>/monaco-page/5/ | works
Click Next | .../<sha>/6 | 404 error


<p>The Next link lost the <code>monaco-page/</code> segment and became a bare index.</p>
<h2 data-heading="Root cause">Root cause</h2>
<p>Two pieces combine:</p>
<ol>
<li><strong><code>WebDiff.java</code></strong> passes the "route prefix" to the view as<br>
<code>request.pathInfo().split("/")[0]</code>. Because <code>pathInfo()</code> starts with a slash<br>
(eg <code>"/monaco-page/5"</code>), <code>split("/")[0]</code> is the empty string <code>""</code> (the<br>
text <em>before</em> the leading slash), not <code>"monaco-page"</code>.</li>
<li><strong><code>AbstractMenuBar.getNextHRef()</code></strong> builds the link as<br>
<code>routePath + (id + 1)</code>. With <code>routePath == ""</code>, that yields <code>"5"</code>, a bare<br>
number with no route prefix.</li>
</ol>
<p>On the live server <code>href="5"</code> resolves relative to the current page and happens<br>
to work. In the static export, <code>WebExporter</code> relativizes it (eg to <code>../../5</code>),<br>
which from <code>.../monaco-page/5/</code> resolves to <code>.../&#x3C;sha>/5</code> → 404.</p>
<h2 data-heading="Changes">Changes</h2>
<h3 data-heading="Part 1: the fix (&#x60;src/main/java/gui/webdiff/WebDiff.java&#x60;)">Part 1: the fix (<code>src/main/java/gui/webdiff/WebDiff.java</code>)</h3>
<p><strong>Structural change first:</strong> the inline <code>/monaco-page/:id</code> and <code>/vanilla-diff/:id</code><br>
route handlers are extracted into two helper methods, <code>returnMonacoView(request)</code><br>
and <code>getVanillaDiff(request)</code>. This is so the same rendering logic can be reused<br>
by the trailing-slash route variants <code>/monaco-page/:id/</code> and <code>/vanilla-diff/:id/</code>,<br>
which are registered alongside the existing ones. The variants matter because the<br>
exported, published pages live at a trailing-slash URL (eg<br>
<code>.../monaco-page/5/</code>), so requests for both forms must resolve to the same view.<br>
The extraction is pure refactoring with no behavior change to the original<br>
routes; the fix below then applies in one place per viewer.</p>
<ul>
<li>Added a <code>routePrefix(Request request)</code> helper that returns the folder portion<br>
of the request path <strong>with both slashes intact</strong>, eg<br>
<code>"/monaco-page/5"</code> → <code>"/monaco-page/"</code>. It also strips a trailing slash first,<br>
so the <code>…/:id</code> and <code>…/:id/</code> route variants (which share these handlers) both<br>
yield the correct prefix.</li>
<li>Replaced <code>request.pathInfo().split("/")[0]</code> with <code>routePrefix(request)</code> at the<br>
two routes that are actually written to the static export:
<ul>
<li><code>returnMonacoView(...)</code> (serves <code>/monaco-page/:id</code>)</li>
<li><code>getVanillaDiff(...)</code> (serves <code>/vanilla-diff/:id</code>)</li>
</ul>
</li>
</ul>
<p>Result: Next/Prev now emit <code>/monaco-page/6</code> (same shape as the file-list links<br>
that already work). The live server still works because that is a valid absolute<br>
route; the static export relativizes it to <code>../../monaco-page/6</code> → resolves<br>
correctly.</p>
<p><strong>Deliberately left untouched:</strong> the three other <code>split("/")[0]</code> call sites<br>
(<code>/monaco-minimal</code>, <code>/monaco-diff</code>, <code>/onDemand</code>) are live-server-only routes that<br>
are never written to the static export, so they cannot cause the 404. Keeping<br>
the change to just the two exported routes minimizes the blast radius.</p>
<h3 data-heading="Part 2: hardening (&#x60;src/main/java/gui/webdiff/export/WebExporter.java&#x60;)">Part 2: hardening (<code>src/main/java/gui/webdiff/export/WebExporter.java</code>)</h3>
<p>The exporter writes every page as <code>&#x3C;page>/index.html</code>, but links between pages<br>
point at the <em>directory</em> (<code>monaco-page/5</code>). That only resolves on hosts that<br>
auto-redirect a directory to its <code>index.html</code> (eg GitHub Pages); it fails when<br>
opened from disk (<code>file://</code>, a downloaded CI artifact) or on a static host<br>
without directory-index resolution.</p>
<ul>
<li>In <code>doProperReplacement(...)</code>, exported-page links now get <code>/index.html</code><br>
appended, so they point straight at the file.</li>
<li>Guarded by a new <code>isExportedPageLink(filePath)</code> helper that whitelists only<br>
the pages the exporter itself generates. It reuses the existing<br>
<code>otherPages</code> (<code>list</code>, <code>singleView</code>) and <code>viewers_path</code><br>
(<code>monaco-page/&#x3C;id></code>, <code>vanilla-diff/&#x3C;id></code>) sets. Anchors (<code>#</code>), the <code>quit</code><br>
endpoint, query-string deleted/added links, and resource links<br>
(<code>.css</code>/<code>.js</code>/<code>.svg</code>) are left untouched.</li>
</ul>
<p>Result: links export as <code>../../monaco-page/6/index.html</code>, which works on GitHub<br>
Pages <strong>and</strong> offline / from an artifact, with no dependency on server-side<br>
directory-index behavior. (Part 1 is the actual bug fix; Part 2 makes<br>
<code>isExportedPageLink("monaco-page/5")</code> meaningful, since a bare <code>"5"</code> would not be<br>
recognized as a page.)</p>
<h2 data-heading="How to verify">How to verify</h2>
<ol>
<li>Build and run <code>refactoringminer diff --url &#x3C;PR/commit with ≥2 changed files> -e</code>.</li>
<li>In <code>web/monaco-page/0/index.html</code>, the Next button should be:
<ul>
<li>before: <code>href="../../1"</code> (bare index)</li>
<li>after Part 1: <code>href="../../monaco-page/1"</code></li>
<li>after Part 1 + 2: <code>href="../../monaco-page/1/index.html"</code></li>
</ul>
</li>
<li>Serve the export (or publish to Pages) and click Next/Prev across all files.<br>
There should be no more <code>.../&#x3C;sha>/&#x3C;number></code> 404s.</li>
</ol>
<h2 data-heading="Tests">Tests</h2>
<p>Two fast, token-free unit tests cover the change, in the same JUnit 5 style as<br>
the existing <code>gui.webdiff</code> tests:</p>
<ul>
<li><code>gui.webdiff.WebDiffTest</code> asserts <code>routePrefix(...)</code> returns the full viewer<br>
folder (<code>/monaco-page/</code>, <code>/vanilla-diff/</code>) for both the <code>/:id</code> and <code>/:id/</code><br>
route forms, locking the fix in against the old empty-string regression.</li>
<li><code>gui.webdiff.export.WebExporterTest</code> asserts <code>doProperReplacement(...)</code><br>
rewrites exported-page links to <code>&#x3C;page>/index.html</code>, sends <code>.css</code>/<code>.js</code> links<br>
to <code>resources/</code> untouched, and leaves non-exported links<br>
(<code>/content?side=...</code>, <code>/quit</code>) alone.</li>
</ul>
<p>To make these reachable without starting the Spark server, two methods were<br>
widened from <code>private</code> to package-private: <code>WebDiff.routePrefix(String)</code><br>
(extracted from the existing <code>routePrefix(Request)</code>) and<br>
<code>WebExporter.doProperReplacement(String, int)</code>.</p>
<p>Run with <code>./gradlew test --tests 'gui.webdiff.*' -Pnotoken</code>.</p>
<h2 data-heading="Scope &#x26; follow-up">Scope &#x26; follow-up</h2>
<p>This PR intentionally covers <strong>only</strong> the Next/Prev navigation bug. A separate,<br>
related issue remains and will be addressed in a <strong>follow-up PR</strong>: clicking a<br>
<strong>deleted or added</strong> file from the list 404s<br>
(<code>.../content?side=deleted&#x26;path=&#x3C;file></code>). Those files have no AST diff, so the<br>
list links them to the live <code>/content?side=…&#x26;path=…</code> endpoint<br>
(<code>DirectoryDiffView</code>), which <code>WebExporter</code> never writes to the static export, so<br>
the page simply doesn't exist on Pages / offline.</p>
<p>That's a <em>missing-page</em> problem (different root cause from this PR's<br>
<em>malformed-link</em> problem), and the fix is larger: it adds static export of those<br>
content pages plus the corresponding link rewriting, building on the<br>
<code>/index.html</code> machinery introduced here in Part 2. Keeping it in its own PR keeps<br>
this one small and easy to review.</p>