### PR TITLE
Handle Python test fixture markup in AST diff

### DIFF
--- a/src/main/java/gr/uom/java/xmi/PythonFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/PythonFileProcessor.java
@@ -27,6 +27,7 @@ public class PythonFileProcessor {
 
 	public void processPythonFile(String filePath, String fileContent, boolean astDiff) {
 		try {
+			fileContent = PythonTestFixtureMarkupSanitizer.sanitize(filePath, fileContent);
 			LangSupportedEnum language = LangSupportedEnum.fromFileName(filePath);
 			LangASTNode ast = LangASTUtil.getLangAST(language, fileContent);
 			if (astDiff) {

--- a/src/main/java/gr/uom/java/xmi/PythonTestFixtureMarkupSanitizer.java
+++ b/src/main/java/gr/uom/java/xmi/PythonTestFixtureMarkupSanitizer.java
@@ -1,0 +1,39 @@
+package gr.uom.java.xmi;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class PythonTestFixtureMarkupSanitizer {
+	private static final Pattern FIXTURE_MARKUP = Pattern.compile(
+			"</?(?:warning|weak_warning|error|info|caret|selection|fold|ref|symbolName|lineMarker|TYPO|inject)(?:\\s+[^<>]*)?>");
+
+	private PythonTestFixtureMarkupSanitizer() {
+	}
+
+	static String sanitize(String filePath, String fileContent) {
+		if(fileContent == null || fileContent.indexOf('<') == -1 || !isTestFixtureFile(filePath)) {
+			return fileContent;
+		}
+		Matcher matcher = FIXTURE_MARKUP.matcher(fileContent);
+		StringBuffer sanitized = new StringBuffer(fileContent.length());
+		while(matcher.find()) {
+			matcher.appendReplacement(sanitized, Matcher.quoteReplacement(toWhitespace(matcher.group())));
+		}
+		matcher.appendTail(sanitized);
+		return sanitized.toString();
+	}
+
+	private static boolean isTestFixtureFile(String filePath) {
+		String normalizedPath = filePath.replace('\\', '/');
+		return normalizedPath.startsWith("testData/") || normalizedPath.contains("/testData/");
+	}
+
+	private static String toWhitespace(String value) {
+		StringBuilder builder = new StringBuilder(value.length());
+		for(int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			builder.append(ch == '\n' || ch == '\r' ? ch : ' ');
+		}
+		return builder.toString();
+	}
+}

--- a/src/test/java/gr/uom/java/xmi/PythonTestFixtureMarkupSanitizerTest.java
+++ b/src/test/java/gr/uom/java/xmi/PythonTestFixtureMarkupSanitizerTest.java
@@ -1,0 +1,43 @@
+package gr.uom.java.xmi;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class PythonTestFixtureMarkupSanitizerTest {
+	@Test
+	void preservesLengthWhenReplacingKnownFixtureMarkup() {
+		String fileContent = "yield <warning descr=\"problem\">1</warning>\n";
+		String sanitized = PythonTestFixtureMarkupSanitizer.sanitize("python/testData/inspections/sample.py", fileContent);
+
+		assertEquals(fileContent.length(), sanitized.length());
+		assertEquals(fileContent.indexOf("1"), sanitized.indexOf("1"));
+		assertEquals(-1, sanitized.indexOf("<warning"));
+	}
+
+	@Test
+	void doesNotSanitizeNonTestDataFiles() {
+		String fileContent = "value = \"<warning descr=\\\"text\\\">\"\n";
+
+		assertSame(fileContent, PythonTestFixtureMarkupSanitizer.sanitize("src/main/python/sample.py", fileContent));
+	}
+
+	@Test
+	void pythonFixtureDiagnosticsDoNotCrashModelReader() {
+		String fileContent = """
+				from typing import Iterable
+
+				def values() -> Iterable[str]:
+				    yield <warning descr="Expected yield type 'str', got 'int' instead">42</warning>
+				""";
+
+		assertDoesNotThrow(() -> new UMLModelASTReader(
+				Map.of("python/testData/inspections/PyTypeCheckerInspection/FunctionYieldTypePy3.py", fileContent),
+				Set.of("python/testData/inspections/PyTypeCheckerInspection"), false).getUmlModel());
+	}
+}


### PR DESCRIPTION
Fixes #1092
Fixes #1094

### Summary
- Replace known marker tags in Python `testData` fixture files before Python AST/model processing.
- Preserve source length while replacing tags, so offsets stay stable.
- Add focused regression tests for Python diagnostic tags.

### Notes
- #1093 is already fixed on `master` by `8efe2113b`, and this branch is rebased on that change.
- #1095 already reached WebDiff startup on `master`, so this PR does not treat it as an open GumTree failure.

### Validation
- `./gradlew test --tests gr.uom.java.xmi.PythonTestFixtureMarkupSanitizerTest --no-daemon --console=plain`
- `git diff --check`
- Reproduced the reported commit URLs for #1092 and #1094 through `diff --url ... --no-browser`; both reached WebDiff startup after the patch.