### PR TITLE
Fix top-down matcher slowdown on repeated subtrees

### DIFF
--- a/src/main/java/org/refactoringminer/astDiff/matchers/vanilla/CustomTopDownMatcher.java
+++ b/src/main/java/org/refactoringminer/astDiff/matchers/vanilla/CustomTopDownMatcher.java
@@ -34,6 +34,10 @@ public class CustomTopDownMatcher extends GreedySubtreeMatcher {
 	private boolean isAcceptableMatch(Mapping mapping) {
 		Tree first = mapping.first;
 		Tree second = mapping.second;
+		return isAcceptableMatch(first, second);
+	}
+
+	private boolean isAcceptableMatch(Tree first, Tree second) {
 		if (isPartOfConditional(first, LANG1) && isPartOfConditional(second, LANG2))
 			if (!isSamePositionInConditional(first,second))
 				return false;
@@ -41,12 +45,12 @@ public class CustomTopDownMatcher extends GreedySubtreeMatcher {
 			return false;
 		if (isPartOfConditional(second, LANG2) && getIndexInConditional(second, LANG2) == 0 && !isPartOfConditional(first, LANG1))
 			return false;
-		return (!mapping.first.getParent().getType().name.equals(LANG1.METHOD_INVOCATION)
+		return (!first.getParent().getType().name.equals(LANG1.METHOD_INVOCATION)
 				||
-				mapping.second.getParent().getType().name.equals(LANG2.METHOD_INVOCATION)) &&
-				(!mapping.second.getParent().getType().name.equals(LANG2.METHOD_INVOCATION)
+				second.getParent().getType().name.equals(LANG2.METHOD_INVOCATION)) &&
+				(!second.getParent().getType().name.equals(LANG2.METHOD_INVOCATION)
 						||
-						mapping.first.getParent().getType().name.equals(LANG1.METHOD_INVOCATION));
+						first.getParent().getType().name.equals(LANG1.METHOD_INVOCATION));
 	}
 
 	private boolean isOnlyOneMethodInvocation(Tree input1, Tree input2) {
@@ -139,7 +143,8 @@ public class CustomTopDownMatcher extends GreedySubtreeMatcher {
 	@Override
 	public void filterMappings(MultiMappingStore multiMappings) {
 		// Select unique mappings first and extract ambiguous mappings.
-		List<Mapping> ambiguousList = new ArrayList<>();
+		List<AmbiguousGroup> ambiguousGroups = new ArrayList<>();
+		long ambiguousMappingCount = 0;
 		Set<Tree> ignored = new HashSet<>();
 		for (var src : multiMappings.allMappedSrcs()) {
 			var isMappingUnique = false;
@@ -154,60 +159,385 @@ public class CustomTopDownMatcher extends GreedySubtreeMatcher {
 			if (!(ignored.contains(src) || isMappingUnique)) {
 				var adsts = multiMappings.getDsts(src);
 				var asrcs = multiMappings.getSrcs(multiMappings.getDsts(src).iterator().next());
-				for (Tree asrc : asrcs)
-					for (Tree adst : adsts) {
-						ambiguousList.add(new Mapping(asrc, adst));
-					}
+				ambiguousGroups.add(new AmbiguousGroup(asrcs, adsts));
+				ambiguousMappingCount += (long) asrcs.size() * adsts.size();
 				ignored.addAll(asrcs);
 			}
 		}
 
 		// Rank the mappings by score.
+		ScoredMappingFactory scoredMappingFactory = new ScoredMappingFactory(mappings);
+		scoredMappingFactory.prepare(ambiguousGroups);
+		List<ScoredMapping> ambiguousList = new ArrayList<>(initialCapacity(ambiguousMappingCount));
+		long order = 0;
+		for (AmbiguousGroup ambiguousGroup : ambiguousGroups) {
+			for (Tree asrc : ambiguousGroup.srcs)
+				for (Tree adst : ambiguousGroup.dsts)
+					ambiguousList.add(scoredMappingFactory.score(asrc, adst, order++));
+		}
 		Set<Tree> srcIgnored = new HashSet<>();
 		Set<Tree> dstIgnored = new HashSet<>();
-		Collections.sort(ambiguousList, new ExtendedFullMappingComparator(mappings));
+		Collections.sort(ambiguousList);
 		if (ambiguousList.size() > 1)
 			ambiguousLeafModification(ambiguousList,srcIgnored,dstIgnored);
 		// Select the best ambiguous mappings
-		retainBestMapping(ambiguousList, srcIgnored, dstIgnored);
+		retainBestScoredMapping(ambiguousList, srcIgnored, dstIgnored);
 	}
 
-	private void ambiguousLeafModification(List<Mapping> ambiguousList, Set<Tree> srcIgnored, Set<Tree> dstIgnored) {
-		List<Mapping> ret = new ArrayList<>();
-		for (Mapping mapping : ambiguousList) {
-			Tree asrc = mapping.first;
-			Tree adst = mapping.second;
-			if (
-					(asrc.getType().name.equals(LANG1.STRING_LITERAL) && adst.getType().name.equals(LANG2.STRING_LITERAL))
-					 || (asrc.getType().name.equals(LANG1.NUMBER_LITERAL) && adst.getType().name.equals(LANG2.NUMBER_LITERAL))
-					 || (asrc.getType().name.equals(LANG1.PREFIX_EXPRESSION) && adst.getType().name.equals(LANG2.PREFIX_EXPRESSION))
-					 || (asrc.getType().name.equals(LANG1.BOOLEAN_LITERAL) && adst.getType().name.equals(LANG2.BOOLEAN_LITERAL))
-				) {
-				if (asrc.getParent() != null && adst.getParent() != null) {
-					int i = asrc.positionInParent();
-					int j = adst.positionInParent();
-					if (i == j && asrc.getParent().getType().name.equals(adst.getParent().getType().name))
-					{
-						ret.add(mapping);
-						srcIgnored.add(asrc);
-						dstIgnored.add(adst);
-					}
-					else if (i > 0 && j > 0) {
-						Tree srcYoungerSibling = asrc.getParent().getChild(i - 1);
-						Tree dstYoungerSibling = adst.getParent().getChild(j - 1);
-						if (mappings.getSrcForDst(dstYoungerSibling) != null)
-							if (mappings.getSrcForDst(dstYoungerSibling).equals(srcYoungerSibling)) {
-								ret.add(mapping);
-								srcIgnored.add(asrc);
-								dstIgnored.add(adst);
-							}
-					}
-				}
-			} else {
+	private int initialCapacity(long mappingCount) {
+		return mappingCount > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) mappingCount;
+	}
+
+	private void ambiguousLeafModification(List<ScoredMapping> ambiguousList, Set<Tree> srcIgnored, Set<Tree> dstIgnored) {
+		for (ScoredMapping scoredMapping : ambiguousList) {
+			Tree asrc = scoredMapping.first;
+			Tree adst = scoredMapping.second;
+
+			if (!isAmbiguousLeafCandidate(asrc, adst)) {
 				break;
+			}
+
+			if (asrc.getParent() == null || adst.getParent() == null) {
+				continue;
+			}
+
+			int i = asrc.positionInParent();
+			int j = adst.positionInParent();
+			if (i == j && asrc.getParent().getType().name.equals(adst.getParent().getType().name)) {
+				ignoreMapping(asrc, adst, srcIgnored, dstIgnored);
+			}
+			else if (i > 0 && j > 0) {
+				Tree srcYoungerSibling = asrc.getParent().getChild(i - 1);
+				Tree dstYoungerSibling = adst.getParent().getChild(j - 1);
+				Tree mappedSrcYoungerSibling = mappings.getSrcForDst(dstYoungerSibling);
+				if (srcYoungerSibling.equals(mappedSrcYoungerSibling)) {
+					ignoreMapping(asrc, adst, srcIgnored, dstIgnored);
+				}
 			}
 		}
 	}
+
+	private boolean isAmbiguousLeafCandidate(Tree asrc, Tree adst) {
+		return (asrc.getType().name.equals(LANG1.STRING_LITERAL) && adst.getType().name.equals(LANG2.STRING_LITERAL))
+				|| (asrc.getType().name.equals(LANG1.NUMBER_LITERAL) && adst.getType().name.equals(LANG2.NUMBER_LITERAL))
+				|| (asrc.getType().name.equals(LANG1.PREFIX_EXPRESSION) && adst.getType().name.equals(LANG2.PREFIX_EXPRESSION))
+				|| (asrc.getType().name.equals(LANG1.BOOLEAN_LITERAL) && adst.getType().name.equals(LANG2.BOOLEAN_LITERAL));
+	}
+
+	private void ignoreMapping(Tree asrc, Tree adst, Set<Tree> srcIgnored, Set<Tree> dstIgnored) {
+		srcIgnored.add(asrc);
+		dstIgnored.add(adst);
+	}
+
+	private void retainBestScoredMapping(List<ScoredMapping> mappingList, Set<Tree> srcIgnored, Set<Tree> dstIgnored) {
+		for (ScoredMapping scoredMapping : mappingList) {
+			Tree first = scoredMapping.first;
+			Tree second = scoredMapping.second;
+			if (isVerifiedMapping(first, second) && !(srcIgnored.contains(first) || dstIgnored.contains(second))) {
+				mappings.addMappingRecursively(first, second);
+				srcIgnored.add(first);
+				srcIgnored.addAll(first.getDescendants());
+				dstIgnored.add(second);
+				dstIgnored.addAll(second.getDescendants());
+			}
+		}
+	}
+
+	private boolean isVerifiedMapping(Tree first, Tree second) {
+		if (TreeUtilFunctions.areBothFromThisType(first, second, LANG1.SIMPLE_NAME, LANG2.SIMPLE_NAME) || TreeUtilFunctions.areBothFromThisType(first, second, LANG1.QUALIFIED_NAME, LANG2.QUALIFIED_NAME)) {
+			return isAcceptableMatch(first, second);
+		}
+		return true;
+	}
+
+	private static class AmbiguousGroup {
+		private final Set<Tree> srcs;
+		private final Set<Tree> dsts;
+
+		private AmbiguousGroup(Set<Tree> srcs, Set<Tree> dsts) {
+			this.srcs = srcs;
+			this.dsts = dsts;
+		}
+	}
+
+	private static class ScoredMapping implements Comparable<ScoredMapping> {
+		private final Tree first;
+		private final Tree second;
+		private final double siblingsSimilarity;
+		private final double parentsSimilarity;
+		private final double parentPositionDistance;
+		private final int absolutePositionDistance;
+		private final int srcPosition;
+		private final int dstPosition;
+		private final long order;
+
+		private ScoredMapping(Tree first, Tree second, double siblingsSimilarity, double parentsSimilarity,
+							  double parentPositionDistance, int absolutePositionDistance, long order) {
+			this.first = first;
+			this.second = second;
+			this.siblingsSimilarity = siblingsSimilarity;
+			this.parentsSimilarity = parentsSimilarity;
+			this.parentPositionDistance = parentPositionDistance;
+			this.absolutePositionDistance = absolutePositionDistance;
+			this.srcPosition = first.getPos();
+			this.dstPosition = second.getPos();
+			this.order = order;
+		}
+
+		@Override
+		public int compareTo(ScoredMapping other) {
+			int result = Double.compare(other.siblingsSimilarity, siblingsSimilarity);
+			if (result != 0) return result;
+			result = Double.compare(other.parentsSimilarity, parentsSimilarity);
+			if (result != 0) return result;
+			result = Double.compare(parentPositionDistance, other.parentPositionDistance);
+			if (result != 0) return result;
+			result = Integer.compare(absolutePositionDistance, other.absolutePositionDistance);
+			if (result != 0) return result;
+			result = Integer.compare(srcPosition, other.srcPosition);
+			if (result != 0) return result;
+			result = Integer.compare(dstPosition, other.dstPosition);
+			if (result != 0) return result;
+			return Long.compare(order, other.order);
+		}
+	}
+
+	private static class ScoredMappingFactory {
+		private final MappingStore mappings;
+		private final Map<Tree, Set<Tree>> srcDescendants = new HashMap<>();
+		private final Map<Tree, Set<Tree>> dstDescendants = new HashMap<>();
+		private final Map<Tree, double[]> positionVectors = new HashMap<>();
+		private final Map<Tree, Map<Tree, Double>> siblingsSimilarities = new HashMap<>();
+		private final Map<Tree, Map<Tree, Double>> parentsSimilarities = new HashMap<>();
+		private final Map<Tree, Map<Tree, Integer>> commonParents = new HashMap<>();
+		private final Map<Tree, Integer> parentDepths = new HashMap<>();
+
+		private ScoredMappingFactory(MappingStore mappings) {
+			this.mappings = mappings;
+		}
+
+		private void prepare(List<AmbiguousGroup> ambiguousGroups) {
+			Map<Tree, Set<Tree>> candidateDstParentsBySrcParent = new HashMap<>();
+			Set<Tree> relevantDstParents = new HashSet<>();
+			for (AmbiguousGroup ambiguousGroup : ambiguousGroups) {
+				for (Tree asrc : ambiguousGroup.srcs) {
+					Tree srcParent = asrc.getParent();
+					Set<Tree> dstParents = candidateDstParentsBySrcParent.computeIfAbsent(srcParent, ignored -> new HashSet<>());
+					for (Tree adst : ambiguousGroup.dsts) {
+						Tree dstParent = adst.getParent();
+						dstParents.add(dstParent);
+						relevantDstParents.add(dstParent);
+					}
+				}
+			}
+			Map<Tree, Map<Tree, Integer>> commonDescendants = new HashMap<>();
+			for (Mapping mapping : mappings) {
+				List<Tree> srcParents = relevantParents(mapping.first, candidateDstParentsBySrcParent.keySet());
+				if (srcParents.isEmpty()) {
+					continue;
+				}
+				List<Tree> dstParents = relevantParents(mapping.second, relevantDstParents);
+				if (dstParents.isEmpty()) {
+					continue;
+				}
+				for (Tree srcParent : srcParents) {
+					Set<Tree> candidateDstParents = candidateDstParentsBySrcParent.get(srcParent);
+					Map<Tree, Integer> countsByDstParent = commonDescendants.computeIfAbsent(srcParent, ignored -> new HashMap<>());
+					for (Tree dstParent : dstParents) {
+						if (candidateDstParents.contains(dstParent)) {
+							countsByDstParent.merge(dstParent, 1, Integer::sum);
+						}
+					}
+				}
+			}
+			for (Map.Entry<Tree, Set<Tree>> entry : candidateDstParentsBySrcParent.entrySet()) {
+				Tree srcParent = entry.getKey();
+				Map<Tree, Integer> countsByDstParent = commonDescendants.getOrDefault(srcParent, Collections.emptyMap());
+				Map<Tree, Double> similaritiesByDstParent = siblingsSimilarities.computeIfAbsent(srcParent, ignored -> new HashMap<>());
+				int srcDescendants = descendantSize(srcParent);
+				for (Tree dstParent : entry.getValue()) {
+					int common = countsByDstParent.getOrDefault(dstParent, 0);
+					int dstDescendants = descendantSize(dstParent);
+					similaritiesByDstParent.put(dstParent, SimilarityMetrics.diceCoefficient(common, srcDescendants, dstDescendants));
+				}
+			}
+		}
+
+		private List<Tree> relevantParents(Tree tree, Set<Tree> relevantParents) {
+			List<Tree> parents = new ArrayList<>();
+			Tree parent = tree.getParent();
+			while (parent != null) {
+				if (relevantParents.contains(parent)) {
+					parents.add(parent);
+				}
+				parent = parent.getParent();
+			}
+			return parents;
+		}
+
+		private int descendantSize(Tree tree) {
+			if (tree == null) {
+				return 0;
+			}
+			return tree.getMetrics().size - 1;
+		}
+
+		private ScoredMapping score(Tree src, Tree dst, long order) {
+			return new ScoredMapping(src, dst,
+					siblingsSimilarity(src.getParent(), dst.getParent()),
+					parentsSimilarity(src, dst),
+					parentPositionDistance(src, dst),
+					Math.abs(src.getMetrics().position - dst.getMetrics().position),
+					order);
+		}
+
+		private double siblingsSimilarity(Tree srcParent, Tree dstParent) {
+			Map<Tree, Double> similaritiesByDstParent = siblingsSimilarities.computeIfAbsent(srcParent, ignored -> new HashMap<>());
+			return similaritiesByDstParent.computeIfAbsent(dstParent, ignored -> {
+				Set<Tree> srcDescendants = srcDescendants(srcParent);
+				Set<Tree> dstDescendants = dstDescendants(dstParent);
+				int commonDescendants = 0;
+				for (Tree srcDescendant : srcDescendants) {
+					Tree dstDescendant = mappings.getDstForSrc(srcDescendant);
+					if (dstDescendant != null && dstDescendants.contains(dstDescendant)) {
+						commonDescendants++;
+					}
+				}
+				return SimilarityMetrics.diceCoefficient(commonDescendants, srcDescendants.size(), dstDescendants.size());
+			});
+		}
+
+		private Set<Tree> srcDescendants(Tree tree) {
+			if (tree == null) {
+				return Collections.emptySet();
+			}
+			return srcDescendants.computeIfAbsent(tree, ignored -> new HashSet<>(tree.getDescendants()));
+		}
+
+		private Set<Tree> dstDescendants(Tree tree) {
+			if (tree == null) {
+				return Collections.emptySet();
+			}
+			return dstDescendants.computeIfAbsent(tree, ignored -> new HashSet<>(tree.getDescendants()));
+		}
+
+		private double parentsSimilarity(Tree src, Tree dst) {
+			Tree srcParent = src.getParent();
+			Tree dstParent = dst.getParent();
+			Map<Tree, Double> similaritiesByDstParent = parentsSimilarities.computeIfAbsent(srcParent, ignored -> new HashMap<>());
+			return similaritiesByDstParent.computeIfAbsent(dstParent, ignored -> {
+				int commonParents = commonParents(srcParent, dstParent);
+				return SimilarityMetrics.diceCoefficient(commonParents, parentDepth(srcParent), parentDepth(dstParent));
+			});
+		}
+
+		private int commonParents(Tree srcParent, Tree dstParent) {
+			if (srcParent == null || dstParent == null) {
+				return 0;
+			}
+			Integer common = cachedCommonParents(srcParent, dstParent);
+			if (common == null) {
+				List<Tree> srcParents = parentChain(srcParent);
+				List<Tree> dstParents = parentChain(dstParent);
+				for (int i = srcParents.size() - 1; i >= 0; i--) {
+					Tree currentSrcParent = srcParents.get(i);
+					for (int j = dstParents.size() - 1; j >= 0; j--) {
+						Tree currentDstParent = dstParents.get(j);
+						if (cachedCommonParents(currentSrcParent, currentDstParent) != null) {
+							continue;
+						}
+						int currentCommon;
+						if (currentSrcParent.hasSameTypeAndLabel(currentDstParent)) {
+							currentCommon = 1 + commonParentsValue(currentSrcParent.getParent(), currentDstParent.getParent());
+						}
+						else {
+							currentCommon = Math.max(
+									commonParentsValue(currentSrcParent.getParent(), currentDstParent),
+									commonParentsValue(currentSrcParent, currentDstParent.getParent()));
+						}
+						cacheCommonParents(currentSrcParent, currentDstParent, currentCommon);
+					}
+				}
+				common = cachedCommonParents(srcParent, dstParent);
+			}
+			return common;
+		}
+
+		private List<Tree> parentChain(Tree tree) {
+			List<Tree> parents = new ArrayList<>();
+			Tree current = tree;
+			while (current != null) {
+				parents.add(current);
+				current = current.getParent();
+			}
+			return parents;
+		}
+
+		private Integer cachedCommonParents(Tree srcParent, Tree dstParent) {
+			Map<Tree, Integer> byDstParent = commonParents.get(srcParent);
+			return byDstParent != null ? byDstParent.get(dstParent) : null;
+		}
+
+		private int commonParentsValue(Tree srcParent, Tree dstParent) {
+			if (srcParent == null || dstParent == null) {
+				return 0;
+			}
+			Integer common = cachedCommonParents(srcParent, dstParent);
+			if (common == null) {
+				throw new IllegalStateException("Parent LCS state was not initialized");
+			}
+			return common;
+		}
+
+		private void cacheCommonParents(Tree srcParent, Tree dstParent, int common) {
+			commonParents.computeIfAbsent(srcParent, ignored -> new HashMap<>()).put(dstParent, common);
+		}
+
+		private int parentDepth(Tree tree) {
+			if (tree == null) {
+				return 0;
+			}
+			Integer depth = parentDepths.get(tree);
+			if (depth == null) {
+				List<Tree> parentChain = parentChain(tree);
+				depth = 0;
+				for (int i = parentChain.size() - 1; i >= 0; i--) {
+					depth++;
+					parentDepths.put(parentChain.get(i), depth);
+				}
+			}
+			return depth;
+		}
+
+		private double parentPositionDistance(Tree src, Tree dst) {
+			double[] srcVector = positionVector(src);
+			double[] dstVector = positionVector(dst);
+			double distance = 0;
+			for (int i = 0; i < Math.min(srcVector.length, dstVector.length); i++) {
+				double difference = srcVector[i] - dstVector[i];
+				distance += difference * difference;
+			}
+			return Math.sqrt(distance);
+		}
+
+		private double[] positionVector(Tree tree) {
+			return positionVectors.computeIfAbsent(tree, ignored -> {
+				List<Double> positions = new ArrayList<>();
+				Tree current = tree;
+				while (current != null && current.getParent() != null) {
+					Tree parent = current.getParent();
+					positions.add(parent.getChildPosition(current) / (double) parent.getChildren().size());
+					current = parent;
+				}
+				double[] vector = new double[positions.size()];
+				for (int i = 0; i < positions.size(); i++) {
+					vector[i] = positions.get(i);
+				}
+				return vector;
+			});
+		}
+	}
+
 	public static class ExtendedFullMappingComparator implements Comparator<Mapping> {
 		private final MappingComparators.FullMappingComparator fullMappingComparator;
 

--- a/src/test/java/org/refactoringminer/astDiff/tests/CustomTopDownMatcherPerformanceTest.java
+++ b/src/test/java/org/refactoringminer/astDiff/tests/CustomTopDownMatcherPerformanceTest.java
@@ -1,0 +1,97 @@
+package org.refactoringminer.astDiff.tests;
+
+import com.github.gumtreediff.matchers.Mapping;
+import com.github.gumtreediff.matchers.MappingStore;
+import com.github.gumtreediff.tree.DefaultTree;
+import com.github.gumtreediff.tree.Tree;
+import com.github.gumtreediff.tree.TreeMetricComputer;
+import com.github.gumtreediff.tree.TreeVisitor;
+import com.github.gumtreediff.tree.TypeSet;
+import org.junit.jupiter.api.Test;
+import org.refactoringminer.astDiff.matchers.vanilla.CustomTopDownMatcher;
+import org.refactoringminer.astDiff.utils.Constants;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+public class CustomTopDownMatcherPerformanceTest {
+	private static final int REPEATED_SUBTREE_COUNT = 300;
+	private static final int ORDERING_EQUIVALENCE_SUBTREE_COUNT = 60;
+
+	@Test
+	public void retainsMappingsForPathologicallyAmbiguousSubtreeGroups() {
+		List<Tree> srcRepeatedSubtrees = new ArrayList<>();
+		List<Tree> dstRepeatedSubtrees = new ArrayList<>();
+		Tree src = repeatedTree("src-root", "src-marker", srcRepeatedSubtrees);
+		Tree dst = repeatedTree("dst-root", "dst-marker", dstRepeatedSubtrees);
+		Constants javaConstants = new Constants(".java");
+
+		MappingStore mappings = assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
+				new CustomTopDownMatcher(0, javaConstants, javaConstants).match(src, dst));
+
+		assertSame(dstRepeatedSubtrees.get(0), mappings.getDstForSrc(srcRepeatedSubtrees.get(0)));
+		assertSame(dstRepeatedSubtrees.get(REPEATED_SUBTREE_COUNT - 1),
+				mappings.getDstForSrc(srcRepeatedSubtrees.get(REPEATED_SUBTREE_COUNT - 1)));
+	}
+
+	@Test
+	public void optimizedRankingMatchesOriginalComparatorRanking() {
+		List<Tree> srcRepeatedSubtrees = new ArrayList<>();
+		List<Tree> dstRepeatedSubtrees = new ArrayList<>();
+		Tree src = repeatedTree("src-root", "src-marker", srcRepeatedSubtrees, ORDERING_EQUIVALENCE_SUBTREE_COUNT);
+		Tree dst = repeatedTree("dst-root", "dst-marker", dstRepeatedSubtrees, ORDERING_EQUIVALENCE_SUBTREE_COUNT);
+		Constants javaConstants = new Constants(".java");
+
+		MappingStore optimized = new CustomTopDownMatcher(0, javaConstants, javaConstants).match(src, dst);
+		MappingStore reference = new ReferenceCustomTopDownMatcher(0, javaConstants, javaConstants).match(src, dst);
+
+		assertEquals(reference.size(), optimized.size());
+		for (Mapping mapping : reference) {
+			assertSame(mapping.second, optimized.getDstForSrc(mapping.first));
+		}
+	}
+
+	private static Tree repeatedTree(String rootLabel, String markerLabel, List<Tree> repeatedSubtrees) {
+		return repeatedTree(rootLabel, markerLabel, repeatedSubtrees, REPEATED_SUBTREE_COUNT);
+	}
+
+	private static Tree repeatedTree(String rootLabel, String markerLabel, List<Tree> repeatedSubtrees,
+									 int repeatedSubtreeCount) {
+		Tree root = tree("root", rootLabel, 0);
+		int position = 1;
+		for (int i = 0; i < repeatedSubtreeCount; i++) {
+			Tree repeated = repeatedSubtree(position);
+			root.addChild(repeated);
+			repeatedSubtrees.add(repeated);
+			position += 3;
+		}
+		root.addChild(markerSubtree(markerLabel, position));
+		TreeVisitor.visitTree(root, new TreeMetricComputer());
+		return root;
+	}
+
+	private static Tree repeatedSubtree(int position) {
+		Tree call = tree("call", "expect", position);
+		call.addChild(tree("identifier", "expect", position + 1));
+		call.addChild(tree("identifier", "env", position + 2));
+		return call;
+	}
+
+	private static Tree markerSubtree(String label, int position) {
+		Tree marker = tree("call", label, position);
+		marker.addChild(tree("identifier", label, position + 1));
+		return marker;
+	}
+
+	private static Tree tree(String type, String label, int position) {
+		DefaultTree tree = new DefaultTree(TypeSet.type(type), label);
+		tree.setPos(position);
+		tree.setLength(1);
+		return tree;
+	}
+}

--- a/src/test/java/org/refactoringminer/astDiff/tests/ReferenceCustomTopDownMatcher.java
+++ b/src/test/java/org/refactoringminer/astDiff/tests/ReferenceCustomTopDownMatcher.java
@@ -1,0 +1,51 @@
+package org.refactoringminer.astDiff.tests;
+
+import com.github.gumtreediff.matchers.Mapping;
+import com.github.gumtreediff.matchers.MultiMappingStore;
+import com.github.gumtreediff.tree.Tree;
+import org.refactoringminer.astDiff.matchers.vanilla.CustomTopDownMatcher;
+import org.refactoringminer.astDiff.utils.Constants;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class ReferenceCustomTopDownMatcher extends CustomTopDownMatcher {
+	ReferenceCustomTopDownMatcher(int minP, Constants LANG1, Constants LANG2) {
+		super(minP, LANG1, LANG2);
+	}
+
+	@Override
+	public void filterMappings(MultiMappingStore multiMappings) {
+		List<Mapping> ambiguousList = new ArrayList<>();
+		Set<Tree> ignored = new HashSet<>();
+		for (var src : multiMappings.allMappedSrcs()) {
+			var isMappingUnique = false;
+			if (multiMappings.isSrcUnique(src)) {
+				var dst = multiMappings.getDsts(src).stream().findAny().get();
+				if (multiMappings.isDstUnique(dst)) {
+					mappings.addMappingRecursively(src, dst);
+					isMappingUnique = true;
+				}
+			}
+
+			if (!(ignored.contains(src) || isMappingUnique)) {
+				var adsts = multiMappings.getDsts(src);
+				var asrcs = multiMappings.getSrcs(multiMappings.getDsts(src).iterator().next());
+				for (Tree asrc : asrcs) {
+					for (Tree adst : adsts) {
+						ambiguousList.add(new Mapping(asrc, adst));
+					}
+				}
+				ignored.addAll(asrcs);
+			}
+		}
+
+		Set<Tree> srcIgnored = new HashSet<>();
+		Set<Tree> dstIgnored = new HashSet<>();
+		ambiguousList.sort(new ExtendedFullMappingComparator(mappings));
+		// The synthetic tree avoids literal leaves, so this isolates the original comparator ranking.
+		retainBestMapping(ambiguousList, srcIgnored, dstIgnored);
+	}
+}


### PR DESCRIPTION
Fixes #1062.

## What was going wrong

The reported GitNexus case was not stuck in parsing. The slowdown happened later, while the AST diff tried to map a large repeated TypeScript test body.

`CustomTopDownMatcher.filterMappings()` adds unique subtree matches to the shared `MappingStore`. For the remaining ambiguous subtrees, it expands each ambiguity class into every possible source/destination pair, sorts those candidates with GumTree's `FullMappingComparator`, and greedily keeps the first non-conflicting mappings.

That is fine for ordinary ambiguity. It falls over when a file contains many repeated blocks. A single group with 300 matching source subtrees and 300 matching destination subtrees creates 90,000 candidate mappings. In the issue repro, one measured run had 137 ambiguous groups, 4,766,641 total candidates, and a largest group of 998 x 991 candidates. The thread dump pointed at `Collections.sort()` under `CustomTopDownMatcher.filterMappings()` and `MappingComparators$FullMappingComparator.compare()`.

## Why this fix

The first attempt used a product cap and skipped very large ambiguous groups. That made the repro fast, but it changed matcher behavior by not ranking or retaining candidates from those groups. This PR avoids that tradeoff.

The matcher still considers the full ambiguous candidate set. It still adds all unique mappings before scoring ambiguous candidates, which matters because GumTree's sibling similarity depends on the current `MappingStore` snapshot. It also keeps the same greedy retention step.

The optimization is in how the ranking keys are computed:

- sibling similarity is now precomputed in bulk for relevant parent pairs by counting already-mapped descendants from the current `MappingStore`
- parent similarity uses the same LCS-over-ancestor-chain definition, but memoizes the recurrence over parent pairs instead of rebuilding ancestor lists and running the generic LCS for every candidate pair
- descendant counts use the existing tree metrics, so the bulk sibling scorer does not allocate descendant sets just to get sizes
- candidate objects still store the exact ranking keys used by the comparator, and sorting still uses the same order

The resulting order is the same as the previous `ExtendedFullMappingComparator` path:

- sibling Dice similarity over already-mapped descendants
- parent LCS Dice similarity
- position-in-parent vector distance
- absolute `TreeMetrics.position` distance
- source and destination offset tie-breakers
- original candidate order for stable ties

This is still an exact ranking pass, not a heuristic pruning pass. The code avoids repeated work in the comparator without dropping any ambiguous mappings.

## Test coverage

`CustomTopDownMatcherPerformanceTest` builds synthetic trees with repeated identical subtrees on each side. That creates the same kind of ambiguous cross product that triggered the issue. The test asserts that the matcher completes within the timeout and still maps repeated subtrees.

The test class also includes a smaller equivalence check against a reference matcher that uses the original `ExtendedFullMappingComparator` path. That guards the optimized scorer against changing the greedy ranking result on an ambiguous input.
