### PR TITLE
Fix deleted/added file 404 in static --export output (export content pages and relink)

### DIFF
--- a/src/main/java/gui/webdiff/export/WebExporter.java
+++ b/src/main/java/gui/webdiff/export/WebExporter.java
@@ -10,8 +10,12 @@ import org.refactoringminer.astDiff.models.ASTDiff;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -31,6 +35,13 @@ public class WebExporter {
             "singleView",
             "list"
     );
+    // Deleted/added files in their list order, used both to generate the
+    // content/<side>/<i> pages and to map their /content?side=&path= links to
+    // those folders. Injected from the comparator in export(); the empty
+    // defaults make doProperReplacement testable without a running server.
+    List<String> deletedFiles = List.of();
+    List<String> addedFiles = List.of();
+    final String contentFolder = "content";
 
     public void setViewers_path(Set<String> viewers_path) {
         this.viewers_path = viewers_path;
@@ -38,6 +49,11 @@ public class WebExporter {
 
     public void setOtherPages(Set<String> otherPages) {
         this.otherPages = otherPages;
+    }
+
+    public void setContentFiles(List<String> deletedFiles, List<String> addedFiles) {
+        this.deletedFiles = deletedFiles;
+        this.addedFiles = addedFiles;
     }
 
     final String baseFolder = "web";
@@ -52,8 +68,11 @@ public class WebExporter {
         if (!exportPath.endsWith(File.separator))
             exportPath += File.separator;
         exportPath = exportPath + baseFolder + File.separator;
+        deletedFiles = new ArrayList<>(webDiff.getComparator().getRemovedFilesName());
+        addedFiles = new ArrayList<>(webDiff.getComparator().getAddedFilesName());
         exportViewers(exportPath);
         exportOthersPages(exportPath);
+        exportContentPages(exportPath);
         exportResources(exportPath + File.separator, resourcePath + webDiff.getResources());
         exportInfo(exportPath);
     }
@@ -97,6 +116,24 @@ public class WebExporter {
         }
     }
 
+    // Deleted/added files have no AST diff and so no /monaco-page/<id> page; the
+    // live server serves them on demand from /content?side=&path=. Materialize
+    // each one as a static page so the export works offline / on GitHub Pages.
+    private void exportContentPages(String exportPath) {
+        exportContentSide(exportPath, "deleted", deletedFiles);
+        exportContentSide(exportPath, "added", addedFiles);
+    }
+
+    private void exportContentSide(String exportPath, String side, List<String> files) {
+        for (int i = 0; i < files.size(); i++) {
+            String encodedPath = URLEncoder.encode(files.get(i), StandardCharsets.UTF_8);
+            String url = String.format("%s:%d/content?side=%s&path=%s", baseURL, webDiff.port, side, encodedPath);
+            // Folder "content/<side>/<i>" sits three levels below the export root,
+            // so export() computes nestingLevel 3 and the right "../../../" prefix.
+            export(exportPath, contentFolder + File.separator + side + File.separator + i, url);
+        }
+    }
+
     private void export(String exportPath, String folderPath, String url) {
         int nestingLevel = folderPath.length() - folderPath.replace(File.separator, "").length() + 1;
         String content = getPage(url);
@@ -132,15 +169,20 @@ public class WebExporter {
                 addon = baseAddonWithResources;
             } else {
                 addon = baseAddon;
-                // Page links target a directory we wrote as <page>/index.html.
-                // Point them straight at the file so navigation also works
-                // offline (file://) and on hosts that don't auto-resolve a
-                // directory to its index.html, not just servers that redirect.
-                if (isExportedPageLink(filePath)) {
+                // Deleted/added links are query-string shaped
+                // (content?side=&path=); rewrite them to the static folder we
+                // generated for that file. Other page links target a directory
+                // we wrote as <page>/index.html, so point them straight at the
+                // file: navigation then works offline (file://) and on hosts
+                // that don't auto-resolve a directory to its index.html.
+                String contentTarget = rewriteContentLink(filePath);
+                if (contentTarget != null) {
+                    filePath = contentTarget;
+                } else if (isExportedPageLink(filePath)) {
                     filePath = filePath + "/index.html";
                 }
             }
-            matcher.appendReplacement(result, addon + filePath);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(addon + filePath));
         }
         matcher.appendTail(result);
         content = result.toString();
@@ -154,6 +196,47 @@ public class WebExporter {
             if (filePath.matches(Pattern.quote(viewer) + "/\\d+")) return true;
         }
         return false;
+    }
+
+    /**
+     * Map a deleted/added link ("content?side=&path=") to the static folder we
+     * exported for that file ("content/<side>/<i>/index.html"), or null if the
+     * link isn't a content link or names a file we didn't export.
+     */
+    String rewriteContentLink(String filePath) {
+        int queryStart = filePath.indexOf('?');
+        if (queryStart < 0 || !filePath.substring(0, queryStart).endsWith(contentFolder)) return null;
+
+        // rendersnake escapes attribute values, so the raw HTML has "&amp;".
+        String query = filePath.substring(queryStart + 1).replace("&amp;", "&");
+        String side = queryParam(query, "side");
+        String rawPath = queryParam(query, "path");
+        if (side == null || rawPath == null) return null;
+
+        // The /content route accepts both deleted/added and left/right.
+        String normalizedSide = "left".equals(side) ? "deleted" : "right".equals(side) ? "added" : side;
+        String path = URLDecoder.decode(rawPath, StandardCharsets.UTF_8);
+        int index;
+        if ("deleted".equals(normalizedSide)) {
+            index = deletedFiles.indexOf(path);
+        } else if ("added".equals(normalizedSide)) {
+            index = addedFiles.indexOf(path);
+        } else {
+            return null;
+        }
+        if (index < 0) return null;
+        return contentFolder + "/" + normalizedSide + "/" + index + "/index.html";
+    }
+
+    /** Read a single parameter out of an already-unescaped query string, URL-decoding nothing. */
+    private static String queryParam(String query, String key) {
+        for (String pair : query.split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq > 0 && pair.substring(0, eq).equals(key)) {
+                return pair.substring(eq + 1);
+            }
+        }
+        return null;
     }
 
     private void exportResources(String destDir, String resourcesPath) {

--- a/src/test/java/gui/webdiff/export/WebExporterTest.java
+++ b/src/test/java/gui/webdiff/export/WebExporterTest.java
@@ -3,6 +3,8 @@ package gui.webdiff.export;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 class WebExporterTest {
@@ -38,14 +40,48 @@ class WebExporterTest {
 	}
 
 	@Test
-	void leavesNonExportedPageLinksAlone() {
+	void rewritesDeletedAndAddedLinksToTheirExportedContentFolders() {
+		WebExporter exporter = new WebExporter(null);
+		// Order here is the order the folders are numbered, mirroring the
+		// comparator's getRemovedFilesName()/getAddedFilesName() ordering.
+		exporter.setContentFiles(List.of("A.java", "src/main/B.java"), List.of("C.java"));
+
+		String html = exporter.doProperReplacement(
+				// rendersnake escapes the "&" in attribute values to "&amp;",
+				// and paths with slashes are URL-encoded (B.java below).
+				"<a href=\"/content?side=deleted&amp;path=A.java\">a</a>"
+						+ "<a href=\"/content?side=deleted&amp;path=src%2Fmain%2FB.java\">b</a>"
+						+ "<a href=\"/content?side=added&amp;path=C.java\">c</a>",
+				MONACO_PAGE_DEPTH);
+
+		assertTrue(html.contains("href=\"../../content/deleted/0/index.html\""), html);
+		assertTrue(html.contains("href=\"../../content/deleted/1/index.html\""), html);
+		assertTrue(html.contains("href=\"../../content/added/0/index.html\""), html);
+	}
+
+	@Test
+	void normalizesLeftRightSidesToDeletedAdded() {
+		WebExporter exporter = new WebExporter(null);
+		exporter.setContentFiles(List.of("A.java"), List.of("C.java"));
+
+		String html = exporter.doProperReplacement(
+				"<a href=\"/content?side=left&amp;path=A.java\">a</a>"
+						+ "<a href=\"/content?side=right&amp;path=C.java\">c</a>",
+				MONACO_PAGE_DEPTH);
+
+		assertTrue(html.contains("href=\"../../content/deleted/0/index.html\""), html);
+		assertTrue(html.contains("href=\"../../content/added/0/index.html\""), html);
+	}
+
+	@Test
+	void leavesUnknownContentLinksAndServerOnlyEndpointsAlone() {
+		// No content files registered, so a /content link names a file we did
+		// not export: leave it as-is rather than pointing at a missing folder.
 		String html = new WebExporter(null).doProperReplacement(
 				"<a href=\"/content?side=deleted&path=A.java\">d</a>"
 						+ "<a href=\"/quit\">q</a>",
 				MONACO_PAGE_DEPTH);
 
-		// The deleted/added content endpoint is not exported here (handled by a
-		// follow-up PR), so its link must be left as-is, not pointed at index.html.
 		assertTrue(html.contains("content?side=deleted&path=A.java"), html);
 		assertFalse(html.contains("A.java/index.html"), html);
 		// quit is a server-only endpoint, not an exported page.


### PR DESCRIPTION
<!-- obsidian --><h3 data-heading="Summary">Summary</h3>
<p>In the web-diff exporter (<code>diff --url &#x3C;url> -e</code>), clicking a <strong>deleted</strong> or <strong>added</strong> file in the static output 404s, even though it works on the live preview server. Deleted/added files are served on the live server by an on demand <code>/content?side=&#x26;path=</code> endpoint that the exporter never writes to disk, so the page simply does not exist in the export. This PR makes the exporter generate a static page for each deleted/added file and rewrites the links to point at it.</p>
<p>This is a follow-up to the Next/Prev static-export fix and builds on the <code>/index.html</code> link-rewriting introduced there.</p>
<h3 data-heading="Problem">Problem</h3>

Step | URL | Result
-- | -- | --
Open list | .../<sha>/list/ | works
Click a modified file | .../<sha>/monaco-page/3/ | works
Click a deleted file | .../<sha>/content?side=deleted&path=Foo.java | 404 error


<p>On the live server the same click works, because the server holds the file contents in memory and renders the page per request.</p>
<h3 data-heading="Root cause">Root cause</h3>
<p>Unlike modified files, deleted and added files have no AST diff, so they are never assigned a <code>monaco-page/&#x3C;id></code>. They exist only as filename strings in <code>DirComparator.getRemovedFilesName()</code> / <code>getAddedFilesName()</code>, and the list links them to a query-string endpoint, <code>/content?side=deleted&#x26;path=&#x3C;file></code> (<code>DirectoryDiffView.java:344</code>).</p>
<p>That endpoint (<code>WebDiff.java:407</code>) is a pure runtime route: it reads <code>side</code> and <code>path</code> at request time and looks the content up in the in-memory <code>getFileContentsBefore()</code> / <code>getFileContentsAfter()</code> maps. The exporter only materializes the indexed routes (<code>exportViewers</code> loops over <code>getNumOfDiffs()</code>, <code>exportOthersPages</code> over a fixed <code>{list, singleView}</code> set), so <code>/content</code> is never crawled or written. On a static host or offline there is no server to answer it, hence the 404.</p>
<p>This is a missing-page problem (the target page was never generated), not a malformed-link problem like the Next/Prev bug.</p>
<h3 data-heading="Changes (&#x60;src/main/java/gui/webdiff/export/WebExporter.java&#x60;)">Changes (<code>src/main/java/gui/webdiff/export/WebExporter.java</code>)</h3>
<p>Everything is in the exporter. No server-side change is needed, since the live <code>/content</code> route already renders correct HTML; the exporter just has to capture it and fix where the links point.</p>
<h4 data-heading="Part 1: generate the pages">Part 1: generate the pages</h4>
<p>Added <code>exportContentPages</code> / <code>exportContentSide</code>, called from <code>export(...)</code>. For each deleted and added file they hit the live <code>/content?side=&#x26;path=</code> endpoint (reusing the same <code>getPage(url)</code> mechanism the viewers already use) and write the result to <code>content/&#x3C;side>/&#x3C;i>/index.html</code>, where <code>&#x3C;i></code> is the file's position in <code>getRemovedFilesName()</code> / <code>getAddedFilesName()</code>. The existing <code>export(...)</code> helper computes the nesting depth, so these three-deep pages get the correct <code>../../../</code> prefix automatically.</p>
<p>The index ordering matches the order <code>AbstractMenuBar</code> already uses (<code>deletedFilePaths.indexOf(...)</code> / <code>.get(i)</code>), so the folder numbers line up with the server's own Prev/Next navigation, no drift.</p>
<h4 data-heading="Part 2: rewrite the links">Part 2: rewrite the links</h4>
<p>The deleted/added links are query-string shaped (<code>content?side=deleted&#x26;path=Foo.java</code>) and appear in three places, all of which flow through <code>doProperReplacement</code> during export: the list page, the last modified page's Next button, and each content page's own Prev/Next. The <code>else</code> branch of <code>doProperReplacement</code> now calls a new <code>rewriteContentLink(filePath)</code> helper that:</p>
<ul>
<li>parses <code>side</code> and <code>path</code> out of the query string,</li>
<li>unescapes the <code>&#x26;amp;</code> that rendersnake writes into attribute values,</li>
<li>URL-decodes the path (so slashes survive: <code>src%2FFoo.java</code> to <code>src/Foo.java</code>),</li>
<li>normalizes <code>left</code>/<code>right</code> to <code>deleted</code>/<code>added</code>,</li>
<li>maps the path to its exported index and returns <code>content/&#x3C;side>/&#x3C;i>/index.html</code>, or <code>null</code> if it is not a content link or names a file we did not export (those are left untouched).</li>
</ul>
<p>The <code>appendReplacement</code> call is also hardened with <code>Matcher.quoteReplacement(...)</code> so paths containing <code>$</code> or <code>\</code> cannot corrupt the output.</p>
<p>Result: a deleted/added link exports as eg <code>../../content/deleted/0/index.html</code>, which resolves on GitHub Pages and offline, with no running server required.</p>
<h3 data-heading="How to verify">How to verify</h3>
<ol>
<li>Run <code>refactoringminer diff --url &#x3C;commit/PR with at least one deleted and one added file> -e</code>.</li>
<li>In the exported <code>web/</code>, confirm <code>content/deleted/0/index.html</code> and <code>content/added/0/index.html</code> exist.</li>
<li>Open <code>list/index.html</code>, click a deleted file and an added file.
<ul>
<li>before: link points at <code>.../content?side=deleted&#x26;path=...</code> and 404s.</li>
<li>after: link points at <code>.../content/deleted/0/index.html</code> and loads the file in the Monaco viewer.</li>
</ul>
</li>
<li>Prev/Next across the boundary between modified and deleted/added files should also resolve with no 404s.</li>
</ol>
<h3 data-heading="Tests">Tests</h3>
<p>The link-rewriting logic is covered by fast, token-free unit tests in <code>gui.webdiff.export.WebExporterTest</code>, in the same JUnit 5 style as the existing tests:</p>
<ul>
<li><code>rewritesDeletedAndAddedLinksToTheirExportedContentFolders</code> asserts that deleted/added links (including an <code>&#x26;amp;</code> separator and a slashed, URL-encoded path) are rewritten to <code>content/&#x3C;side>/&#x3C;i>/index.html</code>.</li>
<li><code>normalizesLeftRightSidesToDeletedAdded</code> asserts <code>side=left</code> / <code>side=right</code> map to the <code>deleted</code> / <code>added</code> folders.</li>
<li><code>leavesUnknownContentLinksAndServerOnlyEndpointsAlone</code> asserts a content link for a file that was not exported, and the server-only <code>/quit</code> endpoint, are left untouched.</li>
</ul>
<p>To make <code>doProperReplacement</code> reachable without starting the Spark server, the deleted/added file lists are injected through a <code>setContentFiles(...)</code> seam (mirroring the existing <code>setViewers_path</code> / <code>setOtherPages</code> setters); they default to empty, which also makes the rewrite backward-safe.</p>
<p>Page generation itself (<code>exportContentSide</code>) is exercised end to end rather than unit tested, since it needs a running server, it was validated by running the action on a sandbox repo against a commit with deleted and added files and confirming the pages load.</p>
<p>Run with <code>./gradlew test --tests 'gui.webdiff.*' -Pnotoken</code>.</p>
<h3 data-heading="Scope">Scope</h3>
<p>This PR only covers static export of deleted/added file content pages. It does not touch the live server routes, <code>AbstractMenuBar</code>, or <code>DirectoryDiffView</code>, those already emit the correct live links and are rewritten at export time.</p>