### PR TITLE
Add htmlDescription field to refactoring JSON output

### DIFF
--- a/src/main/java/org/refactoringminer/api/Refactoring.java
+++ b/src/main/java/org/refactoringminer/api/Refactoring.java
@@ -56,6 +56,9 @@ public interface Refactoring extends Serializable, CodeRangeProvider {
 		sb.append("\t").append("\"").append("description").append("\"").append(": ").append("\"");
 		encoder.quoteAsString(toString().replace('\t', ' '), sb);
 		sb.append("\"").append(",").append("\n");
+		sb.append("\t").append("\"").append("htmlDescription").append("\"").append(": ").append("\"");
+		encoder.quoteAsString(toHTMLString().replace('\t', ' '), sb);
+		sb.append("\"").append(",").append("\n");
 		sb.append("\t").append("\"").append("leftSideLocations").append("\"").append(": ").append(leftSide()).append(",").append("\n");
 		sb.append("\t").append("\"").append("rightSideLocations").append("\"").append(": ").append(rightSide()).append("\n");
 		sb.append("}");


### PR DESCRIPTION
## Summary
Adds an `htmlDescription` field to the JSON produced by `Refactoring.toJSON()`. It carries the same HTML formatted description that `toHTMLString()` already generates for the web diff view (bold refactoring name, `<code>` around code elements, `<a>` around class names). The existing `description` field is unchanged.

## Motivation
`toJSON()` currently exposes only the plain `toString()` description. RefactoringMiner already produces a richer form via `toHTMLString()`, used by the web diff UI, but consumers of the JSON have no access to it. For example, I run RefactoringMiner in a GitHub Action that posts the detected refactorings as a pull request comment, and I want to render code elements as code and class names as links, exactly the way the web view does. Without this field a consumer has to guess which tokens are code or class names. Exposing the markup that the library already computes removes that guesswork and keeps the formatting consistent with the UI.

## Change
A single addition in the default `toJSON()` method on `Refactoring`. After the `description` field, it appends `htmlDescription` using the same `JsonStringEncoder` escaping and the same tab to space normalisation, with the value coming from `toHTMLString()`:

```java
sb.append("\t").append("\"").append("htmlDescription").append("\"").append(": ").append("\"");
encoder.quoteAsString(toHTMLString().replace('\t', ' '), sb);
sb.append("\"").append(",").append("\n");
```
## Tests
The change only adds a field to the serialised output. The oracle based tests compare the plain `toString()` / `description`, not the serialised `toJSON()`, so they are unaffected and the build passes.