### PR TITLE
Redesign MCP diff tool surface

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ The Docker image can also run RefactoringMiner's stdio MCP server. This keeps MC
 docker run --rm -i --pull always -e OAuthToken=$OAuthToken tsantalis/refactoringminer:latest mcp
 ```
 
-For local worktree or commit tools, mount the repository into the container:
+For the default `refactoringminer_diff` worktree mode, mount the repository into the container and set it as the working directory:
 
 ```terminal
 docker run --rm -i \
@@ -37,7 +37,7 @@ docker run --rm -i \
   tsantalis/refactoringminer:latest mcp
 ```
 
-For MCP AST diff browser tools, also publish the WebDiff port:
+For MCP AST diff browser use, also publish the WebDiff port:
 
 ```terminal
 docker run --rm -i \
@@ -48,6 +48,8 @@ docker run --rm -i \
   -e OAuthToken=$OAuthToken \
   tsantalis/refactoringminer:latest mcp
 ```
+
+The MCP tools do not accept host repository paths. Mount the desired repository and start the MCP process from the container working directory that should be analyzed, usually `/workspace`. To work with multiple repositories in the same container, mount their common parent directory and use relative `source.workingDirectory` values for local worktree and commit sources.
 
 The Docker image binds WebDiff inside the container to `0.0.0.0`, but returned links still use `http://127.0.0.1:<port>` for the host browser. Override these only if your Docker setup needs a different address:
 

--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -1,6 +1,6 @@
 # RefactoringMiner MCP server
 
-RefactoringMiner can also run as a local stdio MCP server. Coding agents can ask it for detected refactorings, intent checks, and local AST diff pages. Results come back as small JSON objects built from the existing RefactoringMiner APIs.
+RefactoringMiner can also run as a local stdio MCP server. It exposes three read-only tools grouped by task: `refactoringminer_analyze`, `refactoringminer_validate`, and `refactoringminer_diff`. Each tool accepts a `source` object so agents choose what they are analyzing without choosing among many near-duplicate tools. `source.type` may be explicit, or inferred when fields such as `pullRequestId`, `url`, `commitId`, `beforeFiles`, or `beforePath` make the source clear.
 
 ## Build
 
@@ -82,10 +82,10 @@ Claude Code can load the same file:
 
 ```bash
 claude -p --mcp-config .mcp.json --strict-mcp-config \
-  "Use RefactoringMiner to validate whether my current worktree contains the Rename Method refactoring I intended."
+  "Use RefactoringMiner to analyze my current worktree and report detected refactorings."
 ```
 
-One-shot `claude -p` calls work well for analysis and validation tools that only return JSON. For AST diff browser tools, use an interactive Claude Code session so the MCP process, and the local WebDiff server it started, stays alive while you open the returned URL:
+`refactoringminer_diff` starts a local WebDiff server. Use an interactive client session when you want to open the returned URL, because the URL is only available while the MCP process remains alive:
 
 ```bash
 claude --mcp-config .mcp.json --strict-mcp-config
@@ -94,7 +94,7 @@ claude --mcp-config .mcp.json --strict-mcp-config
 Then ask Claude Code to call a browser tool, for example:
 
 ```text
-Call refactoringminer_diff_worktree with baseRef "HEAD", includeUntracked false, port 6789. Return only the URL and keep this session open.
+Call refactoringminer_diff with source type "worktree", baseRef "HEAD", includeUntracked false, and port 6789. Return only the URL and keep this session open.
 ```
 
 ## Docker
@@ -129,6 +129,35 @@ Use the provided [wrapper script template](../scripts/mcp-wrapper-template.sh). 
    }
    ```
 
+The wrapper should mount the target repository into the container and start the MCP process from that mounted directory. With `source.type: "worktree"`, the MCP tools use the MCP server working directory, so Docker setups should mount the desired project and set the container working directory instead of passing host paths.
+
+To work with multiple repositories in the same long-running container, mount their common parent directory and start the MCP process from that parent. Then pass a relative `source.workingDirectory` such as `repo-a` or `team/repo-b` for local worktree and commit sources.
+
+For a direct Docker command, use:
+
+```bash
+docker run --rm -i \
+  --pull always \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+For AST diff browser use, also publish the WebDiff port:
+
+```bash
+docker run --rm -i \
+  --pull always \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  -p 6789:6789 \
+  -e OAuthToken=$OAuthToken \
+  tsantalis/refactoringminer:latest mcp
+```
+
+The Docker image sets `REFACTORINGMINER_WEBDIFF_BIND_HOST=0.0.0.0` so the published port is reachable from the host. The URL returned to the user still uses `127.0.0.1`.
+
 ### Windows
 
 For Windows, you can use a lighter functional config directly in your MCP client configuration without needing a wrapper script:
@@ -149,7 +178,7 @@ For Windows, you can use a lighter functional config directly in your MCP client
 ```
 Replace `C:/absolute/path/to/your/repo` and `%OAuthToken%` with your actual path and token.
 
-When using the Docker setup, any tool that requires a `repositoryPath` should use the container path (usually `/workspace`), not the host path.
+The MCP tools do not accept `repositoryPath`. Mount the desired repository and start the MCP process from the container working directory that should be analyzed, usually `/workspace`.
 
 Outside Docker, WebDiff binds to `127.0.0.1` by default. These settings can be overridden with environment variables or JVM system properties:
 
@@ -158,81 +187,34 @@ Outside Docker, WebDiff binds to `127.0.0.1` by default. These settings can be o
 | WebDiff bind host | `REFACTORINGMINER_WEBDIFF_BIND_HOST` | `refactoringminer.webdiff.bindHost` | `127.0.0.1` |
 | Returned URL host | `REFACTORINGMINER_WEBDIFF_PUBLIC_HOST` | `refactoringminer.webdiff.publicHost` | `127.0.0.1` |
 
-## Analysis tools
+## Tools
 
-Analysis tools report the refactorings RefactoringMiner detects. They return `status`, `summary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `refactorings` list, and `warnings`.
+The MCP surface has three tools:
 
-| Tool | Required inputs | Optional inputs |
-|------|-----------------|-----------------|
-| `refactoringminer_analyze_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
-| `refactoringminer_analyze_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxRefactorings` |
-| `refactoringminer_analyze_commit` | `commitId` | `repositoryPath`, `parentIndex`, `maxRefactorings` |
-| `refactoringminer_analyze_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `maxRefactorings` |
-| `refactoringminer_analyze_directories` | `beforePath`, `afterPath` | `maxRefactorings` |
+| Tool | Purpose |
+|------|---------|
+| `refactoringminer_analyze` | Detect refactorings from a source and return JSON for the agent. |
+| `refactoringminer_validate` | Check whether detected refactorings from a source match an intended refactoring. |
+| `refactoringminer_diff` | Start a local WebDiff page for a source and return the browser URL plus compact JSON. |
 
-Local paths must be absolute when provided. Worktree and commit tools default `repositoryPath` to the MCP server working directory, which is usually the directory where the agent was started. File-content maps use repository-relative paths as keys and file contents as values. Explicit file-content tools default to `maxFiles=100` and `maxBytesPerFile=200000` to keep calls small. Analysis tools default to `maxRefactorings=20`; set a higher value when the agent needs more returned detail, or `0` when counts and warnings are enough.
+All three tools accept a `source` object. If `source` is omitted, it defaults to `{ "type": "worktree" }`. If `source.type` is omitted, the server infers it from unambiguous fields: `url` selects `url`, `pullRequestId` or `cloneUrl` selects `pullRequest`, `commitId` selects `commit`, `beforeFiles` or `afterFiles` selects `fileContents`, and `beforePath` or `afterPath` selects `directories`.
 
-Commit tools first try the GitHub API when the working tree has a GitHub `origin` remote. If the commit is not available from GitHub, they fall back to the local repository. This keeps pushed commits small for MCP clients while still supporting local-only commits.
+| `source.type` | Supported by | Source fields |
+|---------------|--------------|---------------|
+| `worktree` | analyze, validate, diff | `workingDirectory`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile` |
+| `fileContents` | analyze, validate, diff | `beforeFiles`, `afterFiles`, `maxFiles`, `maxBytesPerFile` |
+| `commit` | analyze, validate, diff | `workingDirectory`, `commitId`, `parentIndex` |
+| `pullRequest` | analyze, validate, diff | `cloneUrl`, `pullRequestId`, `timeoutSeconds` |
+| `directories` | analyze, validate | `beforePath`, `afterPath` |
+| `url` | diff | `url`, `parentIndex`, `timeoutSeconds` |
 
-Pull-request tools also default `cloneUrl` from the MCP server working directory's GitHub `origin` remote. In a Docker config that mounts the repository at `/workspace` and starts the MCP process with `-w /workspace`, agents can usually pass only `pullRequestId`. Keep using an explicit `cloneUrl` when the MCP server is launched outside the target repository, or when the PR belongs to a different repository than the current working directory.
+The MCP tools do not accept `repositoryPath`. For local worktree and commit sources, start the MCP server in the target repository, or pass `source.workingDirectory` as a relative path under the MCP server working directory. Absolute paths and paths that escape the MCP server working directory are rejected.
 
-## Intent validation tools
+`refactoringminer_analyze` accepts `source` and `maxRefactorings`. Its result contains `status`, `summary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `refactorings` list, and `warnings`.
 
-Validation tools let an agent state the refactoring it intended and ask RefactoringMiner whether the detected refactorings match. Validation returns `status`, `summary`, `intent`, `refactoringCount`, `candidateCount`, limited `matches`, limited `candidates`, and `warnings`.
+`refactoringminer_validate` accepts `source`, `intent`, and `maxCandidates`. Validation results contain `status`, `summary`, `intent`, `refactoringCount`, `candidateCount`, limited `matches`, limited `candidates`, and `warnings`.
 
-| Tool | Required inputs | Optional inputs |
-|------|-----------------|-----------------|
-| `refactoringminer_validate_file_contents` | `beforeFiles`, `afterFiles`, `intent` | `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
-| `refactoringminer_validate_worktree` | `intent` | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `maxCandidates` |
-| `refactoringminer_validate_commit` | `commitId`, `intent` | `repositoryPath`, `parentIndex`, `maxCandidates` |
-| `refactoringminer_validate_pull_request` | `pullRequestId`, `intent` | `cloneUrl`, `timeoutSeconds`, `maxCandidates` |
-| `refactoringminer_validate_directories` | `beforePath`, `afterPath`, `intent` | `maxCandidates` |
-
-Validation tools default to `maxCandidates=20`. This only limits what comes back to the MCP client; it does not change the RefactoringMiner detection pass.
-
-The `intent` object has one required field:
-
-```json
-{
-  "type": "Rename Method"
-}
-```
-
-It can also include optional filters:
-
-```json
-{
-  "type": "Rename Method",
-  "beforeFilePaths": ["src/main/java/example/Worker.java"],
-  "afterFilePaths": ["src/main/java/example/Worker.java"],
-  "classNames": ["Worker"],
-  "methodNames": ["calculateTotal"],
-  "fieldNames": [],
-  "descriptionContains": "computeTotal"
-}
-```
-
-Verdicts:
-
-| Status | Meaning |
-|--------|---------|
-| `matched` | Exactly one detected refactoring matched the requested type and filters. |
-| `missing` | RefactoringMiner found no matching refactoring; same-type candidates may be returned for inspection. |
-| `ambiguous` | More than one detected refactoring matched, so the agent should refine the intent filters before claiming success. |
-| `error` | Inputs were invalid or analysis failed. |
-
-Use `maxCandidates` to limit returned matches and candidates. If the result is truncated, it includes a warning.
-
-## AST diff browser tools
-
-Diff browser tools generate a RefactoringMiner AST diff, start the existing local WebDiff server, and return a localhost URL that the user can open in a browser. They return `status`, `summary`, `message`, `url`, `port`, `inputSummary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `affectedFiles` list, and `warnings`.
-
-| Tool | Required inputs | Optional inputs |
-|------|-----------------|-----------------|
-| `refactoringminer_diff_file_contents` | `beforeFiles`, `afterFiles` | `maxFiles`, `maxBytesPerFile`, `port` |
-| `refactoringminer_diff_worktree` | None | `repositoryPath`, `baseRef`, `includeUntracked`, `maxFiles`, `maxBytesPerFile`, `port` |
-| `refactoringminer_diff_commit` | `commitId` | `repositoryPath`, `parentIndex`, `port` |
-| `refactoringminer_diff_pull_request` | `pullRequestId` | `cloneUrl`, `timeoutSeconds`, `port` |
+`refactoringminer_diff` accepts `source`, `port`, and `maxRefactorings`. Its result contains `status`, `summary`, `message`, `url`, `port`, `inputSummary`, `refactoringCount`, `astDiffCount`, `moveAstDiffCount`, `filesBefore`, `filesAfter`, a limited `refactorings` list, a limited `affectedFiles` list, and `warnings`.
 
 The default port is `6789`. The returned `message` uses the same wording as the WebDiff CLI startup line:
 
@@ -244,107 +226,95 @@ MCP tools do not auto-open the desktop browser. They bind WebDiff to `127.0.0.1`
 
 The returned URL is only available while the MCP server process is still running. If an MCP client starts RefactoringMiner for a single command and immediately exits, the local WebDiff server can disappear before the user opens the URL. Use an interactive client session for browser tools, or use the direct WebDiff CLI when the goal is only manual browser inspection.
 
-Repeated browser-tool calls replace the active local WebDiff view in the MCP server process. MCP-managed WebDiff pages hide the WebDiff Quit button so the MCP server can keep serving later browser-tool calls. If the requested port is invalid or already occupied by another process, the tool returns an `error` result with a summary and warnings. Each new browser view terminates the previous one, regardless of whether they use the same port.
+Repeated calls replace the active local WebDiff view in the MCP server process. MCP-managed WebDiff pages hide the WebDiff Quit button so the MCP server can keep serving later calls. If the requested port is invalid or already occupied by another process, the tool returns an `error` result with a summary and warnings.
 
-Example file-content browser request:
+Example analyze request:
 
 ```json
 {
-  "beforeFiles": {
-    "src/main/java/example/Worker.java": "package example; class Worker { void computeTotal() {} }"
+  "source": {
+    "type": "worktree",
+    "workingDirectory": "repo-a",
+    "baseRef": "HEAD",
+    "includeUntracked": false
   },
-  "afterFiles": {
-    "src/main/java/example/Worker.java": "package example; class Worker { void calculateTotal() {} }"
-  },
-  "port": 6789
+  "maxRefactorings": 20
 }
 ```
 
-Example worktree browser request:
+Example validation request:
 
 ```json
 {
-  "baseRef": "HEAD",
-  "includeUntracked": false,
-  "port": 6789
-}
-```
-
-Example commit browser request:
-
-```json
-{
-  "commitId": "abc123",
-  "parentIndex": 0,
-  "port": 6789
-}
-```
-
-Example pull-request browser request:
-
-```json
-{
-  "pullRequestId": 1234,
-  "timeoutSeconds": 300,
-  "port": 6789
-}
-```
-
-Add `cloneUrl` to the request when the MCP process is not running from the repository that owns the pull request.
-
-## Example validation request
-
-For generic MCP clients, call `refactoringminer_validate_file_contents` with arguments like:
-
-```json
-{
-  "beforeFiles": {
-    "src/main/java/example/Worker.java": "class Worker { void computeTotal() {} }"
-  },
-  "afterFiles": {
-    "src/main/java/example/Worker.java": "class Worker { void calculateTotal() {} }"
+  "source": {
+    "type": "fileContents",
+    "beforeFiles": {
+      "src/main/java/example/Worker.java": "package example; class Worker { void computeTotal() {} }"
+    },
+    "afterFiles": {
+      "src/main/java/example/Worker.java": "package example; class Worker { void calculateTotal() {} }"
+    }
   },
   "intent": {
     "type": "Rename Method",
     "methodNames": ["calculateTotal"]
-  },
-  "maxCandidates": 5
+  }
 }
 ```
 
-For file-content validation, provide complete parseable Java compilation units when possible. Small snippets that are not valid source files may still be accepted by the protocol but can produce `missing` because RefactoringMiner has no complete model to compare.
+Example URL browser request:
 
-## Example agent prompts
+```json
+{
+  "source": {
+    "type": "url",
+    "url": "https://github.com/tsantalis/RefactoringMiner/pull/1234",
+    "timeoutSeconds": 300
+  },
+  "port": 6789
+}
+```
+
+Example pull-request browser request with inferred source type:
+
+```json
+{
+  "source": {
+    "cloneUrl": "https://github.com/tsantalis/RefactoringMiner.git",
+    "pullRequestId": 1055
+  },
+  "port": 6789
+}
+```
+
+## Example Agent Prompts
 
 Claude Code:
 
-- "Use the RefactoringMiner MCP server to validate that my current worktree in `/path/to/repo` contains the intended `Rename Method` refactoring. Use `HEAD` as the base ref and return the validation status, summary, matches, candidates, and warnings."
-- "Use `refactoringminer_validate_file_contents` with these before/after Java file contents and intent `{ \"type\": \"Extract Method\", \"methodNames\": [\"parseItems\"] }`. Do not infer behavior preservation from the result."
+- "Use the RefactoringMiner MCP server to analyze my current worktree against `HEAD` and report detected refactorings."
+- "Use `refactoringminer_diff` with a URL source for `https://github.com/tsantalis/RefactoringMiner/pull/1234` and return the startup message and URL."
 
 Codex:
 
-- "Use the configured RefactoringMiner MCP server to validate whether this edit structurally matches my intended `Move Class` refactoring. If the result is `ambiguous`, list the candidate evidence and ask me for a narrower filter."
-- "Before writing the final answer, call RefactoringMiner validation on the changed worktree and report whether the intended refactoring was `matched`, `missing`, or `ambiguous`."
+- "Before writing the final answer, call `refactoringminer_analyze` on the changed worktree and report the detected refactorings."
+- "Call `refactoringminer_diff` with this commit URL as a URL source and `maxRefactorings: 0`; use the counts and warnings only."
 
 Generic MCP clients:
 
-- "Call `refactoringminer_validate_commit` for commit `abc123` with intent `{ \"type\": \"Rename Class\", \"classNames\": [\"OrderService\"] }`."
-- "Call `refactoringminer_validate_pull_request` for PR 1234 with intent `{ \"type\": \"Move Method\", \"methodNames\": [\"detect\"] }`."
-- "Call `refactoringminer_validate_directories` for `/path/to/before` and `/path/to/after` with intent `{ \"type\": \"Extract Method\" }`."
-- "Call `refactoringminer_diff_worktree` and return the local URL."
-- "Call `refactoringminer_diff_pull_request` for PR 1234 and return the startup message and URL."
+- "Call `refactoringminer_analyze` with `{ \"source\": { \"type\": \"worktree\", \"baseRef\": \"HEAD\", \"includeUntracked\": false } }`."
+- "Call `refactoringminer_diff` with `{ \"source\": { \"type\": \"url\", \"url\": \"https://github.com/owner/repo/commit/abc123\", \"parentIndex\": 1 } }`."
 
-## GitHub pull requests
+## GitHub URLs
 
-Pull-request analysis and validation read GitHub data through the existing RefactoringMiner GitHub API path. For private repositories or higher rate limits, provide an OAuth token with one of these mechanisms:
+GitHub pull-request, commit, and URL sources read GitHub data through the existing RefactoringMiner GitHub API path. For private repositories or higher rate limits, provide an OAuth token with one of these mechanisms:
 
 - Environment variable: `OAuthToken`
 - JVM system property: `-DOAuthToken=...`
 - `github-oauth.properties` in the MCP process working directory with `OAuthToken=...`
 
-The MCP tool only reads pull-request data. It does not post comments, mark files viewed, edit pull requests, or change repository state.
+The MCP tools only read GitHub data. They do not post comments, mark files viewed, edit pull requests, or change repository state.
 
-Use a GitHub number that identifies a pull request, not a plain issue. If `cloneUrl` is omitted, the MCP server reads the GitHub `origin` remote from its working directory. If there is no GitHub `origin`, pass `cloneUrl` explicitly. For pull-request diff browser tools, the returned WebDiff URL is local to the machine running the MCP server. It is not a hosted report link.
+For `refactoringminer_diff`, pass a GitHub pull-request URL or commit URL as `source.url` with `source.type: "url"`. Plain issue URLs are not supported. The returned WebDiff URL is local to the machine running the MCP server. It is not a hosted report link.
 
 ## What the server does not do
 
@@ -355,18 +325,17 @@ The MCP server is read-only.
 - It does not post GitHub comments or mutate pull requests.
 - It does not run an external LLM.
 - It does not host an HTTP MCP server.
-- It does not auto-open the desktop browser from diff-browser tools.
+- It does not auto-open the desktop browser from MCP tools.
 
-Intent validation is not a behavior-preservation proof. A `matched` result means RefactoringMiner found a refactoring with the requested type and filters. It does not prove tests pass, specifications still hold, side effects are unchanged, or the edit contains no non-refactoring behavior changes.
+Detected refactorings are not a behavior-preservation proof. They do not prove tests pass, specifications still hold, side effects are unchanged, or the edit contains no non-refactoring behavior changes.
 
-Use tests, review, specifications, or domain-specific checks alongside MCP results. PurityChecker may be useful for the refactoring types it supports, but MCP validation does not run PurityChecker in this release.
+Use tests, review, specifications, or domain-specific checks alongside MCP results.
 
 This release does not include GitHub Action comments, static hosted HTML reports, hosted HTTP MCP, write tools, commit-range MCP analysis, large artifact or resource streaming, or PurityChecker-backed validation results.
 
 ## Troubleshooting
 
 - If a returned WebDiff URL refuses the connection, confirm the MCP client session that started it is still running. For manual inspection, use the direct `diff` CLI instead.
-- If port `6789` is already in use, call the MCP browser tool with another `port` value, or stop the existing local WebDiff process.
-- If Docker-based worktree or commit tools use the wrong repository, set `-w /workspace` in the Docker command or pass `repositoryPath: "/workspace"` explicitly. The MCP server cannot resolve host paths from inside the container.
-- If pull-request tools fail on a private repository or after many calls, configure `OAuthToken` through the environment, JVM system property, or `github-oauth.properties`.
-- If file-content validation returns `missing` for tiny snippets, retry with complete parseable Java compilation units so RefactoringMiner can build a full model.
+- If port `6789` is already in use, call `refactoringminer_diff` with another `port` value, or stop the existing local WebDiff process.
+- If Docker-based worktree sources use the wrong repository, mount the desired project and set `-w /workspace` in the Docker command. For multiple repositories, mount a common parent and use relative `source.workingDirectory`. The MCP tools cannot resolve host paths from inside the container.
+- If URL diffs fail on a private repository or after many calls, configure `OAuthToken` through the environment, JVM system property, or `github-oauth.properties`.

--- a/scripts/mcp-wrapper-template.sh
+++ b/scripts/mcp-wrapper-template.sh
@@ -10,11 +10,12 @@ CONTAINER_NAME="refactoringminer-server"
 PORT_MAPPING="6785-6795:6785-6795"
 
 # Path on host to mount inside the container. Use absolute path.
-# This is the repository you want the MCP server to analyze.
+# This can be one repository or a common parent directory containing multiple repositories.
 HOST_VOLUME_PATH="/absolute/path/to/your/repository"
 
 # Path inside the container. Usually /workspace.
-# When using tools, use this path as 'repositoryPath' instead of the host path.
+# For multiple repositories under HOST_VOLUME_PATH, use the MCP source.workingDirectory
+# field as a relative path under this directory.
 CONTAINER_WORKDIR="/workspace"
 
 # Your GitHub OAuth token for private repos and higher rate limits.

--- a/src/main/java/org/refactoringminer/mcp/DiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/DiffBrowserLauncher.java
@@ -6,5 +6,6 @@ import org.refactoringminer.astDiff.models.ProjectASTDiff;
 
 @FunctionalInterface
 interface DiffBrowserLauncher {
-	McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary, List<String> warnings) throws Exception;
+	McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary, List<String> warnings,
+			int maxRefactorings) throws Exception;
 }

--- a/src/main/java/org/refactoringminer/mcp/McpDiffBrowserResult.java
+++ b/src/main/java/org/refactoringminer/mcp/McpDiffBrowserResult.java
@@ -13,26 +13,43 @@ import org.refactoringminer.astDiff.models.ProjectASTDiff;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record McpDiffBrowserResult(String status, String summary, String message, String url, Integer port,
-		String inputSummary, int refactoringCount, int astDiffCount, int moveAstDiffCount, int filesBefore,
-		int filesAfter, List<String> affectedFiles, List<String> warnings) {
+			String inputSummary, int refactoringCount, int astDiffCount, int moveAstDiffCount, int filesBefore,
+			int filesAfter, List<McpRefactoringResult> refactorings, List<String> affectedFiles, List<String> warnings) {
 	private static final int MAX_AFFECTED_FILES = 50;
+	private static final int DEFAULT_MAX_REFACTORINGS = 20;
 
 	public static final String OK = "ok";
 	public static final String ERROR = "error";
 
 	public McpDiffBrowserResult {
+		refactorings = refactorings == null ? Collections.emptyList() : List.copyOf(refactorings);
 		affectedFiles = affectedFiles == null ? Collections.emptyList() : List.copyOf(affectedFiles);
 		warnings = warnings == null ? Collections.emptyList() : List.copyOf(warnings);
 	}
 
 	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String inputSummary,
 			List<String> additionalWarnings) {
-		return ok(diff, port, WebDiff.LOCAL_HOST, inputSummary, additionalWarnings);
+		return ok(diff, port, WebDiff.LOCAL_HOST, inputSummary, additionalWarnings, DEFAULT_MAX_REFACTORINGS);
+	}
+
+	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String inputSummary,
+			List<String> additionalWarnings, int maxRefactorings) {
+		return ok(diff, port, WebDiff.LOCAL_HOST, inputSummary, additionalWarnings, maxRefactorings);
 	}
 
 	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String publicHost, String inputSummary,
 			List<String> additionalWarnings) {
+		return ok(diff, port, publicHost, inputSummary, additionalWarnings, DEFAULT_MAX_REFACTORINGS);
+	}
+
+	public static McpDiffBrowserResult ok(ProjectASTDiff diff, int port, String publicHost, String inputSummary,
+			List<String> additionalWarnings, int maxRefactorings) {
 		List<Refactoring> refactorings = diff.getRefactorings() == null ? Collections.emptyList() : diff.getRefactorings();
+		int boundedSize = Math.min(refactorings.size(), maxRefactorings);
+		List<McpRefactoringResult> boundedRefactorings = new ArrayList<>();
+		for (int i = 0; i < boundedSize; i++) {
+			boundedRefactorings.add(McpRefactoringResult.from(refactorings.get(i)));
+		}
 		int astDiffCount = diff.getDiffSet() == null ? 0 : diff.getDiffSet().size();
 		int moveAstDiffCount = diff.getMoveDiffSet() == null ? 0 : diff.getMoveDiffSet().size();
 		int filesBefore = diff.getFileContentsBefore() == null ? 0 : diff.getFileContentsBefore().size();
@@ -42,18 +59,22 @@ public record McpDiffBrowserResult(String status, String summary, String message
 		if (additionalWarnings != null) {
 			warnings.addAll(additionalWarnings);
 		}
+		if (boundedSize < refactorings.size()) {
+			warnings.add(String.format("Refactorings truncated to %d of %d.", boundedSize, refactorings.size()));
+		}
 		List<String> affectedFiles = affectedFiles(diff, warnings);
 		String url = WebDiff.localUrl(publicHost, port);
 		String summary = String.format("Started local AST diff browser with %d refactorings, %d AST diffs, %d moved AST diffs across %d before files and %d after files.",
 				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter);
 
 		return new McpDiffBrowserResult(OK, summary, WebDiff.startupMessage(publicHost, port), url, port, inputSummary,
-				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter, affectedFiles, warnings);
+				refactorings.size(), astDiffCount, moveAstDiffCount, filesBefore, filesAfter, boundedRefactorings,
+				affectedFiles, warnings);
 	}
 
 	public static McpDiffBrowserResult error(String summary, Integer port, String inputSummary, List<String> warnings) {
 		return new McpDiffBrowserResult(ERROR, summary, null, null, port, inputSummary, 0, 0, 0, 0, 0,
-				Collections.emptyList(), warnings);
+				Collections.emptyList(), Collections.emptyList(), warnings);
 	}
 
 	private static List<String> affectedFiles(ProjectASTDiff diff, List<String> warnings) {

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpServer.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpServer.java
@@ -39,7 +39,7 @@ public final class RefactoringMinerMcpServer {
 	}
 
 	private static boolean isSmoke(String[] args) {
-		return args.length == 1 && Arrays.asList(args).contains(SMOKE_ARG);
+		return Arrays.asList(args).contains(SMOKE_ARG);
 	}
 
 	private static String version() {

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpService.java
@@ -12,10 +12,12 @@ import java.util.Set;
 import org.eclipse.jgit.lib.Repository;
 import org.refactoringminer.api.GitHistoryRefactoringMiner;
 import org.refactoringminer.astDiff.models.ProjectASTDiff;
+import org.refactoringminer.astDiff.utils.URLHelper;
 import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
 import org.refactoringminer.util.GitServiceImpl;
 
 public class RefactoringMinerMcpService {
+	private static final int DEFAULT_MAX_REFACTORINGS = 20;
 	private static final int DEFAULT_MAX_FILES = 100;
 	private static final int DEFAULT_MAX_BYTES_PER_FILE = 200_000;
 
@@ -345,11 +347,21 @@ public class RefactoringMinerMcpService {
 
 	public McpDiffBrowserResult diffFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
 			int port) {
-		return diffFileContents(beforeFiles, afterFiles, port, DEFAULT_MAX_FILES, DEFAULT_MAX_BYTES_PER_FILE);
+		return diffFileContents(beforeFiles, afterFiles, port, DEFAULT_MAX_FILES, DEFAULT_MAX_BYTES_PER_FILE,
+				DEFAULT_MAX_REFACTORINGS);
 	}
 
 	public McpDiffBrowserResult diffFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
 			int port, int maxFiles, int maxBytesPerFile) {
+		return diffFileContents(beforeFiles, afterFiles, port, maxFiles, maxBytesPerFile, DEFAULT_MAX_REFACTORINGS);
+	}
+
+	public McpDiffBrowserResult diffFileContents(Map<String, String> beforeFiles, Map<String, String> afterFiles,
+			int port, int maxFiles, int maxBytesPerFile, int maxRefactorings) {
+		if (maxRefactorings < 0) {
+			return McpDiffBrowserResult.error("maxRefactorings must be greater than or equal to 0.", port,
+					"Explicit file contents", List.of("maxRefactorings=" + maxRefactorings));
+		}
 		if (beforeFiles == null || afterFiles == null) {
 			return McpDiffBrowserResult.error("beforeFiles and afterFiles are required.", port,
 					"Explicit file contents",
@@ -370,7 +382,7 @@ public class RefactoringMinerMcpService {
 				beforeFiles.size(), afterFiles.size());
 		try {
 			ProjectASTDiff diff = differ.diffAtFileContents(beforeFiles, afterFiles);
-			return launchDiffBrowser(diff, port, inputSummary, List.of());
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxRefactorings);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("File-content diff browser failed: " + e.getMessage(), port,
 					inputSummary, List.of(e.getClass().getName()));
@@ -379,6 +391,16 @@ public class RefactoringMinerMcpService {
 
 	public McpDiffBrowserResult diffWorktree(Path repositoryPath, String baseRef, boolean includeUntracked,
 			int maxFiles, int maxBytesPerFile, int port) {
+		return diffWorktree(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile, port,
+				DEFAULT_MAX_REFACTORINGS);
+	}
+
+	public McpDiffBrowserResult diffWorktree(Path repositoryPath, String baseRef, boolean includeUntracked,
+			int maxFiles, int maxBytesPerFile, int port, int maxRefactorings) {
+		if (maxRefactorings < 0) {
+			return McpDiffBrowserResult.error("maxRefactorings must be greater than or equal to 0.", port,
+					"Worktree changes", List.of("maxRefactorings=" + maxRefactorings));
+		}
 		String resolvedBaseRef = baseRef == null || baseRef.isBlank() ? "HEAD" : baseRef;
 		Path resolvedRepositoryPath = resolveRepositoryPath(repositoryPath);
 		String inputSummary = "Worktree changes in " + resolvedRepositoryPath + " against " + resolvedBaseRef + ".";
@@ -386,7 +408,7 @@ public class RefactoringMinerMcpService {
 			WorktreeChangeCollector.WorktreeChanges changes = new WorktreeChangeCollector()
 					.collect(resolvedRepositoryPath, resolvedBaseRef, includeUntracked, maxFiles, maxBytesPerFile);
 			ProjectASTDiff diff = differ.diffAtFileContents(changes.beforeFiles(), changes.afterFiles());
-			return launchDiffBrowser(diff, port, inputSummary, changes.warnings());
+			return launchDiffBrowser(diff, port, inputSummary, changes.warnings(), maxRefactorings);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Worktree diff browser failed: " + e.getMessage(), port,
 					inputSummary, List.of(e.getClass().getName()));
@@ -394,6 +416,15 @@ public class RefactoringMinerMcpService {
 	}
 
 	public McpDiffBrowserResult diffCommit(Path repositoryPath, String commitId, Integer parentIndex, int port) {
+		return diffCommit(repositoryPath, commitId, parentIndex, port, DEFAULT_MAX_REFACTORINGS);
+	}
+
+	public McpDiffBrowserResult diffCommit(Path repositoryPath, String commitId, Integer parentIndex, int port,
+			int maxRefactorings) {
+		if (maxRefactorings < 0) {
+			return McpDiffBrowserResult.error("maxRefactorings must be greater than or equal to 0.", port,
+					"Commit diff", List.of("maxRefactorings=" + maxRefactorings));
+		}
 		if (commitId == null || commitId.isBlank()) {
 			return McpDiffBrowserResult.error("commitId must be a non-empty string.", port, "Commit diff",
 					List.of("commitId is required."));
@@ -411,7 +442,7 @@ public class RefactoringMinerMcpService {
 			inputSummary = String.format("Commit %s in %s against parent index %d.", commitId, resolvedRepositoryPath,
 					resolvedParentIndex);
 			ProjectASTDiff diff = diffCommit(resolvedRepositoryPath, commitId, resolvedParentIndex, 300);
-			return launchDiffBrowser(diff, port, inputSummary, List.of());
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxRefactorings);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Commit diff browser failed: " + e.getMessage(), port, inputSummary,
 					List.of(e.getClass().getName()));
@@ -419,6 +450,15 @@ public class RefactoringMinerMcpService {
 	}
 
 	public McpDiffBrowserResult diffPullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds, int port) {
+		return diffPullRequest(cloneUrl, pullRequestId, timeoutSeconds, port, DEFAULT_MAX_REFACTORINGS);
+	}
+
+	public McpDiffBrowserResult diffPullRequest(String cloneUrl, int pullRequestId, int timeoutSeconds, int port,
+			int maxRefactorings) {
+		if (maxRefactorings < 0) {
+			return McpDiffBrowserResult.error("maxRefactorings must be greater than or equal to 0.", port,
+					"Pull-request diff", List.of("maxRefactorings=" + maxRefactorings));
+		}
 		if (pullRequestId <= 0) {
 			return McpDiffBrowserResult.error("pullRequestId must be greater than 0.", port, "Pull-request diff",
 					List.of("pullRequestId=" + pullRequestId));
@@ -440,9 +480,60 @@ public class RefactoringMinerMcpService {
 		inputSummary = String.format("Pull request #%d in %s.", pullRequestId, resolvedCloneUrl);
 		try {
 			ProjectASTDiff diff = pullRequestDiffer.diffAtPullRequest(resolvedCloneUrl, pullRequestId, timeoutSeconds);
-			return launchDiffBrowser(diff, port, inputSummary, List.of());
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxRefactorings);
 		} catch (Exception e) {
 			return McpDiffBrowserResult.error("Pull-request diff browser failed: " + e.getMessage(), port,
+					inputSummary, List.of(e.getClass().getName()));
+		}
+	}
+
+	public McpDiffBrowserResult diffUrl(String url, Integer parentIndex, int timeoutSeconds, int port,
+			int maxRefactorings) {
+		String inputSummary = "URL diff.";
+		if (maxRefactorings < 0) {
+			return McpDiffBrowserResult.error("maxRefactorings must be greater than or equal to 0.", port,
+					inputSummary, List.of("maxRefactorings=" + maxRefactorings));
+		}
+		if (url == null || url.isBlank()) {
+			return McpDiffBrowserResult.error("url must be a non-empty string when provided.", port,
+					inputSummary, List.of("url is blank."));
+		}
+		if (timeoutSeconds <= 0) {
+			return McpDiffBrowserResult.error("timeoutSeconds must be greater than 0.", port,
+					inputSummary, List.of("timeoutSeconds=" + timeoutSeconds));
+		}
+		int resolvedParentIndex = parentIndex == null ? 0 : parentIndex;
+		if (resolvedParentIndex < 0) {
+			return McpDiffBrowserResult.error("parentIndex must be greater than or equal to 0.", port,
+					inputSummary, List.of("parentIndex=" + resolvedParentIndex));
+		}
+
+		String cleanUrl = URLHelper.clean(url);
+		inputSummary = "URL diff for " + cleanUrl + ".";
+		if (URLHelper.isPR(cleanUrl) && parentIndex != null) {
+			return McpDiffBrowserResult.error("parentIndex is supported only for commit URLs.", port,
+					inputSummary, List.of("url points to a pull request."));
+		}
+
+		try {
+			ProjectASTDiff diff;
+			if (URLHelper.isPR(cleanUrl)) {
+				diff = pullRequestDiffer.diffAtPullRequest(URLHelper.getRepo(cleanUrl),
+						URLHelper.getPullRequestID(cleanUrl), timeoutSeconds);
+			} else {
+				if (remoteCommitDiffer == null) {
+					return McpDiffBrowserResult.error("URL commit diff is not available.", port,
+							inputSummary, List.of("remote commit differ is not configured."));
+				}
+				diff = remoteCommitDiffer.diffAtMergeCommit(URLHelper.getRepo(cleanUrl), URLHelper.getCommit(cleanUrl),
+						resolvedParentIndex, timeoutSeconds);
+				if (diff != null && diff.getMetaInfo() != null) {
+					diff.setMetaInfo(diff.getMetaInfo().withUrl(cleanUrl));
+				}
+			}
+			return launchDiffBrowser(diff, port, inputSummary, List.of(), maxRefactorings);
+		} catch (Exception e) {
+			return McpDiffBrowserResult.error("URL diff browser failed: " + e.getMessage(), port,
 					inputSummary, List.of(e.getClass().getName()));
 		}
 	}
@@ -569,12 +660,12 @@ public class RefactoringMinerMcpService {
 	}
 
 	private McpDiffBrowserResult launchDiffBrowser(ProjectASTDiff diff, int port, String inputSummary,
-			List<String> warnings) throws Exception {
+			List<String> warnings, int maxRefactorings) throws Exception {
 		if (diff == null) {
 			return McpDiffBrowserResult.error("Analysis did not produce a diff.", port, inputSummary,
 					List.of("RefactoringMiner returned null."));
 		}
-		return diffBrowserLauncher.launch(diff, port, inputSummary, warnings);
+		return diffBrowserLauncher.launch(diff, port, inputSummary, warnings, maxRefactorings);
 	}
 
 	private static void validateFileContentBounds(Map<String, String> beforeFiles, Map<String, String> afterFiles,

--- a/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
+++ b/src/main/java/org/refactoringminer/mcp/RefactoringMinerMcpTools.java
@@ -1,9 +1,12 @@
 package org.refactoringminer.mcp;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,20 +21,26 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
 
 public final class RefactoringMinerMcpTools {
-	static final String ANALYZE_FILE_CONTENTS = "refactoringminer_analyze_file_contents";
-	static final String ANALYZE_WORKTREE = "refactoringminer_analyze_worktree";
-	static final String ANALYZE_COMMIT = "refactoringminer_analyze_commit";
-	static final String ANALYZE_PULL_REQUEST = "refactoringminer_analyze_pull_request";
-	static final String ANALYZE_DIRECTORIES = "refactoringminer_analyze_directories";
-	static final String VALIDATE_FILE_CONTENTS = "refactoringminer_validate_file_contents";
-	static final String VALIDATE_WORKTREE = "refactoringminer_validate_worktree";
-	static final String VALIDATE_COMMIT = "refactoringminer_validate_commit";
-	static final String VALIDATE_PULL_REQUEST = "refactoringminer_validate_pull_request";
-	static final String VALIDATE_DIRECTORIES = "refactoringminer_validate_directories";
-	static final String DIFF_FILE_CONTENTS = "refactoringminer_diff_file_contents";
-	static final String DIFF_WORKTREE = "refactoringminer_diff_worktree";
-	static final String DIFF_COMMIT = "refactoringminer_diff_commit";
-	static final String DIFF_PULL_REQUEST = "refactoringminer_diff_pull_request";
+	static final String ANALYZE = "refactoringminer_analyze";
+	static final String VALIDATE = "refactoringminer_validate";
+	static final String DIFF = "refactoringminer_diff";
+
+	private static final Set<String> ANALYSIS_SOURCE_TYPES =
+			Set.of("fileContents", "worktree", "commit", "pullRequest", "directories");
+	private static final Set<String> DIFF_SOURCE_TYPES =
+			Set.of("fileContents", "worktree", "commit", "pullRequest", "url");
+	private static final Set<String> SOURCE_ARGUMENTS =
+			Set.of("type", "beforeFiles", "afterFiles", "baseRef", "includeUntracked", "maxFiles",
+					"maxBytesPerFile", "commitId", "parentIndex", "cloneUrl", "pullRequestId", "timeoutSeconds",
+					"beforePath", "afterPath", "url", "workingDirectory");
+	private static final Map<String, Set<String>> SOURCE_ARGUMENTS_BY_TYPE = Map.of(
+			"fileContents", Set.of("type", "beforeFiles", "afterFiles", "maxFiles", "maxBytesPerFile"),
+			"worktree", Set.of("type", "workingDirectory", "baseRef", "includeUntracked", "maxFiles",
+					"maxBytesPerFile"),
+			"commit", Set.of("type", "workingDirectory", "commitId", "parentIndex"),
+			"pullRequest", Set.of("type", "cloneUrl", "pullRequestId", "timeoutSeconds"),
+			"directories", Set.of("type", "beforePath", "afterPath"),
+			"url", Set.of("type", "url", "parentIndex", "timeoutSeconds"));
 	private static final int DEFAULT_MAX_REFACTORINGS = 20;
 	private static final int DEFAULT_MAX_CANDIDATES = 20;
 	private static final int DEFAULT_MAX_FILES = 100;
@@ -52,527 +61,263 @@ public final class RefactoringMinerMcpTools {
 
 	static SyncToolSpecification[] toolSpecifications() {
 		RefactoringMinerMcpService service = new RefactoringMinerMcpService();
-		return new SyncToolSpecification[] { analyzeFileContentsTool(service), analyzeWorktreeTool(service),
-				analyzeCommitTool(service), analyzePullRequestTool(service), analyzeDirectoriesTool(service),
-				validateFileContentsTool(service), validateWorktreeTool(service), validateCommitTool(service),
-				validatePullRequestTool(service), validateDirectoriesTool(service), diffFileContentsTool(service),
-				diffWorktreeTool(service), diffCommitTool(service), diffPullRequestTool(service) };
+		return new SyncToolSpecification[] { analyzeTool(service), validateTool(service), diffTool(service) };
 	}
 
-	static SyncToolSpecification analyzeFileContentsTool(RefactoringMinerMcpService service) {
+	static SyncToolSpecification analyzeTool(RefactoringMinerMcpService service) {
 		return SyncToolSpecification.builder()
 				.tool(Tool.builder()
-						.name(ANALYZE_FILE_CONTENTS)
-						.title("Analyze explicit before/after file contents")
-						.description("Find refactorings in explicit before/after file-content maps. Does not edit files.")
-						.inputSchema(inputSchema())
+						.name(ANALYZE)
+						.title("Analyze refactorings")
+						.description("Find refactorings from a source. The source can be fileContents, worktree, commit, pullRequest, or directories. Does not edit files.")
+						.inputSchema(analyzeInputSchema())
 						.outputSchema(outputSchema())
-						.annotations(new ToolAnnotations("Analyze file contents", true, false, true, false, false))
+						.annotations(new ToolAnnotations("Analyze refactorings", true, false, true, true, false))
 						.build())
-				.callHandler((exchange, request) -> handleAnalyzeFileContents(service, request))
+				.callHandler((exchange, request) -> handleAnalyze(service, request))
 				.build();
 	}
 
-	static SyncToolSpecification analyzeWorktreeTool(RefactoringMinerMcpService service) {
+	static SyncToolSpecification validateTool(RefactoringMinerMcpService service) {
 		return SyncToolSpecification.builder()
 				.tool(Tool.builder()
-						.name(ANALYZE_WORKTREE)
-						.title("Analyze local worktree changes")
-						.description("Find refactorings in local modified, added, deleted, and optional untracked files. Does not edit files.")
-						.inputSchema(worktreeInputSchema())
-						.outputSchema(outputSchema())
-						.annotations(new ToolAnnotations("Analyze worktree", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleAnalyzeWorktree(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification analyzeCommitTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(ANALYZE_COMMIT)
-						.title("Analyze a local commit")
-						.description("Find refactorings introduced by a local repository commit. Supports merge parent selection.")
-						.inputSchema(commitInputSchema())
-						.outputSchema(outputSchema())
-						.annotations(new ToolAnnotations("Analyze commit", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleAnalyzeCommit(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification analyzePullRequestTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(ANALYZE_PULL_REQUEST)
-						.title("Analyze a GitHub pull request")
-						.description("Find refactorings in a GitHub pull request using RefactoringMiner's GitHub reader.")
-						.inputSchema(pullRequestInputSchema())
-						.outputSchema(outputSchema())
-						.annotations(new ToolAnnotations("Analyze pull request", true, false, true, true, false))
-						.build())
-				.callHandler((exchange, request) -> handleAnalyzePullRequest(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification analyzeDirectoriesTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(ANALYZE_DIRECTORIES)
-						.title("Analyze before and after directories")
-						.description("Find refactorings between local before/after directories or files.")
-						.inputSchema(directoriesInputSchema())
-						.outputSchema(outputSchema())
-						.annotations(new ToolAnnotations("Analyze directories", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleAnalyzeDirectories(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification validateFileContentsTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(VALIDATE_FILE_CONTENTS)
-						.title("Validate intended refactoring against file contents")
-						.description("Check a stated refactoring intent against explicit before/after file-content maps.")
-						.inputSchema(validateFileContentsInputSchema())
+						.name(VALIDATE)
+						.title("Validate intended refactoring")
+						.description("Check whether detected refactorings from a source match a stated intent. Does not edit files.")
+						.inputSchema(validateInputSchema())
 						.outputSchema(validationOutputSchema())
-						.annotations(new ToolAnnotations("Validate file contents", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleValidateFileContents(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification validateWorktreeTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(VALIDATE_WORKTREE)
-						.title("Validate intended refactoring against worktree changes")
-						.description("Check a stated refactoring intent against local worktree changes.")
-						.inputSchema(validateWorktreeInputSchema())
-						.outputSchema(validationOutputSchema())
-						.annotations(new ToolAnnotations("Validate worktree", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleValidateWorktree(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification validateCommitTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(VALIDATE_COMMIT)
-						.title("Validate intended refactoring against a commit")
-						.description("Check a stated refactoring intent against a local repository commit.")
-						.inputSchema(validateCommitInputSchema())
-						.outputSchema(validationOutputSchema())
-						.annotations(new ToolAnnotations("Validate commit", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleValidateCommit(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification validatePullRequestTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(VALIDATE_PULL_REQUEST)
-						.title("Validate intended refactoring against a pull request")
-						.description("Check a stated refactoring intent against a GitHub pull request.")
-						.inputSchema(validatePullRequestInputSchema())
-						.outputSchema(validationOutputSchema())
-						.annotations(new ToolAnnotations("Validate pull request", true, false, true, true, false))
-						.build())
-				.callHandler((exchange, request) -> handleValidatePullRequest(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification validateDirectoriesTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(VALIDATE_DIRECTORIES)
-						.title("Validate intended refactoring against directories")
-						.description("Check a stated refactoring intent against before/after directories.")
-						.inputSchema(validateDirectoriesInputSchema())
-						.outputSchema(validationOutputSchema())
-						.annotations(new ToolAnnotations("Validate directories", true, false, true, false, false))
-						.build())
-				.callHandler((exchange, request) -> handleValidateDirectories(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification diffFileContentsTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(DIFF_FILE_CONTENTS)
-						.title("Open AST diff browser for file contents")
-						.description("Start a local RefactoringMiner AST diff page for explicit before/after file-content maps. Returns a localhost URL and does not open a browser.")
-						.inputSchema(diffFileContentsInputSchema())
-						.outputSchema(diffBrowserOutputSchema())
-						.annotations(new ToolAnnotations("Open file-content AST diff browser", true, false, true, false,
+						.annotations(new ToolAnnotations("Validate intended refactoring", true, false, true, true,
 								false))
 						.build())
-				.callHandler((exchange, request) -> handleDiffFileContents(service, request))
+				.callHandler((exchange, request) -> handleValidate(service, request))
 				.build();
 	}
 
-	static SyncToolSpecification diffWorktreeTool(RefactoringMinerMcpService service) {
+	static SyncToolSpecification diffTool(RefactoringMinerMcpService service) {
 		return SyncToolSpecification.builder()
 				.tool(Tool.builder()
-						.name(DIFF_WORKTREE)
-						.title("Open AST diff browser for worktree changes")
-						.description("Start a local RefactoringMiner AST diff page for modified, added, deleted, and optional untracked files. Returns a localhost URL and does not open a browser.")
-						.inputSchema(diffWorktreeInputSchema())
+						.name(DIFF)
+						.title("Open RefactoringMiner AST diff")
+						.description("Start a local RefactoringMiner AST diff page from a source. The source can be fileContents, worktree, commit, pullRequest, or url.")
+						.inputSchema(diffInputSchema())
 						.outputSchema(diffBrowserOutputSchema())
-						.annotations(new ToolAnnotations("Open worktree AST diff browser", true, false, true, false,
+						.annotations(new ToolAnnotations("Open RefactoringMiner AST diff", true, false, true, true,
 								false))
 						.build())
-				.callHandler((exchange, request) -> handleDiffWorktree(service, request))
+				.callHandler((exchange, request) -> handleDiff(service, request))
 				.build();
 	}
 
-	static SyncToolSpecification diffCommitTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(DIFF_COMMIT)
-						.title("Open AST diff browser for a local commit")
-						.description("Start a local RefactoringMiner AST diff page for a repository commit. Supports merge parent selection and returns a localhost URL.")
-						.inputSchema(diffCommitInputSchema())
-						.outputSchema(diffBrowserOutputSchema())
-						.annotations(new ToolAnnotations("Open commit AST diff browser", true, false, true, false,
-								false))
-						.build())
-				.callHandler((exchange, request) -> handleDiffCommit(service, request))
-				.build();
-	}
-
-	static SyncToolSpecification diffPullRequestTool(RefactoringMinerMcpService service) {
-		return SyncToolSpecification.builder()
-				.tool(Tool.builder()
-						.name(DIFF_PULL_REQUEST)
-						.title("Open AST diff browser for a GitHub pull request")
-						.description("Start a local RefactoringMiner AST diff page for a GitHub pull request. Returns a localhost URL and does not open a browser.")
-						.inputSchema(diffPullRequestInputSchema())
-						.outputSchema(diffBrowserOutputSchema())
-						.annotations(new ToolAnnotations("Open pull request AST diff browser", true, false, true, true,
-								false))
-						.build())
-				.callHandler((exchange, request) -> handleDiffPullRequest(service, request))
-				.build();
-	}
-
-	private static CallToolResult handleAnalyzeFileContents(RefactoringMinerMcpService service, CallToolRequest request) {
+	private static CallToolResult handleAnalyze(RefactoringMinerMcpService service, CallToolRequest request) {
 		McpAnalysisResult result = analyze(service, request.arguments());
 		return toCallToolResult(result);
 	}
 
 	static McpAnalysisResult analyze(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
-		}
+		Map<String, Object> resolvedArguments = arguments == null ? Map.of() : arguments;
 		try {
-			Map<String, String> beforeFiles = stringMap(arguments.get("beforeFiles"), "beforeFiles");
-			Map<String, String> afterFiles = stringMap(arguments.get("afterFiles"), "afterFiles");
-			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
+			String unsupportedArgument = unsupportedArgument(resolvedArguments, Set.of("source", "maxRefactorings"));
+			if (unsupportedArgument != null) {
+				return McpAnalysisResult.error("Unsupported argument for " + ANALYZE + ": " + unsupportedArgument
+						+ ".", unsupportedArgumentWarnings(unsupportedArgument));
+			}
+			Map<String, Object> source = sourceValue(resolvedArguments.get("source"));
+			McpAnalysisResult unsupported = unsupportedSourceArgument(source, ANALYZE);
+			if (unsupported != null) {
+				return unsupported;
+			}
+			String sourceType = sourceType(source);
+			if (!ANALYSIS_SOURCE_TYPES.contains(sourceType)) {
+				return McpAnalysisResult.error("Unsupported source.type for " + ANALYZE + ": " + sourceType + ".",
+						List.of("Supported source types are fileContents, worktree, commit, pullRequest, and directories."));
+			}
+			String unsupportedSourceArgument = unsupportedSourceArgumentForType(source, sourceType);
+			if (unsupportedSourceArgument != null) {
+				return McpAnalysisResult.error("Unsupported source argument for " + sourceType + ": "
+						+ unsupportedSourceArgument + ".", unsupportedArgumentWarnings(unsupportedSourceArgument));
+			}
+			int maxRefactorings = integerValue(resolvedArguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
-			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
-					"maxBytesPerFile");
-			return service.analyzeFileContents(beforeFiles, afterFiles, maxRefactorings, maxFiles,
-					maxBytesPerFile);
+			return switch (sourceType) {
+				case "fileContents" -> service.analyzeFileContents(
+						stringMap(source.get("beforeFiles"), "source.beforeFiles"),
+						stringMap(source.get("afterFiles"), "source.afterFiles"),
+						maxRefactorings,
+						integerValue(source.get("maxFiles"), DEFAULT_MAX_FILES, "source.maxFiles"),
+						integerValue(source.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
+								"source.maxBytesPerFile"));
+				case "worktree" -> service.analyzeWorktree(workingDirectory(source),
+						optionalStringValue(source.get("baseRef"), "HEAD"),
+						booleanValue(source.get("includeUntracked"), false),
+						integerValue(source.get("maxFiles"), DEFAULT_MAX_FILES, "source.maxFiles"),
+						integerValue(source.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
+								"source.maxBytesPerFile"),
+						maxRefactorings);
+				case "commit" -> service.analyzeCommit(workingDirectory(source),
+						stringValue(source.get("commitId"), "source.commitId"),
+						optionalIntegerValue(source.get("parentIndex"), "source.parentIndex"),
+						maxRefactorings);
+				case "pullRequest" -> service.analyzePullRequest(
+						optionalCloneUrlValue(source.get("cloneUrl")),
+						integerValue(source.get("pullRequestId"), 0, "source.pullRequestId"),
+						integerValue(source.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "source.timeoutSeconds"),
+						maxRefactorings);
+				case "directories" -> service.analyzeDirectories(
+						pathValue(source.get("beforePath"), "source.beforePath"),
+						pathValue(source.get("afterPath"), "source.afterPath"),
+						maxRefactorings);
+				default -> throw new IllegalStateException("Unexpected source type: " + sourceType);
+			};
 		} catch (IllegalArgumentException e) {
 			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
 		}
 	}
 
-	private static CallToolResult handleAnalyzeWorktree(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpAnalysisResult result = analyzeWorktree(service, request.arguments());
+	private static CallToolResult handleValidate(RefactoringMinerMcpService service, CallToolRequest request) {
+		McpValidationResult result = validate(service, request.arguments());
 		return toCallToolResult(result);
 	}
 
-	static McpAnalysisResult analyzeWorktree(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
-		}
+	static McpValidationResult validate(RefactoringMinerMcpService service, Map<String, Object> arguments) {
+		Map<String, Object> resolvedArguments = arguments == null ? Map.of() : arguments;
+		McpRefactoringIntent intent = null;
 		try {
-			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
-			String baseRef = optionalStringValue(arguments.get("baseRef"), "HEAD");
-			boolean includeUntracked = booleanValue(arguments.get("includeUntracked"), false);
-			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
-			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
-					"maxBytesPerFile");
-			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
+			String unsupportedArgument = unsupportedArgument(resolvedArguments,
+					Set.of("source", "intent", "maxCandidates"));
+			if (unsupportedArgument != null) {
+				return McpValidationResult.error("Unsupported argument for " + VALIDATE + ": " + unsupportedArgument
+						+ ".", null, unsupportedArgumentWarnings(unsupportedArgument));
+			}
+			intent = intentValue(resolvedArguments.get("intent"));
+			Map<String, Object> source = sourceValue(resolvedArguments.get("source"));
+			McpValidationResult unsupported = unsupportedValidationSourceArgument(source, intent);
+			if (unsupported != null) {
+				return unsupported;
+			}
+			String sourceType = sourceType(source);
+			if (!ANALYSIS_SOURCE_TYPES.contains(sourceType)) {
+				return McpValidationResult.error("Unsupported source.type for " + VALIDATE + ": " + sourceType + ".",
+						intent, List.of("Supported source types are fileContents, worktree, commit, pullRequest, and directories."));
+			}
+			String unsupportedSourceArgument = unsupportedSourceArgumentForType(source, sourceType);
+			if (unsupportedSourceArgument != null) {
+				return McpValidationResult.error("Unsupported source argument for " + sourceType + ": "
+						+ unsupportedSourceArgument + ".", intent, unsupportedArgumentWarnings(unsupportedSourceArgument));
+			}
+			int maxCandidates = integerValue(resolvedArguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES,
+					"maxCandidates");
+			return switch (sourceType) {
+				case "fileContents" -> service.validateFileContents(
+						stringMap(source.get("beforeFiles"), "source.beforeFiles"),
+						stringMap(source.get("afterFiles"), "source.afterFiles"),
+						intent,
+						maxCandidates,
+						integerValue(source.get("maxFiles"), DEFAULT_MAX_FILES, "source.maxFiles"),
+						integerValue(source.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
+								"source.maxBytesPerFile"));
+				case "worktree" -> service.validateWorktree(workingDirectory(source),
+						optionalStringValue(source.get("baseRef"), "HEAD"),
+						booleanValue(source.get("includeUntracked"), false),
+						integerValue(source.get("maxFiles"), DEFAULT_MAX_FILES, "source.maxFiles"),
+						integerValue(source.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
+								"source.maxBytesPerFile"),
+						intent,
+						maxCandidates);
+				case "commit" -> service.validateCommit(workingDirectory(source),
+						stringValue(source.get("commitId"), "source.commitId"),
+						optionalIntegerValue(source.get("parentIndex"), "source.parentIndex"),
+						intent,
+						maxCandidates);
+				case "pullRequest" -> service.validatePullRequest(
+						optionalCloneUrlValue(source.get("cloneUrl")),
+						integerValue(source.get("pullRequestId"), 0, "source.pullRequestId"),
+						integerValue(source.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "source.timeoutSeconds"),
+						intent,
+						maxCandidates);
+				case "directories" -> service.validateDirectories(
+						pathValue(source.get("beforePath"), "source.beforePath"),
+						pathValue(source.get("afterPath"), "source.afterPath"),
+						intent,
+						maxCandidates);
+				default -> throw new IllegalStateException("Unexpected source type: " + sourceType);
+			};
+		} catch (IllegalArgumentException e) {
+			return McpValidationResult.error(e.getMessage(), intent, List.of("Invalid tool arguments."));
+		}
+	}
+
+	private static CallToolResult handleDiff(RefactoringMinerMcpService service, CallToolRequest request) {
+		McpDiffBrowserResult result = diff(service, request.arguments());
+		return toCallToolResult(result);
+	}
+
+	static McpDiffBrowserResult diff(RefactoringMinerMcpService service, Map<String, Object> arguments) {
+		Map<String, Object> resolvedArguments = arguments == null ? Map.of() : arguments;
+		try {
+			String unsupportedArgument = unsupportedArgument(resolvedArguments,
+					Set.of("source", "port", "maxRefactorings"));
+			int port = portValue(resolvedArguments.get("port"));
+			if (unsupportedArgument != null) {
+				return McpDiffBrowserResult.error("Unsupported argument for " + DIFF + ": " + unsupportedArgument
+						+ ".", port, "RefactoringMiner diff", unsupportedArgumentWarnings(unsupportedArgument));
+			}
+			Map<String, Object> source = sourceValue(resolvedArguments.get("source"));
+			McpDiffBrowserResult unsupported = unsupportedDiffSourceArgument(source, port);
+			if (unsupported != null) {
+				return unsupported;
+			}
+			String sourceType = sourceType(source);
+			if (!DIFF_SOURCE_TYPES.contains(sourceType)) {
+				return McpDiffBrowserResult.error("Unsupported source.type for " + DIFF + ": " + sourceType + ".",
+						port, "RefactoringMiner diff",
+						List.of("Supported source types are fileContents, worktree, commit, pullRequest, and url."));
+			}
+			String unsupportedSourceArgument = unsupportedSourceArgumentForType(source, sourceType);
+			if (unsupportedSourceArgument != null) {
+				return McpDiffBrowserResult.error("Unsupported source argument for " + sourceType + ": "
+						+ unsupportedSourceArgument + ".", port, "RefactoringMiner diff",
+						unsupportedArgumentWarnings(unsupportedSourceArgument));
+			}
+			int maxRefactorings = integerValue(resolvedArguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
 					"maxRefactorings");
-			return service.analyzeWorktree(repositoryPath, baseRef, includeUntracked, maxFiles,
-					maxBytesPerFile, maxRefactorings);
+			return switch (sourceType) {
+				case "fileContents" -> service.diffFileContents(
+						stringMap(source.get("beforeFiles"), "source.beforeFiles"),
+						stringMap(source.get("afterFiles"), "source.afterFiles"),
+						port,
+						integerValue(source.get("maxFiles"), DEFAULT_MAX_FILES, "source.maxFiles"),
+						integerValue(source.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
+								"source.maxBytesPerFile"),
+						maxRefactorings);
+				case "worktree" -> service.diffWorktree(workingDirectory(source),
+						optionalStringValue(source.get("baseRef"), "HEAD"),
+						booleanValue(source.get("includeUntracked"), false),
+						integerValue(source.get("maxFiles"), DEFAULT_MAX_FILES, "source.maxFiles"),
+						integerValue(source.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
+								"source.maxBytesPerFile"),
+						port,
+						maxRefactorings);
+				case "commit" -> service.diffCommit(workingDirectory(source),
+						stringValue(source.get("commitId"), "source.commitId"),
+						optionalIntegerValue(source.get("parentIndex"), "source.parentIndex"),
+						port,
+						maxRefactorings);
+				case "pullRequest" -> service.diffPullRequest(
+						optionalCloneUrlValue(source.get("cloneUrl")),
+						integerValue(source.get("pullRequestId"), 0, "source.pullRequestId"),
+						integerValue(source.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "source.timeoutSeconds"),
+						port,
+						maxRefactorings);
+				case "url" -> service.diffUrl(
+						stringValue(source.get("url"), "source.url"),
+						optionalIntegerValue(source.get("parentIndex"), "source.parentIndex"),
+						integerValue(source.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "source.timeoutSeconds"),
+						port,
+						maxRefactorings);
+				default -> throw new IllegalStateException("Unexpected source type: " + sourceType);
+			};
 		} catch (IllegalArgumentException e) {
-			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleAnalyzeCommit(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpAnalysisResult result = analyzeCommit(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpAnalysisResult analyzeCommit(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
-		}
-		try {
-			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
-			String commitId = stringValue(arguments.get("commitId"), "commitId");
-			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
-			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
-					"maxRefactorings");
-			return service.analyzeCommit(repositoryPath, commitId, parentIndex, maxRefactorings);
-		} catch (IllegalArgumentException e) {
-			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleAnalyzePullRequest(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpAnalysisResult result = analyzePullRequest(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpAnalysisResult analyzePullRequest(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
-		}
-		try {
-			String cloneUrl = optionalCloneUrlValue(arguments.get("cloneUrl"));
-			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
-			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
-			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
-					"maxRefactorings");
-			return service.analyzePullRequest(cloneUrl, pullRequestId, timeoutSeconds, maxRefactorings);
-		} catch (IllegalArgumentException e) {
-			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleAnalyzeDirectories(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpAnalysisResult result = analyzeDirectories(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpAnalysisResult analyzeDirectories(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpAnalysisResult.error("Tool arguments are required.", List.of("arguments=null"));
-		}
-		try {
-			String beforePath = stringValue(arguments.get("beforePath"), "beforePath");
-			String afterPath = stringValue(arguments.get("afterPath"), "afterPath");
-			int maxRefactorings = integerValue(arguments.get("maxRefactorings"), DEFAULT_MAX_REFACTORINGS,
-					"maxRefactorings");
-			return service.analyzeDirectories(Path.of(beforePath), Path.of(afterPath), maxRefactorings);
-		} catch (IllegalArgumentException e) {
-			return McpAnalysisResult.error(e.getMessage(), List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleValidateFileContents(RefactoringMinerMcpService service,
-			CallToolRequest request) {
-		McpValidationResult result = validateFileContents(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpValidationResult validateFileContents(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
-		}
-		try {
-			Map<String, String> beforeFiles = stringMap(arguments.get("beforeFiles"), "beforeFiles");
-			Map<String, String> afterFiles = stringMap(arguments.get("afterFiles"), "afterFiles");
-			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
-			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
-			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
-					"maxBytesPerFile");
-			return service.validateFileContents(beforeFiles, afterFiles, intent, maxCandidates, maxFiles,
-					maxBytesPerFile);
-		} catch (IllegalArgumentException e) {
-			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleValidateWorktree(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpValidationResult result = validateWorktree(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpValidationResult validateWorktree(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
-		}
-		try {
-			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
-			String baseRef = optionalStringValue(arguments.get("baseRef"), "HEAD");
-			boolean includeUntracked = booleanValue(arguments.get("includeUntracked"), false);
-			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
-			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
-					"maxBytesPerFile");
-			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
-			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			return service.validateWorktree(repositoryPath, baseRef, includeUntracked, maxFiles,
-					maxBytesPerFile, intent, maxCandidates);
-		} catch (IllegalArgumentException e) {
-			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleValidateCommit(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpValidationResult result = validateCommit(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpValidationResult validateCommit(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
-		}
-		try {
-			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
-			String commitId = stringValue(arguments.get("commitId"), "commitId");
-			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
-			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
-			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			return service.validateCommit(repositoryPath, commitId, parentIndex, intent, maxCandidates);
-		} catch (IllegalArgumentException e) {
-			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleValidatePullRequest(RefactoringMinerMcpService service,
-			CallToolRequest request) {
-		McpValidationResult result = validatePullRequest(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpValidationResult validatePullRequest(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
-		}
-		try {
-			String cloneUrl = optionalCloneUrlValue(arguments.get("cloneUrl"));
-			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
-			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
-			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
-			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			return service.validatePullRequest(cloneUrl, pullRequestId, timeoutSeconds, intent, maxCandidates);
-		} catch (IllegalArgumentException e) {
-			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleValidateDirectories(RefactoringMinerMcpService service,
-			CallToolRequest request) {
-		McpValidationResult result = validateDirectories(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpValidationResult validateDirectories(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpValidationResult.error("Tool arguments are required.", null, List.of("arguments=null"));
-		}
-		try {
-			String beforePath = stringValue(arguments.get("beforePath"), "beforePath");
-			String afterPath = stringValue(arguments.get("afterPath"), "afterPath");
-			McpRefactoringIntent intent = intentValue(arguments.get("intent"));
-			int maxCandidates = integerValue(arguments.get("maxCandidates"), DEFAULT_MAX_CANDIDATES, "maxCandidates");
-			return service.validateDirectories(Path.of(beforePath), Path.of(afterPath), intent, maxCandidates);
-		} catch (IllegalArgumentException e) {
-			return McpValidationResult.error(e.getMessage(), null, List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleDiffFileContents(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpDiffBrowserResult result = diffFileContents(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpDiffBrowserResult diffFileContents(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpDiffBrowserResult.error("Tool arguments are required.", null, "Explicit file contents",
-					List.of("arguments=null"));
-		}
-		try {
-			Map<String, String> beforeFiles = stringMap(arguments.get("beforeFiles"), "beforeFiles");
-			Map<String, String> afterFiles = stringMap(arguments.get("afterFiles"), "afterFiles");
-			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
-			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
-					"maxBytesPerFile");
-			return service.diffFileContents(beforeFiles, afterFiles, port, maxFiles, maxBytesPerFile);
-		} catch (IllegalArgumentException e) {
-			return McpDiffBrowserResult.error(e.getMessage(), null, "Explicit file contents",
-					List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleDiffWorktree(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpDiffBrowserResult result = diffWorktree(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpDiffBrowserResult diffWorktree(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpDiffBrowserResult.error("Tool arguments are required.", null, "Worktree changes",
-					List.of("arguments=null"));
-		}
-		try {
-			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
-			String baseRef = optionalStringValue(arguments.get("baseRef"), "HEAD");
-			boolean includeUntracked = booleanValue(arguments.get("includeUntracked"), false);
-			int maxFiles = integerValue(arguments.get("maxFiles"), DEFAULT_MAX_FILES, "maxFiles");
-			int maxBytesPerFile = integerValue(arguments.get("maxBytesPerFile"), DEFAULT_MAX_BYTES_PER_FILE,
-					"maxBytesPerFile");
-			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffWorktree(repositoryPath, baseRef, includeUntracked, maxFiles, maxBytesPerFile,
-					port);
-		} catch (IllegalArgumentException e) {
-			return McpDiffBrowserResult.error(e.getMessage(), null, "Worktree changes",
-					List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleDiffCommit(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpDiffBrowserResult result = diffCommit(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpDiffBrowserResult diffCommit(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpDiffBrowserResult.error("Tool arguments are required.", null, "Commit diff",
-					List.of("arguments=null"));
-		}
-		try {
-			Path repositoryPath = repositoryPath(arguments.get("repositoryPath"));
-			String commitId = stringValue(arguments.get("commitId"), "commitId");
-			Integer parentIndex = optionalIntegerValue(arguments.get("parentIndex"), "parentIndex");
-			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffCommit(repositoryPath, commitId, parentIndex, port);
-		} catch (IllegalArgumentException e) {
-			return McpDiffBrowserResult.error(e.getMessage(), null, "Commit diff", List.of("Invalid tool arguments."));
-		}
-	}
-
-	private static CallToolResult handleDiffPullRequest(RefactoringMinerMcpService service, CallToolRequest request) {
-		McpDiffBrowserResult result = diffPullRequest(service, request.arguments());
-		return toCallToolResult(result);
-	}
-
-	static McpDiffBrowserResult diffPullRequest(RefactoringMinerMcpService service, Map<String, Object> arguments) {
-		if (arguments == null) {
-			return McpDiffBrowserResult.error("Tool arguments are required.", null, "Pull-request diff",
-					List.of("arguments=null"));
-		}
-		try {
-			String cloneUrl = optionalCloneUrlValue(arguments.get("cloneUrl"));
-			int pullRequestId = integerValue(arguments.get("pullRequestId"), 0, "pullRequestId");
-			int timeoutSeconds = integerValue(arguments.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS, "timeoutSeconds");
-			int port = integerValue(arguments.get("port"), DEFAULT_WEB_DIFF_PORT, "port");
-			return service.diffPullRequest(cloneUrl, pullRequestId, timeoutSeconds, port);
-		} catch (IllegalArgumentException e) {
-			return McpDiffBrowserResult.error(e.getMessage(), null, "Pull-request diff",
+			return McpDiffBrowserResult.error(e.getMessage(), null, "RefactoringMiner diff",
 					List.of("Invalid tool arguments."));
 		}
 	}
@@ -585,19 +330,19 @@ public final class RefactoringMinerMcpTools {
 				.build();
 	}
 
-	private static CallToolResult toCallToolResult(McpDiffBrowserResult result) {
-		return CallToolResult.builder()
-				.addContent(new TextContent(writeResult(result)))
-				.structuredContent(result)
-				.isError(McpDiffBrowserResult.ERROR.equals(result.status()))
-				.build();
-	}
-
 	private static CallToolResult toCallToolResult(McpValidationResult result) {
 		return CallToolResult.builder()
 				.addContent(new TextContent(writeResult(result)))
 				.structuredContent(result)
 				.isError(McpValidationResult.ERROR.equals(result.status()))
+				.build();
+	}
+
+	private static CallToolResult toCallToolResult(McpDiffBrowserResult result) {
+		return CallToolResult.builder()
+				.addContent(new TextContent(writeResult(result)))
+				.structuredContent(result)
+				.isError(McpDiffBrowserResult.ERROR.equals(result.status()))
 				.build();
 	}
 
@@ -607,6 +352,121 @@ public final class RefactoringMinerMcpTools {
 		} catch (JsonProcessingException e) {
 			return "{\"status\":\"error\",\"summary\":\"Failed to serialize MCP result.\"}";
 		}
+	}
+
+	private static Map<String, Object> sourceValue(Object value) {
+		if (value == null) {
+			return Map.of("type", "worktree");
+		}
+		if (!(value instanceof Map<?, ?> map)) {
+			throw new IllegalArgumentException("source must be an object.");
+		}
+		Map<String, Object> source = new LinkedHashMap<>();
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			if (!(entry.getKey() instanceof String key)) {
+				throw new IllegalArgumentException("source keys must be strings.");
+			}
+			source.put(key, entry.getValue());
+		}
+		return source;
+	}
+
+	private static String sourceType(Map<String, Object> source) {
+		Object value = source.get("type");
+		if (value == null) {
+			return inferSourceType(source);
+		}
+		if (value instanceof String stringValue && !stringValue.isBlank()) {
+			return normalizeSourceType(stringValue);
+		}
+		throw new IllegalArgumentException("source.type must be a non-empty string.");
+	}
+
+	private static String inferSourceType(Map<String, Object> source) {
+		if (source.containsKey("url")) {
+			return "url";
+		}
+		if (source.containsKey("pullRequestId") || source.containsKey("cloneUrl")) {
+			return "pullRequest";
+		}
+		if (source.containsKey("commitId")) {
+			return "commit";
+		}
+		if (source.containsKey("beforeFiles") || source.containsKey("afterFiles")) {
+			return "fileContents";
+		}
+		if (source.containsKey("beforePath") || source.containsKey("afterPath")) {
+			return "directories";
+		}
+		return "worktree";
+	}
+
+	private static String normalizeSourceType(String sourceType) {
+		String normalized = sourceType.trim().toLowerCase(Locale.ROOT)
+				.replace("_", "")
+				.replace("-", "")
+				.replace(" ", "");
+		return switch (normalized) {
+			case "filecontents", "filecontent", "files" -> "fileContents";
+			case "worktree", "local", "localworktree" -> "worktree";
+			case "commit" -> "commit";
+			case "pullrequest", "pullrequests", "pr" -> "pullRequest";
+			case "directories", "directory", "dirs" -> "directories";
+			case "url", "uri" -> "url";
+			default -> sourceType.trim();
+		};
+	}
+
+	private static McpAnalysisResult unsupportedSourceArgument(Map<String, Object> source, String toolName) {
+		String unsupportedArgument = unsupportedArgument(source, SOURCE_ARGUMENTS);
+		if (unsupportedArgument == null) {
+			return null;
+		}
+		return McpAnalysisResult.error("Unsupported source argument for " + toolName + ": " + unsupportedArgument
+				+ ".", unsupportedArgumentWarnings(unsupportedArgument));
+	}
+
+	private static McpValidationResult unsupportedValidationSourceArgument(Map<String, Object> source,
+			McpRefactoringIntent intent) {
+		String unsupportedArgument = unsupportedArgument(source, SOURCE_ARGUMENTS);
+		if (unsupportedArgument == null) {
+			return null;
+		}
+		return McpValidationResult.error("Unsupported source argument for " + VALIDATE + ": " + unsupportedArgument
+				+ ".", intent, unsupportedArgumentWarnings(unsupportedArgument));
+	}
+
+	private static McpDiffBrowserResult unsupportedDiffSourceArgument(Map<String, Object> source, int port) {
+		String unsupportedArgument = unsupportedArgument(source, SOURCE_ARGUMENTS);
+		if (unsupportedArgument == null) {
+			return null;
+		}
+		return McpDiffBrowserResult.error("Unsupported source argument for " + DIFF + ": " + unsupportedArgument
+				+ ".", port, "RefactoringMiner diff", unsupportedArgumentWarnings(unsupportedArgument));
+	}
+
+	private static String unsupportedArgument(Map<String, Object> arguments, Set<String> supportedArguments) {
+		for (String argument : arguments.keySet()) {
+			if (!supportedArguments.contains(argument)) {
+				return argument;
+			}
+		}
+		return null;
+	}
+
+	private static String unsupportedSourceArgumentForType(Map<String, Object> source, String sourceType) {
+		Set<String> supportedArguments = SOURCE_ARGUMENTS_BY_TYPE.get(sourceType);
+		if (supportedArguments == null) {
+			return null;
+		}
+		return unsupportedArgument(source, supportedArguments);
+	}
+
+	private static List<String> unsupportedArgumentWarnings(String unsupportedArgument) {
+		if ("repositoryPath".equals(unsupportedArgument)) {
+			return List.of("Start the MCP server in the target project directory instead of passing repositoryPath.");
+		}
+		return List.of("Use the source object to select fileContents, worktree, commit, pullRequest, directories, or url.");
 	}
 
 	private static McpRefactoringIntent intentValue(Object value) {
@@ -636,7 +496,7 @@ public final class RefactoringMinerMcpTools {
 		if (!(value instanceof List<?> list)) {
 			throw new IllegalArgumentException(name + " must be a string or array of strings.");
 		}
-		List<String> strings = new java.util.ArrayList<>();
+		List<String> strings = new ArrayList<>();
 		for (Object item : list) {
 			if (!(item instanceof String stringItem)) {
 				throw new IllegalArgumentException(name + " must contain only strings.");
@@ -670,6 +530,29 @@ public final class RefactoringMinerMcpTools {
 		return strings;
 	}
 
+	private static Path pathValue(Object value, String name) {
+		return Path.of(stringValue(value, name));
+	}
+
+	private static Path workingDirectory(Map<String, Object> source) {
+		Object value = source.get("workingDirectory");
+		if (value == null) {
+			return null;
+		}
+		String path = stringValue(value, "source.workingDirectory");
+		Path relativePath = Path.of(path);
+		if (relativePath.isAbsolute()) {
+			throw new IllegalArgumentException(
+					"source.workingDirectory must be relative to the MCP server working directory.");
+		}
+		Path normalizedPath = relativePath.normalize();
+		if (normalizedPath.startsWith("..")) {
+			throw new IllegalArgumentException(
+					"source.workingDirectory must stay inside the MCP server working directory.");
+		}
+		return Path.of(System.getProperty("user.dir")).resolve(normalizedPath).normalize().toAbsolutePath();
+	}
+
 	private static int integerValue(Object value, int defaultValue, String name) {
 		if (value == null) {
 			return defaultValue;
@@ -678,7 +561,11 @@ public final class RefactoringMinerMcpTools {
 			return number.intValue();
 		}
 		if (value instanceof String stringValue) {
-			return Integer.parseInt(stringValue);
+			try {
+				return Integer.parseInt(stringValue);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(name + " must be an integer.", e);
+			}
 		}
 		throw new IllegalArgumentException(name + " must be an integer.");
 	}
@@ -703,6 +590,14 @@ public final class RefactoringMinerMcpTools {
 		throw new IllegalArgumentException("includeUntracked must be a boolean.");
 	}
 
+	private static int portValue(Object value) {
+		int port = integerValue(value, DEFAULT_WEB_DIFF_PORT, "port");
+		if (port < 1 || port > 65535) {
+			throw new IllegalArgumentException("port must be between 1 and 65535.");
+		}
+		return port;
+	}
+
 	private static String stringValue(Object value, String name) {
 		if (value instanceof String stringValue && !stringValue.isBlank()) {
 			return stringValue;
@@ -717,14 +612,7 @@ public final class RefactoringMinerMcpTools {
 		if (value instanceof String stringValue && !stringValue.isBlank()) {
 			return stringValue;
 		}
-		throw new IllegalArgumentException("cloneUrl must be a non-empty string when provided.");
-	}
-
-	private static Path repositoryPath(Object value) {
-		if (value == null) {
-			return Path.of(System.getProperty("user.dir"));
-		}
-		return Path.of(stringValue(value, "repositoryPath"));
+		throw new IllegalArgumentException("source.cloneUrl must be a non-empty string when provided.");
 	}
 
 	private static String optionalStringValue(Object value, String defaultValue) {
@@ -734,173 +622,66 @@ public final class RefactoringMinerMcpTools {
 		if (value instanceof String stringValue && !stringValue.isBlank()) {
 			return stringValue;
 		}
-		throw new IllegalArgumentException("baseRef must be a non-empty string.");
+		throw new IllegalArgumentException("source.baseRef must be a non-empty string.");
 	}
 
-	private static JsonSchema inputSchema() {
-		Map<String, Object> fileMapSchema = Map.of(
-				"type", "object",
-				"additionalProperties", Map.of("type", "string"));
-		Map<String, Object> maxRefactoringsSchema = Map.of(
-				"type", "integer",
-				"minimum", 0,
-				"default", DEFAULT_MAX_REFACTORINGS);
+	private static JsonSchema analyzeInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("beforeFiles", fileMapSchema);
-		properties.put("afterFiles", fileMapSchema);
-		properties.put("maxRefactorings", maxRefactoringsSchema);
-		putFileContentBoundsProperties(properties);
-		return new JsonSchema("object", properties, List.of("beforeFiles", "afterFiles"), false, null, null);
-	}
-
-	private static JsonSchema worktreeInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putRepositoryPathProperty(properties);
-		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
-		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
-		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
-		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
-		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
+		properties.put("source", sourceSchema(List.of("fileContents", "worktree", "commit", "pullRequest",
+				"directories")));
+		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0,
+				"default", DEFAULT_MAX_REFACTORINGS));
 		return new JsonSchema("object", properties, List.of(), false, null, null);
 	}
 
-	private static JsonSchema commitInputSchema() {
+	private static JsonSchema validateInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		putRepositoryPathProperty(properties);
-		properties.put("commitId", Map.of("type", "string"));
-		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
-		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
-		return new JsonSchema("object", properties, List.of("commitId"), false, null, null);
-	}
-
-	private static JsonSchema pullRequestInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putCloneUrlProperty(properties);
-		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
-		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
-		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
-		return new JsonSchema("object", properties, List.of("pullRequestId"), false, null, null);
-	}
-
-	private static JsonSchema directoriesInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("beforePath", Map.of("type", "string"));
-		properties.put("afterPath", Map.of("type", "string"));
-		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_REFACTORINGS));
-		return new JsonSchema("object", properties, List.of("beforePath", "afterPath"), false, null, null);
-	}
-
-	private static JsonSchema validateFileContentsInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("beforeFiles", fileMapSchema());
-		properties.put("afterFiles", fileMapSchema());
-		putFileContentBoundsProperties(properties);
-		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("beforeFiles", "afterFiles", "intent"), false, null, null);
-	}
-
-	private static JsonSchema validateWorktreeInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putRepositoryPathProperty(properties);
-		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
-		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
-		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
-		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
-		putValidationProperties(properties);
+		properties.put("source", sourceSchema(List.of("fileContents", "worktree", "commit", "pullRequest",
+				"directories")));
+		properties.put("intent", intentSchema());
+		properties.put("maxCandidates", Map.of("type", "integer", "minimum", 0,
+				"default", DEFAULT_MAX_CANDIDATES));
 		return new JsonSchema("object", properties, List.of("intent"), false, null, null);
 	}
 
-	private static JsonSchema validateCommitInputSchema() {
+	private static JsonSchema diffInputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
-		putRepositoryPathProperty(properties);
-		properties.put("commitId", Map.of("type", "string"));
-		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
-		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("commitId", "intent"), false, null, null);
-	}
-
-	private static JsonSchema validatePullRequestInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putCloneUrlProperty(properties);
-		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
-		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
-		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("pullRequestId", "intent"), false, null, null);
-	}
-
-	private static JsonSchema validateDirectoriesInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("beforePath", Map.of("type", "string"));
-		properties.put("afterPath", Map.of("type", "string"));
-		putValidationProperties(properties);
-		return new JsonSchema("object", properties, List.of("beforePath", "afterPath", "intent"), false, null, null);
-	}
-
-	private static JsonSchema diffFileContentsInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("beforeFiles", fileMapSchema());
-		properties.put("afterFiles", fileMapSchema());
-		putFileContentBoundsProperties(properties);
-		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of("beforeFiles", "afterFiles"), false, null, null);
-	}
-
-	private static JsonSchema diffWorktreeInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putRepositoryPathProperty(properties);
-		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
-		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
-		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
-		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_BYTES_PER_FILE));
-		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of(), false, null, null);
-	}
-
-	private static JsonSchema diffCommitInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putRepositoryPathProperty(properties);
-		properties.put("commitId", Map.of("type", "string"));
-		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
-		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of("commitId"), false, null, null);
-	}
-
-	private static JsonSchema diffPullRequestInputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		putCloneUrlProperty(properties);
-		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
-		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_TIMEOUT_SECONDS));
-		putDiffBrowserProperties(properties);
-		return new JsonSchema("object", properties, List.of("pullRequestId"), false, null, null);
-	}
-
-	private static void putDiffBrowserProperties(Map<String, Object> properties) {
+		properties.put("source", sourceSchema(List.of("fileContents", "worktree", "commit", "pullRequest", "url")));
 		properties.put("port", Map.of("type", "integer", "minimum", 1, "maximum", 65535,
 				"default", DEFAULT_WEB_DIFF_PORT,
 				"description", "Local WebDiff port. Defaults to 6789."));
+		properties.put("maxRefactorings", Map.of("type", "integer", "minimum", 0,
+				"default", DEFAULT_MAX_REFACTORINGS));
+		return new JsonSchema("object", properties, List.of(), false, null, null);
 	}
 
-	private static void putRepositoryPathProperty(Map<String, Object> properties) {
-		properties.put("repositoryPath", Map.of(
-				"type", "string",
-				"description", "Absolute repository path. Defaults to the MCP server working directory."));
-	}
-
-	private static void putCloneUrlProperty(Map<String, Object> properties) {
-		properties.put("cloneUrl", Map.of(
-				"type", "string",
-				"description", "GitHub repository clone URL. Defaults to the MCP server working directory's origin remote."));
-	}
-
-	private static void putFileContentBoundsProperties(Map<String, Object> properties) {
+	private static Map<String, Object> sourceSchema(List<String> sourceTypes) {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("type", Map.of("type", "string", "enum", sourceTypes, "default", "worktree",
+				"description", "Optional when another source field makes the source clear, such as pullRequestId, url, commitId, beforeFiles, or beforePath."));
+		properties.put("beforeFiles", fileMapSchema());
+		properties.put("afterFiles", fileMapSchema());
+		properties.put("baseRef", Map.of("type", "string", "default", "HEAD"));
+		properties.put("workingDirectory", Map.of("type", "string",
+				"description", "Relative subdirectory under the MCP server working directory for local worktree and commit sources."));
+		properties.put("includeUntracked", Map.of("type", "boolean", "default", false));
 		properties.put("maxFiles", Map.of("type", "integer", "minimum", 1, "default", DEFAULT_MAX_FILES));
 		properties.put("maxBytesPerFile", Map.of("type", "integer", "minimum", 1,
 				"default", DEFAULT_MAX_BYTES_PER_FILE));
-	}
-
-	private static void putValidationProperties(Map<String, Object> properties) {
-		properties.put("intent", intentSchema());
-		properties.put("maxCandidates", Map.of("type", "integer", "minimum", 0, "default", DEFAULT_MAX_CANDIDATES));
+		properties.put("commitId", Map.of("type", "string"));
+		properties.put("parentIndex", Map.of("type", "integer", "minimum", 0));
+		properties.put("cloneUrl", Map.of("type", "string",
+				"description", "GitHub repository clone URL. Defaults to the MCP server working directory's origin remote."));
+		properties.put("pullRequestId", Map.of("type", "integer", "minimum", 1));
+		properties.put("timeoutSeconds", Map.of("type", "integer", "minimum", 1,
+				"default", DEFAULT_TIMEOUT_SECONDS));
+		properties.put("beforePath", Map.of("type", "string"));
+		properties.put("afterPath", Map.of("type", "string"));
+		properties.put("url", Map.of("type", "string", "description", "GitHub commit or pull request URL."));
+		return Map.of(
+				"type", "object",
+				"properties", properties,
+				"additionalProperties", false);
 	}
 
 	private static Map<String, Object> fileMapSchema() {
@@ -932,24 +713,6 @@ public final class RefactoringMinerMcpTools {
 				Map.of("type", "array", "items", Map.of("type", "string"))));
 	}
 
-	private static Map<String, Object> validationOutputSchema() {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("status", Map.of("type", "string",
-				"enum", List.of("matched", "missing", "ambiguous", "error")));
-		properties.put("summary", Map.of("type", "string"));
-		properties.put("intent", intentSchema());
-		properties.put("refactoringCount", Map.of("type", "integer"));
-		properties.put("candidateCount", Map.of("type", "integer"));
-		properties.put("matches", Map.of("type", "array"));
-		properties.put("candidates", Map.of("type", "array"));
-		properties.put("warnings", Map.of("type", "array", "items", Map.of("type", "string")));
-		return Map.of(
-				"type", "object",
-				"properties", properties,
-				"required", List.of("status", "summary", "refactoringCount", "candidateCount", "matches",
-						"candidates", "warnings"));
-	}
-
 	private static Map<String, Object> outputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("status", Map.of("type", "string", "enum", List.of("ok", "error")));
@@ -968,6 +731,24 @@ public final class RefactoringMinerMcpTools {
 						"filesBefore", "filesAfter", "refactorings", "warnings"));
 	}
 
+	private static Map<String, Object> validationOutputSchema() {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("status", Map.of("type", "string",
+				"enum", List.of("matched", "missing", "ambiguous", "error")));
+		properties.put("summary", Map.of("type", "string"));
+		properties.put("intent", intentSchema());
+		properties.put("refactoringCount", Map.of("type", "integer"));
+		properties.put("candidateCount", Map.of("type", "integer"));
+		properties.put("matches", Map.of("type", "array"));
+		properties.put("candidates", Map.of("type", "array"));
+		properties.put("warnings", Map.of("type", "array", "items", Map.of("type", "string")));
+		return Map.of(
+				"type", "object",
+				"properties", properties,
+				"required", List.of("status", "summary", "refactoringCount", "candidateCount", "matches",
+						"candidates", "warnings"));
+	}
+
 	private static Map<String, Object> diffBrowserOutputSchema() {
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("status", Map.of("type", "string", "enum", List.of("ok", "error")));
@@ -981,12 +762,13 @@ public final class RefactoringMinerMcpTools {
 		properties.put("moveAstDiffCount", Map.of("type", "integer"));
 		properties.put("filesBefore", Map.of("type", "integer"));
 		properties.put("filesAfter", Map.of("type", "integer"));
+		properties.put("refactorings", Map.of("type", "array"));
 		properties.put("affectedFiles", Map.of("type", "array", "items", Map.of("type", "string")));
 		properties.put("warnings", Map.of("type", "array", "items", Map.of("type", "string")));
 		return Map.of(
 				"type", "object",
 				"properties", properties,
 				"required", List.of("status", "summary", "inputSummary", "refactoringCount", "astDiffCount",
-						"moveAstDiffCount", "filesBefore", "filesAfter", "affectedFiles", "warnings"));
+						"moveAstDiffCount", "filesBefore", "filesAfter", "refactorings", "affectedFiles", "warnings"));
 	}
 }

--- a/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
+++ b/src/main/java/org/refactoringminer/mcp/WebDiffBrowserLauncher.java
@@ -38,7 +38,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 
 	@Override
 	public synchronized McpDiffBrowserResult launch(ProjectASTDiff diff, int port, String inputSummary,
-			List<String> warnings) throws Exception {
+			List<String> warnings, int maxRefactorings) throws Exception {
 		if (diff == null) {
 			throw new IllegalArgumentException("ProjectASTDiff is required.");
 		}
@@ -64,7 +64,7 @@ final class WebDiffBrowserLauncher implements DiffBrowserLauncher {
 		}
 		activeView = view;
 		activePort = port;
-		return McpDiffBrowserResult.ok(diff, port, publicHost, inputSummary, warnings);
+		return McpDiffBrowserResult.ok(diff, port, publicHost, inputSummary, warnings, maxRefactorings);
 	}
 
 	private void stopActiveView() {

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpServiceTest.java
@@ -84,8 +84,9 @@ class RefactoringMinerMcpServiceTest {
 			return diff;
 		}, (repositoryPath, commitId, parentIndex) -> new ProjectASTDiff(Map.of(), Map.of()),
 				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(Map.of(), Map.of()),
-				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
-				(diff, port, inputSummary, warnings) -> McpDiffBrowserResult.ok(diff, port, inputSummary, warnings));
+					(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
+					(diff, port, inputSummary, warnings, maxRefactorings) ->
+							McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxRefactorings));
 		Map<String, String> before = Map.of("src/main/java/A.java", "class A { void f() {} }");
 		Map<String, String> after = Map.of("src/main/java/A.java", "class A { void g() {} }");
 
@@ -106,10 +107,10 @@ class RefactoringMinerMcpServiceTest {
 		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> new ProjectASTDiff(before, after),
 				(repositoryPath, commitId, parentIndex) -> new ProjectASTDiff(Map.of(), Map.of()),
 				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(Map.of(), Map.of()),
-				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
-				(diff, port, inputSummary, warnings) -> {
-					throw new IllegalArgumentException("port must be between 1 and 65535.");
-				});
+					(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
+					(diff, port, inputSummary, warnings, maxRefactorings) -> {
+						throw new IllegalArgumentException("port must be between 1 and 65535.");
+					});
 
 		McpDiffBrowserResult result = service.diffFileContents(
 				Map.of("src/main/java/A.java", "class A {}"),

--- a/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
+++ b/src/test/java/org/refactoringminer/mcp/RefactoringMinerMcpToolsTest.java
@@ -16,10 +16,11 @@ import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
-import org.eclipse.jgit.api.Git;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.refactoringminer.api.Refactoring;
 import org.refactoringminer.api.RefactoringType;
 import org.refactoringminer.astDiff.models.ProjectASTDiff;
@@ -31,317 +32,50 @@ class RefactoringMinerMcpToolsTest {
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	@Test
-	void fileContentsToolMetadataIsReadOnlyAndNamedForAgents() {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeFileContentsTool(
-				new RefactoringMinerMcpService((before, after) -> new ProjectASTDiff(before, after)));
-
-		assertEquals(RefactoringMinerMcpTools.ANALYZE_FILE_CONTENTS, tool.tool().name());
-		assertTrue(tool.tool().description().contains("Find refactorings"));
-		assertTrue(tool.tool().annotations().readOnlyHint());
-		assertFalse(tool.tool().annotations().destructiveHint());
-		assertTrue(tool.tool().inputSchema().required().contains("beforeFiles"));
-		assertTrue(tool.tool().inputSchema().required().contains("afterFiles"));
-	}
-
-	@Test
-	void worktreeToolMetadataIsReadOnlyAndDefaultsRepositoryPath() {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeWorktreeTool(
-				new RefactoringMinerMcpService((before, after) -> new ProjectASTDiff(before, after)));
-
-		assertEquals(RefactoringMinerMcpTools.ANALYZE_WORKTREE, tool.tool().name());
-		assertTrue(tool.tool().description().contains("local modified, added, deleted"));
-		assertTrue(tool.tool().annotations().readOnlyHint());
-		assertFalse(tool.tool().annotations().destructiveHint());
-		assertFalse(tool.tool().inputSchema().required().contains("repositoryPath"));
-	}
-
-	@Test
-	void toolSpecificationsExposeFullReadOnlyV1Surface() {
+	void toolSpecificationsExposeThreeSourceParameterizedTools() {
 		SyncToolSpecification[] tools = RefactoringMinerMcpTools.toolSpecifications();
 
-		assertEquals(14, tools.length);
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.ANALYZE_FILE_CONTENTS.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.ANALYZE_WORKTREE.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.ANALYZE_COMMIT.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.ANALYZE_PULL_REQUEST.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.ANALYZE_DIRECTORIES.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.VALIDATE_FILE_CONTENTS.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.VALIDATE_WORKTREE.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.VALIDATE_COMMIT.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.VALIDATE_PULL_REQUEST.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.VALIDATE_DIRECTORIES.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.DIFF_FILE_CONTENTS.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.DIFF_WORKTREE.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.DIFF_COMMIT.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools)
-				.anyMatch(tool -> RefactoringMinerMcpTools.DIFF_PULL_REQUEST.equals(tool.tool().name())));
-		assertTrue(java.util.Arrays.stream(tools).allMatch(tool -> tool.tool().annotations().readOnlyHint()));
-		assertTrue(java.util.Arrays.stream(tools).noneMatch(tool -> tool.tool().annotations().destructiveHint()));
-	}
-
-	@Test
-	void remainingToolMetadataIsReadOnlyAndHasExpectedRequiredInputs() {
-		RefactoringMinerMcpService service = fakeService();
-		SyncToolSpecification commitTool = RefactoringMinerMcpTools.analyzeCommitTool(service);
-		SyncToolSpecification pullRequestTool = RefactoringMinerMcpTools.analyzePullRequestTool(service);
-		SyncToolSpecification directoriesTool = RefactoringMinerMcpTools.analyzeDirectoriesTool(service);
-
-		assertTrue(commitTool.tool().annotations().readOnlyHint());
-		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
-		assertTrue(pullRequestTool.tool().annotations().readOnlyHint());
-		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
-		assertFalse(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
-		assertTrue(pullRequestTool.tool().inputSchema().required().contains("pullRequestId"));
-		assertTrue(directoriesTool.tool().annotations().readOnlyHint());
-		assertTrue(directoriesTool.tool().inputSchema().required().contains("beforePath"));
-		assertTrue(directoriesTool.tool().inputSchema().required().contains("afterPath"));
-	}
-
-	@Test
-	void diffBrowserToolMetadataIsReadOnlyAndUsesLocalhostPortDefault() {
-		RefactoringMinerMcpService service = fakeDiffBrowserService();
-		SyncToolSpecification fileTool = RefactoringMinerMcpTools.diffFileContentsTool(service);
-		SyncToolSpecification worktreeTool = RefactoringMinerMcpTools.diffWorktreeTool(service);
-		SyncToolSpecification commitTool = RefactoringMinerMcpTools.diffCommitTool(service);
-		SyncToolSpecification pullRequestTool = RefactoringMinerMcpTools.diffPullRequestTool(service);
-
-		for (SyncToolSpecification tool : List.of(fileTool, worktreeTool, commitTool, pullRequestTool)) {
+		assertEquals(3, tools.length);
+		assertEquals(RefactoringMinerMcpTools.ANALYZE, tools[0].tool().name());
+		assertEquals(RefactoringMinerMcpTools.VALIDATE, tools[1].tool().name());
+		assertEquals(RefactoringMinerMcpTools.DIFF, tools[2].tool().name());
+		for (SyncToolSpecification tool : tools) {
 			assertTrue(tool.tool().annotations().readOnlyHint());
 			assertFalse(tool.tool().annotations().destructiveHint());
-			assertTrue(tool.tool().description().contains("localhost URL"));
-			Object portSchema = tool.tool().inputSchema().properties().get("port");
-			assertTrue(portSchema instanceof Map<?, ?>);
-			assertEquals(6789, ((Map<?, ?>) portSchema).get("default"));
+			assertTrue(tool.tool().annotations().openWorldHint());
+			assertTrue(tool.tool().inputSchema().properties().containsKey("source"));
+			assertFalse(tool.tool().inputSchema().properties().containsKey("repositoryPath"));
+			assertFalse(tool.tool().inputSchema().toString().contains("repositoryPath"));
 		}
-		assertTrue(fileTool.tool().inputSchema().required().contains("beforeFiles"));
-		assertTrue(fileTool.tool().inputSchema().required().contains("afterFiles"));
-		assertFalse(worktreeTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
-		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
-		assertFalse(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
-		assertTrue(pullRequestTool.tool().inputSchema().required().contains("pullRequestId"));
 	}
 
 	@Test
-	void validationToolMetadataIsReadOnlyAndRequiresIntent() {
-		RefactoringMinerMcpService service = fakeService();
-		SyncToolSpecification fileTool = RefactoringMinerMcpTools.validateFileContentsTool(service);
-		SyncToolSpecification worktreeTool = RefactoringMinerMcpTools.validateWorktreeTool(service);
-		SyncToolSpecification commitTool = RefactoringMinerMcpTools.validateCommitTool(service);
-		SyncToolSpecification pullRequestTool = RefactoringMinerMcpTools.validatePullRequestTool(service);
-		SyncToolSpecification directoriesTool = RefactoringMinerMcpTools.validateDirectoriesTool(service);
-
-		for (SyncToolSpecification tool : List.of(fileTool, worktreeTool, commitTool, pullRequestTool, directoriesTool)) {
-			assertTrue(tool.tool().annotations().readOnlyHint());
-			assertFalse(tool.tool().annotations().destructiveHint());
-			assertTrue(tool.tool().inputSchema().required().contains("intent"));
-		}
-		assertTrue(fileTool.tool().inputSchema().required().contains("beforeFiles"));
-		assertTrue(fileTool.tool().inputSchema().required().contains("afterFiles"));
-		assertFalse(worktreeTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertFalse(commitTool.tool().inputSchema().required().contains("repositoryPath"));
-		assertTrue(commitTool.tool().inputSchema().required().contains("commitId"));
-		assertTrue(pullRequestTool.tool().annotations().openWorldHint());
-		assertFalse(pullRequestTool.tool().inputSchema().required().contains("cloneUrl"));
-		assertTrue(pullRequestTool.tool().inputSchema().required().contains("pullRequestId"));
-		assertTrue(directoriesTool.tool().inputSchema().required().contains("beforePath"));
-		assertTrue(directoriesTool.tool().inputSchema().required().contains("afterPath"));
-	}
-
-	@Test
-	void fileContentsToolReturnsJsonTextAndStructuredContent() throws Exception {
-		RefactoringMinerMcpService service = new RefactoringMinerMcpService((before, after) -> {
-			ProjectASTDiff diff = new ProjectASTDiff(before, after);
-			diff.setRefactorings(java.util.List.of());
-			return diff;
-		});
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeFileContentsTool(service);
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_FILE_CONTENTS, Map.of(
-				"beforeFiles", Map.of("src/main/java/A.java", "class A {}"),
-				"afterFiles", Map.of("src/main/java/A.java", "class A { int x; }"),
+	void analyzeToolUsesFileContentsSource() throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE, Map.of(
+				"source", Map.of(
+						"type", "fileContents",
+						"beforeFiles", Map.of("src/main/java/A.java", "class A { void f() {} }"),
+						"afterFiles", Map.of("src/main/java/A.java", "class A { void g() {} }")),
 				"maxRefactorings", 5));
 
 		CallToolResult result = tool.callHandler().apply(null, request);
 
 		assertFalse(result.isError());
 		assertTrue(result.structuredContent() instanceof McpAnalysisResult);
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
+		JsonNode json = json(result);
 		assertEquals("ok", json.get("status").asText());
-		assertEquals(1, json.get("filesBefore").asInt());
-		assertEquals(1, json.get("filesAfter").asInt());
+		assertEquals(1, json.get("refactorings").size());
 	}
 
 	@Test
-	void fileContentsToolReturnsErrorShapeForInvalidArguments() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeFileContentsTool(
-				new RefactoringMinerMcpService((before, after) -> new ProjectASTDiff(before, after)));
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_FILE_CONTENTS, Map.of(
-				"beforeFiles", "not-an-object",
-				"afterFiles", Map.of()));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("beforeFiles and afterFiles are required"));
-	}
-
-	@Test
-	void explicitFileContentToolsRejectOversizedInput() throws Exception {
-		Map<String, String> beforeFiles = Map.of("src/main/java/A.java", "class A { void f() {} }");
-		Map<String, String> afterFiles = Map.of("src/main/java/A.java", "class A { void g() {} }");
-		List<CallToolResult> results = List.of(
-				RefactoringMinerMcpTools.analyzeFileContentsTool(fakeService()).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_FILE_CONTENTS, Map.of(
-								"beforeFiles", beforeFiles,
-								"afterFiles", afterFiles,
-								"maxBytesPerFile", 4))),
-				RefactoringMinerMcpTools.validateFileContentsTool(fakeServiceWithRefactoring()).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_FILE_CONTENTS, Map.of(
-								"beforeFiles", beforeFiles,
-								"afterFiles", afterFiles,
-								"intent", renameMethodIntent(),
-								"maxBytesPerFile", 4))),
-				RefactoringMinerMcpTools.diffFileContentsTool(fakeDiffBrowserService()).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.DIFF_FILE_CONTENTS, Map.of(
-								"beforeFiles", beforeFiles,
-								"afterFiles", afterFiles,
-								"port", 6790,
-								"maxBytesPerFile", 4))));
-
-		for (CallToolResult result : results) {
-			assertTrue(result.isError());
-			TextContent content = (TextContent) result.content().get(0);
-			JsonNode json = OBJECT_MAPPER.readTree(content.text());
-			assertEquals("error", json.get("status").asText());
-			assertTrue(json.get("summary").asText().contains("exceeds maxBytesPerFile=4"));
-		}
-	}
-
-	@Test
-	void worktreeToolReturnsErrorShapeForInvalidRepositoryPath() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeWorktreeTool(
-				new RefactoringMinerMcpService((before, after) -> new ProjectASTDiff(before, after)));
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_WORKTREE, Map.of(
-				"repositoryPath", "relative/path"));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("repositoryPath must be absolute"));
-	}
-
-	@Test
-	void worktreeToolRejectsNegativeMaxRefactorings(@TempDir Path tempDir) throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeWorktreeTool(fakeService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_WORKTREE, Map.of(
-				"repositoryPath", tempDir.toString(),
-				"maxRefactorings", -1));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("maxRefactorings must be greater than or equal to 0"));
-	}
-
-	@Test
-	void pullRequestToolReturnsJsonTextAndStructuredContentWithoutNetwork() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzePullRequestTool(fakeService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_PULL_REQUEST, Map.of(
-				"cloneUrl", "https://github.com/tsantalis/RefactoringMiner.git",
-				"pullRequestId", 1,
-				"timeoutSeconds", 30,
-				"maxRefactorings", 5));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertFalse(result.isError());
-		assertTrue(result.structuredContent() instanceof McpAnalysisResult);
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("ok", json.get("status").asText());
-		assertEquals(1, json.get("filesBefore").asInt());
-		assertEquals(1, json.get("filesAfter").asInt());
-	}
-
-	@Test
-	void commitToolReturnsErrorShapeForInvalidRepositoryPath() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeCommitTool(fakeService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_COMMIT, Map.of(
-				"repositoryPath", "relative/path",
-				"commitId", "abc123"));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("repositoryPath must be absolute"));
-	}
-
-	@Test
-	void pullRequestToolReturnsErrorShapeForInvalidPullRequestId() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzePullRequestTool(fakeService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_PULL_REQUEST, Map.of(
-				"cloneUrl", "https://github.com/tsantalis/RefactoringMiner.git",
-				"pullRequestId", 0));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("pullRequestId must be greater than 0"));
-	}
-
-	@Test
-	void directoriesToolReturnsErrorShapeForInvalidBeforePath() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.analyzeDirectoriesTool(fakeService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.ANALYZE_DIRECTORIES, Map.of(
-				"beforePath", "relative/before",
-				"afterPath", "/tmp/after"));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("beforePath must be absolute"));
-	}
-
-	@Test
-	void fileContentsValidationToolReturnsJsonTextAndStructuredContent() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.validateFileContentsTool(fakeServiceWithRefactoring());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_FILE_CONTENTS, Map.of(
-				"beforeFiles", Map.of("src/main/java/A.java", "class A { void f() {} }"),
-				"afterFiles", Map.of("src/main/java/A.java", "class A { void g() {} }"),
+	void validateToolUsesFileContentsSource() throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.validateTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.VALIDATE, Map.of(
+				"source", Map.of(
+						"type", "fileContents",
+						"beforeFiles", Map.of("src/main/java/A.java", "class A { void f() {} }"),
+						"afterFiles", Map.of("src/main/java/A.java", "class A { void g() {} }")),
 				"intent", Map.of("type", "Rename Method", "methodNames", List.of("g")),
 				"maxCandidates", 5));
 
@@ -349,131 +83,14 @@ class RefactoringMinerMcpToolsTest {
 
 		assertFalse(result.isError());
 		assertTrue(result.structuredContent() instanceof McpValidationResult);
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
+		JsonNode json = json(result);
 		assertEquals("matched", json.get("status").asText());
-		assertFalse(json.get("intent").has("descriptionContains"));
 		assertEquals(1, json.get("matches").size());
-		assertEquals(0, json.get("candidates").size());
 	}
 
 	@Test
-	void repositoryBackedValidationHandlersReturnStructuredContentWithoutNetwork(@TempDir Path tempDir)
-			throws Exception {
-		RefactoringMinerMcpService service = fakeServiceWithRefactoring();
-		Path beforePath = Files.createDirectories(tempDir.resolve("before"));
-		Path afterPath = Files.createDirectories(tempDir.resolve("after"));
-
-		List<CallToolResult> results = List.of(
-				RefactoringMinerMcpTools.validateCommitTool(service).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_COMMIT, Map.of(
-								"repositoryPath", tempDir.toString(),
-								"commitId", "abc123",
-								"intent", renameMethodIntent()))),
-				RefactoringMinerMcpTools.validatePullRequestTool(service).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_PULL_REQUEST, Map.of(
-								"cloneUrl", "https://github.com/tsantalis/RefactoringMiner.git",
-								"pullRequestId", 1,
-								"timeoutSeconds", 30,
-								"intent", renameMethodIntent()))),
-				RefactoringMinerMcpTools.validateDirectoriesTool(service).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_DIRECTORIES, Map.of(
-								"beforePath", beforePath.toString(),
-								"afterPath", afterPath.toString(),
-								"intent", renameMethodIntent()))));
-
-		for (CallToolResult result : results) {
-			assertFalse(result.isError());
-			assertTrue(result.structuredContent() instanceof McpValidationResult);
-			TextContent content = (TextContent) result.content().get(0);
-			JsonNode json = OBJECT_MAPPER.readTree(content.text());
-			assertEquals("matched", json.get("status").asText());
-		}
-	}
-
-	@Test
-	void worktreeValidationToolReturnsErrorShapeForInvalidRepositoryPath() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.validateWorktreeTool(fakeServiceWithRefactoring());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_WORKTREE, Map.of(
-				"repositoryPath", "relative/path",
-				"intent", renameMethodIntent()));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertTrue(json.get("summary").asText().contains("repositoryPath must be absolute"));
-	}
-
-	@Test
-	void fileContentsValidationToolReturnsErrorShapeForInvalidIntentArguments() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.validateFileContentsTool(fakeServiceWithRefactoring());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.VALIDATE_FILE_CONTENTS, Map.of(
-				"beforeFiles", Map.of("src/main/java/A.java", "class A { void f() {} }"),
-				"afterFiles", Map.of("src/main/java/A.java", "class A { void g() {} }"),
-				"intent", Map.of("type", "Not A Refactoring")));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("error", json.get("status").asText());
-		assertFalse(json.has("intent"));
-		assertTrue(json.get("summary").asText().contains("Unknown refactoring type"));
-	}
-
-	@Test
-	void fileContentsDiffToolReturnsJsonTextAndStructuredContent() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.diffFileContentsTool(fakeDiffBrowserService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF_FILE_CONTENTS, Map.of(
-				"beforeFiles", Map.of("src/main/java/A.java", "class A { void f() {} }"),
-				"afterFiles", Map.of("src/main/java/A.java", "class A { void g() {} }"),
-				"port", 6790));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertFalse(result.isError());
-		assertTrue(result.structuredContent() instanceof McpDiffBrowserResult);
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("ok", json.get("status").asText());
-		assertEquals("http://127.0.0.1:6790", json.get("url").asText());
-		assertEquals("Starting server: http://127.0.0.1:6790", json.get("message").asText());
-		assertEquals(1, json.get("affectedFiles").size());
-	}
-
-	@Test
-	void worktreeDiffToolReturnsJsonTextAndStructuredContentWithoutNetwork(@TempDir Path tempDir) throws Exception {
-		Path repo = tempDir.resolve("repo");
-		try (Git git = Git.init().setDirectory(repo.toFile()).call()) {
-			write(repo, "src/main/java/A.java", "class A { void f() {} }");
-			git.add().addFilepattern(".").call();
-			git.commit().setMessage("initial").setAuthor("Test", "test@example.com")
-					.setCommitter("Test", "test@example.com").call();
-			write(repo, "src/main/java/A.java", "class A { void g() {} }");
-		}
-		SyncToolSpecification tool = RefactoringMinerMcpTools.diffWorktreeTool(fakeDiffBrowserService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF_WORKTREE, Map.of(
-				"repositoryPath", repo.toString(),
-				"baseRef", "HEAD",
-				"port", 6793));
-
-		CallToolResult result = tool.callHandler().apply(null, request);
-
-		assertFalse(result.isError());
-		assertTrue(result.structuredContent() instanceof McpDiffBrowserResult);
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
-		assertEquals("ok", json.get("status").asText());
-		assertEquals("http://127.0.0.1:6793", json.get("url").asText());
-		assertEquals("src/main/java/A.java", json.get("affectedFiles").get(0).asText());
-	}
-
-	@Test
-	void worktreeDiffToolDefaultsRepositoryPathToUserDir(@TempDir Path tempDir) throws Exception {
+	@ResourceLock("user.dir")
+	void diffToolDefaultsSourceToUserDirWorktree(@TempDir Path tempDir) throws Exception {
 		Path repo = tempDir.resolve("repo");
 		try (Git git = Git.init().setDirectory(repo.toFile()).call()) {
 			write(repo, "src/main/java/A.java", "class A { void f() {} }");
@@ -485,17 +102,51 @@ class RefactoringMinerMcpToolsTest {
 		String previousUserDir = System.getProperty("user.dir");
 		try {
 			System.setProperty("user.dir", repo.toString());
-			SyncToolSpecification tool = RefactoringMinerMcpTools.diffWorktreeTool(fakeDiffBrowserService());
-			CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF_WORKTREE, Map.of(
-					"baseRef", "HEAD",
-					"port", 6793));
+			SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+			CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of("port", 6794));
 
 			CallToolResult result = tool.callHandler().apply(null, request);
 
 			assertFalse(result.isError());
-			TextContent content = (TextContent) result.content().get(0);
-			JsonNode json = OBJECT_MAPPER.readTree(content.text());
+			assertTrue(result.structuredContent() instanceof McpDiffBrowserResult);
+			JsonNode json = json(result);
 			assertEquals("ok", json.get("status").asText());
+			assertEquals("http://127.0.0.1:6794", json.get("url").asText());
+			assertEquals("src/main/java/A.java", json.get("affectedFiles").get(0).asText());
+			assertEquals(1, json.get("refactorings").size());
+		} finally {
+			System.setProperty("user.dir", previousUserDir);
+		}
+	}
+
+	@Test
+	@ResourceLock("user.dir")
+	void diffToolSupportsRelativeWorkingDirectoryUnderUserDir(@TempDir Path tempDir) throws Exception {
+		Path repo = tempDir.resolve("repo-a");
+		try (Git git = Git.init().setDirectory(repo.toFile()).call()) {
+			write(repo, "src/main/java/A.java", "class A { void f() {} }");
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("initial").setAuthor("Test", "test@example.com")
+					.setCommitter("Test", "test@example.com").call();
+			write(repo, "src/main/java/A.java", "class A { void g() {} }");
+		}
+		String previousUserDir = System.getProperty("user.dir");
+		try {
+			System.setProperty("user.dir", tempDir.toString());
+			SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+			CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+					"source", Map.of(
+							"type", "worktree",
+							"workingDirectory", "repo-a",
+							"baseRef", "HEAD"),
+					"port", 6798));
+
+			CallToolResult result = tool.callHandler().apply(null, request);
+
+			assertFalse(result.isError());
+			JsonNode json = json(result);
+			assertEquals("ok", json.get("status").asText());
+			assertTrue(json.get("inputSummary").asText().contains(repo.toString()));
 			assertEquals("src/main/java/A.java", json.get("affectedFiles").get(0).asText());
 		} finally {
 			System.setProperty("user.dir", previousUserDir);
@@ -503,80 +154,259 @@ class RefactoringMinerMcpToolsTest {
 	}
 
 	@Test
-	void repositoryBackedDiffBrowserHandlersReturnStructuredContentWithoutNetwork(@TempDir Path tempDir)
-			throws Exception {
-		RefactoringMinerMcpService service = fakeDiffBrowserService();
-
-		List<CallToolResult> results = List.of(
-				RefactoringMinerMcpTools.diffCommitTool(service).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.DIFF_COMMIT, Map.of(
-								"repositoryPath", tempDir.toString(),
-								"commitId", "abc123",
-								"port", 6791))),
-				RefactoringMinerMcpTools.diffPullRequestTool(service).callHandler().apply(null,
-						new CallToolRequest(RefactoringMinerMcpTools.DIFF_PULL_REQUEST, Map.of(
-								"cloneUrl", "https://github.com/tsantalis/RefactoringMiner.git",
-								"pullRequestId", 1,
-								"timeoutSeconds", 30,
-								"port", 6792))));
-
-		for (CallToolResult result : results) {
-			assertFalse(result.isError());
-			assertTrue(result.structuredContent() instanceof McpDiffBrowserResult);
-			TextContent content = (TextContent) result.content().get(0);
-			JsonNode json = OBJECT_MAPPER.readTree(content.text());
-			assertEquals("ok", json.get("status").asText());
-			assertTrue(json.get("url").asText().startsWith("http://127.0.0.1:"));
-		}
-	}
-
-	@Test
-	void diffBrowserToolReturnsErrorShapeForInvalidPort() throws Exception {
-		SyncToolSpecification tool = RefactoringMinerMcpTools.diffFileContentsTool(fakeDiffBrowserService());
-		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF_FILE_CONTENTS, Map.of(
-				"beforeFiles", Map.of("src/main/java/A.java", "class A {}"),
-				"afterFiles", Map.of("src/main/java/A.java", "class A { int x; }"),
-				"port", 0));
+	void toolsRejectAbsoluteWorkingDirectory(@TempDir Path tempDir) throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"type", "worktree",
+						"workingDirectory", tempDir.toString()),
+				"port", 6798));
 
 		CallToolResult result = tool.callHandler().apply(null, request);
 
 		assertTrue(result.isError());
-		TextContent content = (TextContent) result.content().get(0);
-		JsonNode json = OBJECT_MAPPER.readTree(content.text());
+		JsonNode json = json(result);
+		assertEquals("error", json.get("status").asText());
+		assertTrue(json.get("summary").asText().contains("source.workingDirectory must be relative"));
+	}
+
+	@Test
+	void toolsRejectEscapingWorkingDirectory() throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"type", "worktree",
+						"workingDirectory", "../repo"),
+				"port", 6798));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertTrue(result.isError());
+		JsonNode json = json(result);
+		assertEquals("error", json.get("status").asText());
+		assertTrue(json.get("summary").asText().contains("source.workingDirectory must stay inside"));
+	}
+
+	@Test
+	void diffToolInfersPullRequestSourceFromPullRequestFields() throws Exception {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> {
+					throw new AssertionError("worktree differ should not run for PR input");
+				},
+				(repositoryPath, commitId, parentIndex) -> {
+					throw new AssertionError("local commit differ should not run for PR input");
+				},
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> {
+					throw new AssertionError("commit URL differ should not run for PR input");
+				},
+				(cloneUrl, pullRequestId, timeoutSeconds) -> {
+					assertEquals("https://github.com/tsantalis/RefactoringMiner.git", cloneUrl);
+					assertEquals(1055, pullRequestId);
+					assertEquals(30, timeoutSeconds);
+					return diffWithRefactoring(
+							Map.of("src/main/java/A.java", "class A { void f() {} }"),
+							Map.of("src/main/java/A.java", "class A { void g() {} }"));
+				},
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(diff, port, inputSummary, warnings, maxRefactorings) ->
+						McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxRefactorings));
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(service);
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"cloneUrl", "https://github.com/tsantalis/RefactoringMiner.git",
+						"pullRequestId", 1055,
+						"timeoutSeconds", 30),
+				"port", 6795));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertFalse(result.isError());
+		JsonNode json = json(result);
+		assertEquals("ok", json.get("status").asText());
+		assertEquals("http://127.0.0.1:6795", json.get("url").asText());
+		assertEquals(1, json.get("refactorings").size());
+	}
+
+	@Test
+	void diffToolAcceptsPullRequestSourceAlias() throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"type", "PULL_REQUEST",
+						"cloneUrl", "https://github.com/tsantalis/RefactoringMiner.git",
+						"pullRequestId", 1055),
+				"port", 6795));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertFalse(result.isError());
+		JsonNode json = json(result);
+		assertEquals("ok", json.get("status").asText());
+		assertEquals("http://127.0.0.1:6795", json.get("url").asText());
+	}
+
+	@Test
+	void diffToolDispatchesPullRequestUrlSource() throws Exception {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> {
+					throw new AssertionError("worktree differ should not run for URL input");
+				},
+				(repositoryPath, commitId, parentIndex) -> {
+					throw new AssertionError("local commit differ should not run for PR URL input");
+				},
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> {
+					throw new AssertionError("commit URL differ should not run for PR URL input");
+				},
+				(cloneUrl, pullRequestId, timeoutSeconds) -> {
+					assertEquals("https://github.com/tsantalis/RefactoringMiner.git", cloneUrl);
+					assertEquals(1086, pullRequestId);
+					assertEquals(30, timeoutSeconds);
+					return diffWithRefactoring(
+							Map.of("src/main/java/A.java", "class A { void f() {} }"),
+							Map.of("src/main/java/A.java", "class A { void g() {} }"));
+				},
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(diff, port, inputSummary, warnings, maxRefactorings) ->
+						McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxRefactorings));
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(service);
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"type", "url",
+						"url", "https://github.com/tsantalis/RefactoringMiner/pull/1086/files",
+						"timeoutSeconds", 30),
+				"port", 6795));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertFalse(result.isError());
+		JsonNode json = json(result);
+		assertEquals("ok", json.get("status").asText());
+		assertEquals("http://127.0.0.1:6795", json.get("url").asText());
+		assertTrue(json.get("inputSummary").asText().contains("/pull/1086/files"));
+		assertEquals(1, json.get("refactorings").size());
+	}
+
+	@Test
+	void diffToolInfersUrlSourceFromUrlField() throws Exception {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> {
+					throw new AssertionError("worktree differ should not run for URL input");
+				},
+				(repositoryPath, commitId, parentIndex) -> {
+					throw new AssertionError("local commit differ should not run for URL input");
+				},
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> {
+					throw new AssertionError("commit URL differ should not run for PR URL input");
+				},
+				(cloneUrl, pullRequestId, timeoutSeconds) -> {
+					assertEquals("https://github.com/tsantalis/RefactoringMiner.git", cloneUrl);
+					assertEquals(1055, pullRequestId);
+					return diffWithRefactoring(
+							Map.of("src/main/java/A.java", "class A { void f() {} }"),
+							Map.of("src/main/java/A.java", "class A { void g() {} }"));
+				},
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(diff, port, inputSummary, warnings, maxRefactorings) ->
+						McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxRefactorings));
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(service);
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"url", "https://github.com/tsantalis/RefactoringMiner/pull/1055/files",
+						"timeoutSeconds", 30),
+				"port", 6795));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertFalse(result.isError());
+		JsonNode json = json(result);
+		assertEquals("ok", json.get("status").asText());
+		assertEquals("http://127.0.0.1:6795", json.get("url").asText());
+		assertTrue(json.get("inputSummary").asText().contains("/pull/1055/files"));
+	}
+
+	@Test
+	void diffToolDispatchesCommitUrlSourceWithParentIndex() throws Exception {
+		RefactoringMinerMcpService service = new RefactoringMinerMcpService(
+				(before, after) -> {
+					throw new AssertionError("worktree differ should not run for URL input");
+				},
+				(repositoryPath, commitId, parentIndex) -> {
+					throw new AssertionError("local commit differ should not run for URL input");
+				},
+				(cloneUrl, commitId, parentIndex, timeoutSeconds) -> {
+					assertEquals("https://github.com/tsantalis/RefactoringMiner.git", cloneUrl);
+					assertEquals("abcdef1234567890", commitId);
+					assertEquals(1, parentIndex);
+					assertEquals(45, timeoutSeconds);
+					return diffWithRefactoring(
+							Map.of("src/main/java/A.java", "class A { void f() {} }"),
+							Map.of("src/main/java/A.java", "class A { void g() {} }"));
+				},
+				(cloneUrl, pullRequestId, timeoutSeconds) -> {
+					throw new AssertionError("PR differ should not run for commit URL input");
+				},
+				(beforePath, afterPath) -> new ProjectASTDiff(Map.of(), Map.of()),
+				(diff, port, inputSummary, warnings, maxRefactorings) ->
+						McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxRefactorings));
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(service);
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"type", "url",
+						"url", "https://github.com/tsantalis/RefactoringMiner/commit/abcdef1234567890?diff=split",
+						"parentIndex", 1,
+						"timeoutSeconds", 45),
+				"maxRefactorings", 0,
+				"port", 6796));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertFalse(result.isError());
+		JsonNode json = json(result);
+		assertEquals("ok", json.get("status").asText());
+		assertEquals("http://127.0.0.1:6796", json.get("url").asText());
+		assertEquals(1, json.get("refactoringCount").asInt());
+		assertEquals(0, json.get("refactorings").size());
+		assertTrue(json.get("warnings").get(0).asText().contains("Refactorings truncated to 0 of 1"));
+	}
+
+	@Test
+	void toolsRejectRepositoryPathInSource(@TempDir Path tempDir) throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of(
+				"source", Map.of(
+						"type", "worktree",
+						"repositoryPath", tempDir.toString()),
+				"port", 6797));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertTrue(result.isError());
+		JsonNode json = json(result);
+		assertEquals("error", json.get("status").asText());
+		assertTrue(json.get("summary").asText().contains("Unsupported source argument"));
+		assertTrue(json.get("warnings").get(0).asText().contains("target project directory"));
+	}
+
+	@Test
+	void diffToolReturnsErrorShapeForInvalidPort() throws Exception {
+		SyncToolSpecification tool = RefactoringMinerMcpTools.diffTool(fakeService());
+		CallToolRequest request = new CallToolRequest(RefactoringMinerMcpTools.DIFF, Map.of("port", 0));
+
+		CallToolResult result = tool.callHandler().apply(null, request);
+
+		assertTrue(result.isError());
+		JsonNode json = json(result);
 		assertEquals("error", json.get("status").asText());
 		assertTrue(json.get("summary").asText().contains("port must be between 1 and 65535"));
 	}
 
+	private static JsonNode json(CallToolResult result) throws Exception {
+		TextContent content = (TextContent) result.content().get(0);
+		return OBJECT_MAPPER.readTree(content.text());
+	}
+
 	private static RefactoringMinerMcpService fakeService() {
 		return new RefactoringMinerMcpService(
-				(before, after) -> new ProjectASTDiff(before, after),
-				(repositoryPath, commitId, parentIndex) -> new ProjectASTDiff(
-						Map.of("src/main/java/A.java", "class A {}"),
-						Map.of("src/main/java/A.java", "class A { int x; }")),
-				(cloneUrl, pullRequestId, timeoutSeconds) -> new ProjectASTDiff(
-						Map.of("src/main/java/A.java", "class A {}"),
-						Map.of("src/main/java/A.java", "class A { int x; }")),
-				(beforePath, afterPath) -> new ProjectASTDiff(
-						Map.of("src/main/java/A.java", "class A {}"),
-						Map.of("src/main/java/A.java", "class A { int x; }")));
-	}
-
-	private static RefactoringMinerMcpService fakeServiceWithRefactoring() {
-		return new RefactoringMinerMcpService(
-				(before, after) -> diffWithRefactoring(before, after),
-				(repositoryPath, commitId, parentIndex) -> diffWithRefactoring(
-						Map.of("src/main/java/A.java", "class A { void f() {} }"),
-						Map.of("src/main/java/A.java", "class A { void g() {} }")),
-				(cloneUrl, pullRequestId, timeoutSeconds) -> diffWithRefactoring(
-						Map.of("src/main/java/A.java", "class A { void f() {} }"),
-						Map.of("src/main/java/A.java", "class A { void g() {} }")),
-				(beforePath, afterPath) -> diffWithRefactoring(
-						Map.of("src/main/java/A.java", "class A { void f() {} }"),
-						Map.of("src/main/java/A.java", "class A { void g() {} }")));
-	}
-
-	private static RefactoringMinerMcpService fakeDiffBrowserService() {
-		return new RefactoringMinerMcpService(
 				(before, after) -> diffWithRefactoring(before, after),
 				(repositoryPath, commitId, parentIndex) -> diffWithRefactoring(
 						Map.of("src/main/java/A.java", "class A { void f() {} }"),
@@ -587,11 +417,11 @@ class RefactoringMinerMcpToolsTest {
 				(beforePath, afterPath) -> diffWithRefactoring(
 						Map.of("src/main/java/A.java", "class A { void f() {} }"),
 						Map.of("src/main/java/A.java", "class A { void g() {} }")),
-				(diff, port, inputSummary, warnings) -> {
+				(diff, port, inputSummary, warnings, maxRefactorings) -> {
 					if (port < 1 || port > 65535) {
 						throw new IllegalArgumentException("port must be between 1 and 65535.");
 					}
-					return McpDiffBrowserResult.ok(diff, port, inputSummary, warnings);
+					return McpDiffBrowserResult.ok(diff, port, inputSummary, warnings, maxRefactorings);
 				});
 	}
 
@@ -599,10 +429,6 @@ class RefactoringMinerMcpToolsTest {
 		ProjectASTDiff diff = new ProjectASTDiff(before, after);
 		diff.setRefactorings(List.of(new FakeRefactoring()));
 		return diff;
-	}
-
-	private static Map<String, Object> renameMethodIntent() {
-		return Map.of("type", "Rename Method", "methodNames", List.of("g"));
 	}
 
 	private static void write(Path repo, String relativePath, String content) throws Exception {

--- a/src/test/java/org/refactoringminer/mcp/WebDiffBrowserLauncherTest.java
+++ b/src/test/java/org/refactoringminer/mcp/WebDiffBrowserLauncherTest.java
@@ -33,7 +33,7 @@ class WebDiffBrowserLauncherTest {
 
 		try {
 			System.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8));
-			McpDiffBrowserResult result = launcher.launch(projectDiff(), 6790, "test input", List.of());
+			McpDiffBrowserResult result = launcher.launch(projectDiff(), 6790, "test input", List.of(), 20);
 
 			assertEquals("ok", result.status());
 			assertEquals("Starting server: http://127.0.0.1:6790", result.message());
@@ -56,8 +56,8 @@ class WebDiffBrowserLauncherTest {
 		}, port -> {
 		});
 
-		launcher.launch(projectDiff(), 6790, "first", List.of());
-		launcher.launch(projectDiff(), 6791, "second", List.of());
+		launcher.launch(projectDiff(), 6790, "first", List.of(), 20);
+		launcher.launch(projectDiff(), 6791, "second", List.of(), 20);
 
 		assertEquals(2, views.size());
 		assertTrue(views.get(0).terminated);
@@ -78,9 +78,9 @@ class WebDiffBrowserLauncherTest {
 			}
 		});
 
-		launcher.launch(projectDiff(), 6790, "first", List.of());
+		launcher.launch(projectDiff(), 6790, "first", List.of(), 20);
 		IllegalArgumentException occupied = assertThrows(IllegalArgumentException.class,
-				() -> launcher.launch(projectDiff(), 6791, "second", List.of()));
+				() -> launcher.launch(projectDiff(), 6791, "second", List.of(), 20));
 
 		assertTrue(occupied.getMessage().contains("port is already in use"));
 		assertEquals(1, views.size());
@@ -95,7 +95,7 @@ class WebDiffBrowserLauncherTest {
 		WebDiffBrowserLauncher launcher = new WebDiffBrowserLauncher(diff -> failingView, port -> {
 		});
 
-		assertThrows(IllegalStateException.class, () -> launcher.launch(projectDiff(), 6790, "input", List.of()));
+		assertThrows(IllegalStateException.class, () -> launcher.launch(projectDiff(), 6790, "input", List.of(), 20));
 
 		assertTrue(failingView.started);
 		assertTrue(failingView.terminated);
@@ -112,9 +112,9 @@ class WebDiffBrowserLauncherTest {
 				});
 
 		assertThrows(IllegalArgumentException.class,
-				() -> invalidPortLauncher.launch(projectDiff(), 0, "input", List.of()));
+				() -> invalidPortLauncher.launch(projectDiff(), 0, "input", List.of(), 20));
 		IllegalArgumentException occupied = assertThrows(IllegalArgumentException.class,
-				() -> occupiedPortLauncher.launch(projectDiff(), 6790, "input", List.of()));
+				() -> occupiedPortLauncher.launch(projectDiff(), 6790, "input", List.of(), 20));
 
 		assertTrue(occupied.getMessage().contains("port is already in use"));
 	}
@@ -129,7 +129,7 @@ class WebDiffBrowserLauncherTest {
 		}, port -> {
 		});
 
-		launcher.launch(diff, 6790, "input", List.of());
+		launcher.launch(diff, 6790, "input", List.of(), 20);
 
 		assertSame(diff, received.get(0));
 	}
@@ -144,7 +144,7 @@ class WebDiffBrowserLauncherTest {
 		}, port -> {
 		}, "0.0.0.0", "localhost");
 
-		McpDiffBrowserResult result = launcher.launch(projectDiff(), 6790, "input", List.of());
+		McpDiffBrowserResult result = launcher.launch(projectDiff(), 6790, "input", List.of(), 20);
 
 		assertEquals("http://localhost:6790", result.url());
 		assertEquals("Starting server: http://localhost:6790", result.message());


### PR DESCRIPTION
## Summary

- Replace the old multi-tool MCP surface with three source-parameterized tools: `refactoringminer_analyze`, `refactoringminer_validate`, and `refactoringminer_diff`.
- Route each tool through a `source` object so agents choose file contents, worktree, commit, pull request, directories, or URL sources without choosing among near-duplicate tools.
- Infer `source.type` from unambiguous source fields such as `pullRequestId`, `cloneUrl`, `url`, `commitId`, and file/path inputs, and accept common aliases like `PULL_REQUEST`.
- Keep `repositoryPath` out of the MCP schema; local worktree and commit sources use the MCP server working directory by default, and can target relative `source.workingDirectory` subdirectories for shared Docker sidecar containers.
- Return bounded refactoring details and affected files from diff-browser results, and update MCP docs/tests for the new source model.

Refs #1086

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew test --tests 'org.refactoringminer.mcp.*' mcpSmoke --no-daemon --console=plain`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew shadowJar --no-daemon --console=plain`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) npx -y @modelcontextprotocol/inspector --cli --transport stdio java -jar build/libs/RM-fat.jar mcp --method tools/call --tool-name refactoringminer_diff --tool-arg source='{"cloneUrl":"https://github.com/tsantalis/RefactoringMiner.git","pullRequestId":1055}' --tool-arg port=6789` -> `status: ok`, 4 AST diffs, 0 refactorings.