### PR TITLE
Improve C++ function/class processing and operation body handling

### DIFF
--- a/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
@@ -9,10 +9,12 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
+import org.eclipse.cdt.core.dom.ast.IASTCompositeTypeSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTCompoundStatement;
 import org.eclipse.cdt.core.dom.ast.IASTDeclSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTFileLocation;
+import org.eclipse.cdt.core.dom.ast.IASTFunctionDefinition;
 import org.eclipse.cdt.core.dom.ast.IASTFunctionDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTFunctionStyleMacroParameter;
 import org.eclipse.cdt.core.dom.ast.IASTName;
@@ -33,10 +35,12 @@ import org.eclipse.cdt.core.dom.ast.IASTPreprocessorObjectStyleMacroDefinition;
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorPragmaStatement;
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorStatement;
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorUndefStatement;
+import org.eclipse.cdt.core.dom.ast.IASTSimpleDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTStandardFunctionDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTStatement;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTVisibilityLabel;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCompositeTypeSpecifier;
 import org.eclipse.cdt.core.dom.ast.gnu.c.GCCLanguage;
 import org.eclipse.cdt.core.dom.ast.gnu.cpp.GPPLanguage;
 import org.eclipse.cdt.core.parser.DefaultLogService;
@@ -219,10 +223,10 @@ public class CppFileProcessor {
 		Visibility currentVisibility = null;
 		for(IASTDeclaration declaration : declarations) {
 			if(declaration instanceof CPPASTSimpleDeclaration cppSimpleDeclaration) {
-					
+				processSimpleDeclaration(packageName, sourceFolder, cppSimpleDeclaration);
 			}
 			else if(declaration instanceof CASTSimpleDeclaration cSimpleDeclaration) {
-				
+				processSimpleDeclaration(packageName, sourceFolder, cSimpleDeclaration);
 			}
 			else if(declaration instanceof CPPASTAmbiguousSimpleDeclaration cppAmbiguousSimpleDeclaration) {
 				
@@ -235,12 +239,14 @@ public class CppFileProcessor {
 				//Similar to destructuring or unpacking in languages like JavaScript and Python, it directly binds specified identifiers to the sub-objects, members, or elements of an initializer.
 			}
 			else if(declaration instanceof CASTFunctionDefinition cFunctionDefinition) {
-				UMLOperation operation = processCFunctionDefinition(cFunctionDefinition, sourceFolder, parentContainer);
+				UMLOperation operation = processFunctionDefinition(cFunctionDefinition, packageName, sourceFolder, parentContainer);
 				parentContainer.addOperation(operation);
 			}
 			else if(declaration instanceof CPPASTFunctionDefinition cppFunctionDefinition) {
 				//org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFunctionWithTryBlock is a subclass
 				//Function-Try-Block should be handled similar to Kotlin, which allows functions to have a try-expression as a body
+				UMLOperation operation = processFunctionDefinition(cppFunctionDefinition, packageName, sourceFolder, parentContainer);
+				parentContainer.addOperation(operation);
 			}
 			else if(declaration instanceof CPPASTAliasDeclaration cppAliasDeclaration) {
 				//A C++ alias declaration (introduced in C++11) uses the using keyword to create a readable, interchangeable synonym for an existing type or template. It is the modern, preferred alternative to typedef.
@@ -328,11 +334,32 @@ public class CppFileProcessor {
 		return umlClass;
 	}
 
-	private UMLOperation processCFunctionDefinition(CASTFunctionDefinition functionDefinition, String sourceFolder, UMLAbstractClass parentContainer) {
+	private void processSimpleDeclaration(String packageName, String sourceFolder, IASTSimpleDeclaration simpleDeclaration) {
+		if(simpleDeclaration.getDeclSpecifier() instanceof IASTCompositeTypeSpecifier compositeTypeSpecifier) {
+			if(compositeTypeSpecifier.getName() == null) {
+				return;
+			}
+			String className = compositeTypeSpecifier.getName().toString();
+			if(className.isBlank()) {
+				return;
+			}
+			LocationInfo locationInfo = new LocationInfo(sourceFolder, filePath, compositeTypeSpecifier, CodeElementType.TYPE_DECLARATION, fileContent);
+			UMLClass umlClass = new UMLClass(packageName, className, locationInfo, true, Collections.emptyList());
+			umlClass.setVisibility(Visibility.PUBLIC);
+			if(compositeTypeSpecifier instanceof ICPPASTCompositeTypeSpecifier cppCompositeTypeSpecifier) {
+				umlClass.setFinal(cppCompositeTypeSpecifier.isFinal());
+			}
+			umlClass.setActualSignature(simpleDeclaration.getRawSignature());
+			processDeclarations(packageName + "." + className, sourceFolder, umlClass, compositeTypeSpecifier.getMembers());
+			this.umlModel.addClass(umlClass);
+		}
+	}
+
+	private UMLOperation processFunctionDefinition(IASTFunctionDefinition functionDefinition, String className, String sourceFolder, UMLAbstractClass parentContainer) {
 		IASTFunctionDeclarator declarator = functionDefinition.getDeclarator();
 		IASTName functionName = declarator.getName();
 		LocationInfo locationInfo = new LocationInfo(sourceFolder, filePath, functionDefinition, CodeElementType.METHOD_DECLARATION, fileContent);
-		UMLOperation operation = new UMLOperation(functionName.toString(), locationInfo, parentContainer.getName());
+		UMLOperation operation = new UMLOperation(functionName.toString(), locationInfo, className);
 		operation.setVisibility(Visibility.PUBLIC);
 		operation.setStatic(functionDefinition.getDeclSpecifier().getStorageClass() == IASTDeclSpecifier.sc_static);
 		operation.setInline(functionDefinition.getDeclSpecifier().isInline());
@@ -420,7 +447,7 @@ public class CppFileProcessor {
 		return "arg" + index;
 	}
 
-	private String extractActualSignature(CASTFunctionDefinition functionDefinition) {
+	private String extractActualSignature(IASTFunctionDefinition functionDefinition) {
 		IASTFileLocation functionLocation = functionDefinition.getFileLocation();
 		if(functionLocation == null) {
 			return functionDefinition.getRawSignature();

--- a/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
@@ -239,13 +239,13 @@ public class CppFileProcessor {
 				//Similar to destructuring or unpacking in languages like JavaScript and Python, it directly binds specified identifiers to the sub-objects, members, or elements of an initializer.
 			}
 			else if(declaration instanceof CASTFunctionDefinition cFunctionDefinition) {
-				UMLOperation operation = processFunctionDefinition(cFunctionDefinition, packageName, sourceFolder, parentContainer);
+				UMLOperation operation = processFunctionDefinition(cFunctionDefinition, packageName, sourceFolder, parentContainer, currentVisibility);
 				parentContainer.addOperation(operation);
 			}
 			else if(declaration instanceof CPPASTFunctionDefinition cppFunctionDefinition) {
 				//org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFunctionWithTryBlock is a subclass
 				//Function-Try-Block should be handled similar to Kotlin, which allows functions to have a try-expression as a body
-				UMLOperation operation = processFunctionDefinition(cppFunctionDefinition, packageName, sourceFolder, parentContainer);
+				UMLOperation operation = processFunctionDefinition(cppFunctionDefinition, packageName, sourceFolder, parentContainer, currentVisibility);
 				parentContainer.addOperation(operation);
 			}
 			else if(declaration instanceof CPPASTAliasDeclaration cppAliasDeclaration) {
@@ -355,12 +355,12 @@ public class CppFileProcessor {
 		}
 	}
 
-	private UMLOperation processFunctionDefinition(IASTFunctionDefinition functionDefinition, String className, String sourceFolder, UMLAbstractClass parentContainer) {
+	private UMLOperation processFunctionDefinition(IASTFunctionDefinition functionDefinition, String className, String sourceFolder, UMLAbstractClass parentContainer, Visibility currentVisibility) {
 		IASTFunctionDeclarator declarator = functionDefinition.getDeclarator();
 		IASTName functionName = declarator.getName();
 		LocationInfo locationInfo = new LocationInfo(sourceFolder, filePath, functionDefinition, CodeElementType.METHOD_DECLARATION, fileContent);
 		UMLOperation operation = new UMLOperation(functionName.toString(), locationInfo, className);
-		operation.setVisibility(Visibility.PUBLIC);
+		operation.setVisibility(currentVisibility != null ? currentVisibility : Visibility.PUBLIC);
 		operation.setStatic(functionDefinition.getDeclSpecifier().getStorageClass() == IASTDeclSpecifier.sc_static);
 		operation.setInline(functionDefinition.getDeclSpecifier().isInline());
 

--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -81,6 +81,9 @@ public class CppOperationBody extends OperationBody {
 			IASTStatement[] blockStatements = compoundStatement.getStatements();
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, compoundStatement, parent.getDepth()+1, CodeElementType.BLOCK, fileContent);
 			parent.addStatement(child);
+			if(compoundStatement instanceof ICPPASTCompoundStatement cppCompoundStatement) {
+				// TODO: model cppCompoundStatement.getImplicitDestructorNames() when C++ implicit destructor calls are represented in operation bodies.
+			}
 			addStatementInVariableScopes(child);
 			for(IASTStatement blockStatement : blockStatements) {
 				processStatement(sourceFolder, filePath, child, blockStatement, fileContent);
@@ -132,7 +135,36 @@ public class CppOperationBody extends OperationBody {
 		}
 		else if(statement instanceof IASTForStatement forStatement) {
 			// IASTForStatement models a generic for loop; ICPPASTForStatement adds C++ condition declarations and implicit destructor names.
-			// composite
+			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, forStatement, parent.getDepth()+1, CodeElementType.FOR_STATEMENT, fileContent);
+			parent.addStatement(child);
+			if(forStatement.getInitializerStatement() instanceof IASTExpressionStatement initializerStatement && initializerStatement.getExpression() != null) {
+				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, initializerStatement.getExpression(), CodeElementType.FOR_STATEMENT_INITIALIZER, container, activeVariableDeclarations, fileContent, Collections.emptyList());
+				child.addExpression(abstractExpression);
+			}
+			else if(forStatement.getInitializerStatement() != null) {
+				// TODO: teach CppVisitor to extract C++ declaration initializers so variables declared in for initializers are scoped to this for statement.
+				processStatement(sourceFolder, filePath, child, forStatement.getInitializerStatement(), fileContent);
+			}
+			if(forStatement instanceof ICPPASTForStatement cppForStatement) {
+				if(cppForStatement.getConditionDeclaration() != null) {
+					// TODO: teach CppVisitor to extract C++ condition declarations so variables declared in for conditions are scoped to this for statement.
+				}
+			}
+			if(forStatement.getConditionExpression() != null) {
+				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, forStatement.getConditionExpression(), CodeElementType.FOR_STATEMENT_CONDITION, container, activeVariableDeclarations, fileContent, Collections.emptyList());
+				child.addExpression(abstractExpression);
+			}
+			if(forStatement.getIterationExpression() != null) {
+				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, forStatement.getIterationExpression(), CodeElementType.FOR_STATEMENT_UPDATER, container, activeVariableDeclarations, fileContent, Collections.emptyList());
+				child.addExpression(abstractExpression);
+			}
+			addStatementInVariableScopes(child);
+			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
+			addAllInActiveVariableDeclarations(variableDeclarations);
+			if(forStatement.getBody() != null) {
+				processStatement(sourceFolder, filePath, child, forStatement.getBody(), fileContent);
+			}
+			removeAllFromActiveVariableDeclarations(variableDeclarations);
 		}
 		else if(statement instanceof IASTGotoStatement gotoStatement) {
 			StatementObject child = new StatementObject(sourceFolder, filePath, gotoStatement, parent.getDepth()+1, CodeElementType.GOTO_STATEMENT, container, activeVariableDeclarations, fileContent);
@@ -188,12 +220,34 @@ public class CppOperationBody extends OperationBody {
 		}
 		else if(statement instanceof IASTSwitchStatement switchStatement) {
 			// IASTSwitchStatement uses a controller expression; ICPPASTSwitchStatement also supports C++ init-statements, controller declarations, and scope.
-			// composite
+			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, switchStatement, parent.getDepth()+1, CodeElementType.SWITCH_STATEMENT, fileContent);
+			parent.addStatement(child);
+			if(switchStatement instanceof ICPPASTSwitchStatement cppSwitchStatement) {
+				if(cppSwitchStatement.getInitializerStatement() != null) {
+					processStatement(sourceFolder, filePath, child, cppSwitchStatement.getInitializerStatement(), fileContent);
+				}
+				if(cppSwitchStatement.getControllerDeclaration() != null) {
+					// TODO: teach CppVisitor to extract C++ controller declarations so variables declared in switch controllers are scoped to this switch statement.
+				}
+			}
+			if(switchStatement.getControllerExpression() != null) {
+				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, switchStatement.getControllerExpression(), CodeElementType.SWITCH_STATEMENT_CONDITION, container, activeVariableDeclarations, fileContent, Collections.emptyList());
+				child.addExpression(abstractExpression);
+			}
+			addStatementInVariableScopes(child);
+			if(switchStatement.getBody() != null) {
+				processStatement(sourceFolder, filePath, child, switchStatement.getBody(), fileContent);
+			}
 		}
 		else if(statement instanceof IASTWhileStatement whileStatement) {
 			// IASTWhileStatement uses a condition expression; ICPPASTWhileStatement also supports C++ condition declarations and scope.
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, whileStatement, parent.getDepth()+1, CodeElementType.WHILE_STATEMENT, fileContent);
 			parent.addStatement(child);
+			if(whileStatement instanceof ICPPASTWhileStatement cppWhileStatement) {
+				if(cppWhileStatement.getConditionDeclaration() != null) {
+					// TODO: teach CppVisitor to extract C++ condition declarations so variables declared in while conditions are scoped to this while statement.
+				}
+			}
 			if(whileStatement.getCondition() != null) {
 				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, whileStatement.getCondition(), CodeElementType.WHILE_STATEMENT_CONDITION, container, activeVariableDeclarations, fileContent, Collections.emptyList());
 				child.addExpression(abstractExpression);
@@ -206,81 +260,10 @@ public class CppOperationBody extends OperationBody {
 		else if(statement instanceof ICPPASTCatchHandler catchHandler) {
 			// composite
 		}
-		else if(statement instanceof ICPPASTCompoundStatement cppCompoundStatement) {
-			// ICPPASTCompoundStatement is the C++ block form of IASTCompoundStatement and can own implicit destructor names.
-			//C++ objects created in the block may be destroyed automatically at the end of the block, 
-			//even though there is no explicit destructor call in the source:
-			//{
-			//    Widget w;
-			//    doWork();
-			//} // w.~Widget() happens implicitly here
-			// composite
-		}
-		else if(statement instanceof ICPPASTForStatement cppForStatement) {
-			// ICPPASTForStatement is the C++ for-loop form of IASTForStatement with condition declarations and implicit destructor names.
-			//example of what you can do in C++
-			//for (; Widget w = nextWidget(); ) {
-			  //  use(w);
-			//}
-			//Widget w may have destructors that CDT tracks implicitly, even though no destructor call appears directly in the source.
-			// composite
-		}
-		else if(statement instanceof ICPPASTIfStatement cppIfStatement) {
-			// ICPPASTIfStatement is the C++ if form of IASTIfStatement with init-statements, condition declarations, constexpr, and scope.
-			//if (int x = getValue(); x > 0) {
-		    //use(x);
-			//}
-			//
-			//int x = getValue(); part is the init-statement.
-			//also supports a condition declaration:
-			//if (Widget w = makeWidget()) {
-			//  use(w);
-			//}
-			//
-			//supports constexpr if:
-			//if constexpr (std::is_integral_v<T>) {
-			//    handleInteger();
-			//} else {
-			//    handleOther();
-			//}
-			//That is a compile-time branch in C++ templates.
-			// composite
-		}
 		else if(statement instanceof ICPPASTRangeBasedForStatement rangeBasedForStatement) {
 			// composite
 		}
-		else if(statement instanceof ICPPASTSwitchStatement cppSwitchStatement) {
-			// ICPPASTSwitchStatement is the C++ switch form of IASTSwitchStatement with init-statements, controller declarations, and scope.
-			//Covers C++ extras, like an init-statement:
-			//switch (int code = readCode(); code) {
-		    //case 0:
-		    //    break;
-		    //case 1:
-		    //    break;
-			//}
-			//int code = readCode(); runs first. Then code is used as the switch controller. The variable code is scoped to the switch.
-			//
-			//also have a controller declaration:
-			//switch (int code = readCode()) {
-		    //case 0:
-		    //    break;
-		    //case 1:
-		    //    break;
-			//}
-			//Here the controller itself declares code, instead of being only an existing expression.
-			// composite
-		}
 		else if(statement instanceof ICPPASTTryBlockStatement tryBlockStatement) {
-			// composite
-		}
-		else if(statement instanceof ICPPASTWhileStatement cppWhileStatement) {
-			// ICPPASTWhileStatement is the C++ while form of IASTWhileStatement with condition declarations and scope.
-			//also covers a C++ condition declaration:
-			//while (std::shared_ptr<Node> node = nextNode()) {
-			//    use(node);
-			//}
-			//Here the condition declares node, initializes it with nextNode(), and then tests whether node converts to true.
-			//use(node) is scoped only wihtin the loop
 			// composite
 		}
 		else if(statement instanceof IGNUASTGotoStatement gnuGotoStatement) {

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -103,11 +103,75 @@ class CppFileProcessorTest {
 		assertNotNull(size.getParametersWithoutReturnType().get(0).getVariableDeclaration());
 	}
 
+	@Test
+	void processesCppFunctionDefinitionsIntoNamespaceQualifiedOperations() {
+		String filePath = "src/math.cpp";
+		String fileContent = String.join("\n",
+				"namespace outer {",
+				"namespace inner {",
+				"static inline int add(int lhs, int rhs) {",
+				"  return lhs + rhs;",
+				"}",
+				"}",
+				"}") + "\n";
+
+		UMLModel model = new UMLModel(Set.of("src"));
+		CppFileProcessor processor = new CppFileProcessor(model);
+
+		processor.processCppFile(filePath, fileContent, false);
+
+		UMLClass moduleClass = findClass(model.getClassList(), "math");
+		assertTrue(moduleClass.isModule());
+
+		UMLOperation add = findOperation(moduleClass.getOperations(), "add");
+		assertTrue(add.getClassName().contains("outer.inner"));
+		assertTrue(add.isStatic());
+		assertTrue(add.isInline());
+		assertEquals("int", add.getReturnParameter().getType().toString());
+		assertEquals(List.of("lhs", "rhs"), add.getParameterNameList());
+		assertEquals(List.of("int", "int"), parameterTypeNames(add));
+	}
+
+	@Test
+	void processesCppClassesUnderNamespaces() {
+		String filePath = "src/widgets.cpp";
+		String fileContent = String.join("\n",
+				"namespace outer {",
+				"namespace inner {",
+				"class Widget {",
+				"public:",
+				"  int value() {",
+				"    return 1;",
+				"  }",
+				"};",
+				"}",
+				"}") + "\n";
+
+		UMLModel model = new UMLModel(Set.of("src"));
+		CppFileProcessor processor = new CppFileProcessor(model);
+
+		processor.processCppFile(filePath, fileContent, false);
+
+		UMLClass widget = findClass(model.getClassList(), "Widget");
+		assertTrue(widget.getPackageName().contains("outer.inner"));
+
+		UMLOperation value = findOperation(widget.getOperations(), "value");
+		assertTrue(value.getClassName().contains("outer.inner"));
+		assertTrue(value.getClassName().contains("Widget"));
+	}
+
 	private static UMLOperation findOperation(List<UMLOperation> operations, String name) {
 		return operations.stream()
 				.filter(operation -> operation.getName().equals(name))
 				.findFirst()
 				.orElseThrow(() -> new AssertionError("Expected operation: " + name));
+	}
+
+	private static UMLClass findClass(List<UMLClass> classes, String name) {
+		return classes.stream()
+				.filter(umlClass -> umlClass.getName().equals(name) || umlClass.getName().endsWith("." + name))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Expected class: " + name));
 	}
 
 	private static List<String> parameterTypeNames(UMLOperation operation) {

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -160,6 +160,36 @@ class CppFileProcessorTest {
 		assertTrue(value.getClassName().contains("Widget"));
 	}
 
+	@Test
+	void appliesCppVisibilityLabelsToFunctionDefinitions() {
+		String filePath = "src/widget.cpp";
+		String fileContent = String.join("\n",
+				"class Widget {",
+				"public:",
+				"  int visible() {",
+				"    return 1;",
+				"  }",
+				"protected:",
+				"  int inherited() {",
+				"    return 2;",
+				"  }",
+				"private:",
+				"  int hidden() {",
+				"    return 3;",
+				"  }",
+				"};") + "\n";
+
+		UMLModel model = new UMLModel(Set.of("src"));
+		CppFileProcessor processor = new CppFileProcessor(model);
+
+		processor.processCppFile(filePath, fileContent, false);
+
+		UMLClass widget = findClass(model.getClassList(), "Widget");
+		assertEquals(Visibility.PUBLIC, findOperation(widget.getOperations(), "visible").getVisibility());
+		assertEquals(Visibility.PROTECTED, findOperation(widget.getOperations(), "inherited").getVisibility());
+		assertEquals(Visibility.PRIVATE, findOperation(widget.getOperations(), "hidden").getVisibility());
+	}
+
 	private static UMLOperation findOperation(List<UMLOperation> operations, String name) {
 		return operations.stream()
 				.filter(operation -> operation.getName().equals(name))


### PR DESCRIPTION
Adds preliminary processing for C++ function definitions so they are converted into UMLOperations, including namespace-qualified class names, return types, parameters, static, and inline metadata.

Adds support for processing C/C++ composite type simple declarations into UMLClass entries, including nested namespace/class handling.

Preserves C++ visibility labels when creating operations from function definitions.

Expands CppOperationBody handling for for, switch, and while statements, including condition/initializer/updater expressions where available. Remove redundant branches.

Adds tests covering namespace-qualified C++ functions, classes inside namespaces, and visibility label propagation.