### PR TITLE
Fetch parent file directly when GitHub omits the PR patch (#1108)

### DIFF
--- a/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
+++ b/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
@@ -2151,7 +2151,26 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 			}
 		}
 		else {
-			PagedIterable<GHPullRequestFileDetail> files = pullRequest.listFiles();
+			List<GHPullRequestFileDetail> files = pullRequest.listFiles().toList();
+			String headSha = pullRequest.getHead().getSha();
+			// GitHub omits the patch of a file when its diff is too large (e.g. thousands of changed lines).
+			// In that case the parent file cannot be reconstructed by reverse-applying the patch, so we fetch
+			// the parent file content directly, anchored at the merge base of the pull request.
+			String mergeBaseSha = null;
+			for(GHPullRequestFileDetail commitFile : files) {
+				if(PathFileUtils.isSupportedFile(commitFile.getFilename()) && commitFile.getPatch() == null) {
+					String status = commitFile.getStatus();
+					if(status.equals("modified") || status.equals("renamed")) {
+						try {
+							mergeBaseSha = repository.getCompare(pullRequest.getBase().getSha(), headSha).getMergeBaseCommit().getSHA1();
+						}
+						catch(IOException e) {
+							logger.warn(String.format("Could not determine merge base for PR %s; files with omitted patches may be incomplete", pullRequestId), e);
+						}
+						break;
+					}
+				}
+			}
 			int changedFiles = pullRequest.getChangedFiles();
 			if(changedFiles == 0) {
 				changedFiles = 10;
@@ -2169,7 +2188,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 					}
 					multiThreadedFetch(filesBefore, filesCurrent, renamedFilesHint, repositoryDirectoriesBefore,
 							repositoryDirectoriesCurrent, deletedAndRenamedFileParentDirectories, commitFileNames, pool,
-							commitFile, fileName);
+							commitFile, fileName, headSha, mergeBaseSha);
 					count++;
 				}
 			}
@@ -2231,19 +2250,25 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 	private void multiThreadedFetch(Map<String, String> filesBefore, Map<String, String> filesCurrent,
 			Map<String, String> renamedFilesHint, Set<String> repositoryDirectoriesBefore,
 			Set<String> repositoryDirectoriesCurrent, Set<String> deletedAndRenamedFileParentDirectories,
-			List<String> commitFileNames, ExecutorService pool, GHPullRequestFileDetail commitFile, String fileName) {
+			List<String> commitFileNames, ExecutorService pool, GHPullRequestFileDetail commitFile, String fileName,
+			String headSha, String mergeBaseSha) {
 		if (commitFile.getStatus().equals("modified")) {
 			Runnable r = () -> {
 				try {
 					URL currentRawURL = commitFile.getRawUrl();
-					URLConnection connection = currentRawURL.openConnection();
-					connection.setRequestProperty("User-Agent", "Mozilla/5.0");
-					InputStream currentRawFileInputStream = connection.getInputStream();
-					String currentRawFile = streamToString(currentRawFileInputStream);
+					String currentRawFile = fetchRawFileContent(currentRawURL);
 					List<String> patchLineList = createPatchLines(commitFile);
-					com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
-					List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
-					String parentRawFile = String.join("\n", parentRawFileLines);
+					String parentRawFile;
+					if (patchLineList.isEmpty() && mergeBaseSha != null) {
+						// GitHub omitted the patch (very large diff); fetch the parent file directly at the merge base.
+						URL parentRawURL = new URL(currentRawURL.toString().replace(headSha, mergeBaseSha));
+						parentRawFile = fetchRawFileContent(parentRawURL);
+					}
+					else {
+						com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
+						List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
+						parentRawFile = String.join("\n", parentRawFileLines);
+					}
 					filesBefore.put(fileName, parentRawFile);
 					filesCurrent.put(fileName, currentRawFile);
 					String directory = new String(fileName);
@@ -2296,12 +2321,20 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 				try {
 					String previousFilename = commitFile.getPreviousFilename();
 					URL currentRawURL = commitFile.getRawUrl();
-					InputStream currentRawFileInputStream = currentRawURL.openStream();
-					String currentRawFile = streamToString(currentRawFileInputStream);
+					String currentRawFile = fetchRawFileContent(currentRawURL);
 					List<String> patchLineList = createPatchLines(commitFile);
-					com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
-					List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
-					String parentRawFile = String.join("\n", parentRawFileLines);
+					String parentRawFile;
+					if (patchLineList.isEmpty() && mergeBaseSha != null) {
+						// GitHub omitted the patch (very large diff); fetch the parent file directly at the merge base.
+						String parentRawURL = currentRawURL.toString().replace(headSha, mergeBaseSha)
+								.replace(encodeRawUrlPath(fileName), encodeRawUrlPath(previousFilename));
+						parentRawFile = fetchRawFileContent(new URL(parentRawURL));
+					}
+					else {
+						com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
+						List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
+						parentRawFile = String.join("\n", parentRawFileLines);
+					}
 					filesBefore.put(previousFilename, parentRawFile);
 					filesCurrent.put(fileName, currentRawFile);
 					renamedFilesHint.put(previousFilename, fileName);
@@ -2325,6 +2358,19 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 			};
 			pool.submit(r);
 		}
+	}
+
+	private String fetchRawFileContent(URL rawURL) throws IOException {
+		URLConnection connection = rawURL.openConnection();
+		connection.setRequestProperty("User-Agent", "Mozilla/5.0");
+		return streamToString(connection.getInputStream());
+	}
+
+	// Encodes a repository path the way GitHub encodes it inside a raw file URL (slashes become %2F).
+	// URLEncoder maps spaces to '+', whereas GitHub uses %20, so we convert those; a literal '+' in a
+	// path is encoded as %2B by URLEncoder, so this replacement only ever touches encoded spaces.
+	private static String encodeRawUrlPath(String path) {
+		return URLEncoder.encode(path, StandardCharsets.UTF_8).replace("+", "%20");
 	}
 
 	private List<String> createPatchLines(GHPullRequestFileDetail commitFile) {

--- a/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
+++ b/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
@@ -15,8 +15,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,6 +69,7 @@ import org.refactoringminer.astDiff.utils.URLHelper;
 import org.refactoringminer.astDiff.matchers.ProjectASTDiffer;
 import org.refactoringminer.util.GitServiceImpl;
 import org.refactoringminer.util.GitHubOAuthTokenProvider;
+import org.refactoringminer.util.GitHubRawContentFetcher;
 import org.refactoringminer.util.PathFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1388,11 +1387,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 					}
 					else {
 						URL currentRawURL = commitFile.getRawUrl();
-						InputStream currentRawFileInputStream = currentRawURL.openStream();
-						currentRawFile = streamToString(currentRawFileInputStream);
-						String rawURLInParentCommit = currentRawURL.toString().replace(commitId, parentCommitId);
-						InputStream parentRawFileInputStream = new URL(rawURLInParentCommit).openStream();
-						parentRawFile = streamToString(parentRawFileInputStream);
+						currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
+						parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommit(currentRawURL, commitId, parentCommitId));
 					}
 					if(!filesBefore.containsKey(fileName))
 						filesBefore.put(fileName, parentRawFile);
@@ -1413,9 +1409,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 						currentRawFile = streamToString(currentRawFileInputStream);
 					}
 					else {
-						URL currentRawURL = commitFile.getRawUrl();
-						InputStream currentRawFileInputStream = currentRawURL.openStream();
-						currentRawFile = streamToString(currentRawFileInputStream);
+						currentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 					}
 					filesCurrent.put(fileName, currentRawFile);
 				}
@@ -1434,9 +1428,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 						parentRawFile = streamToString(parentRawFileInputStream);
 					}
 					else {
-						URL rawURL = commitFile.getRawUrl();
-						InputStream rawFileInputStream = rawURL.openStream();
-						parentRawFile = streamToString(rawFileInputStream);
+						parentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 					}
 					filesBefore.put(fileName, parentRawFile);
 					if(fileName.contains("/")) {
@@ -1464,13 +1456,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 					}
 					else {
 						URL currentRawURL = commitFile.getRawUrl();
-						InputStream currentRawFileInputStream = currentRawURL.openStream();
-						currentRawFile = streamToString(currentRawFileInputStream);
-						String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
-						String encodedPreviousFilename = URLEncoder.encode(previousFilename, StandardCharsets.UTF_8);
-						String rawURLInParentCommit = currentRawURL.toString().replace(commitId, parentCommitId).replace(encodedFileName, encodedPreviousFilename);
-						InputStream parentRawFileInputStream = new URL(rawURLInParentCommit).openStream();
-						parentRawFile = streamToString(parentRawFileInputStream);
+						currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
+						parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommitAndPath(currentRawURL, commitId, parentCommitId, fileName, previousFilename));
 					}
 					if(!filesBefore.containsKey(previousFilename))
 						filesBefore.put(previousFilename, parentRawFile);
@@ -1489,7 +1476,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 	}
 
 	public String streamToString(InputStream rawFileInputStream) throws IOException {
-		return EmojiParser.removeAllEmojis(IOUtils.toString(rawFileInputStream, StandardCharsets.UTF_8));
+		return GitHubRawContentFetcher.read(rawFileInputStream);
 	}
 
 	public void detectAtCommitWithGitHubAPI(String cloneURL, String commitId, File rootFolder, RefactoringHandler m) {
@@ -1697,11 +1684,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 							}
 							else {
 								URL currentRawURL = commitFile.getRawUrl();
-								InputStream currentRawFileInputStream = currentRawURL.openStream();
-								currentRawFile = streamToString(currentRawFileInputStream);
-								String rawURLInParentCommit = currentRawURL.toString().replace(commitId, parentCommitId);
-								InputStream parentRawFileInputStream = new URL(rawURLInParentCommit).openStream();
-								parentRawFile = streamToString(parentRawFileInputStream);
+								currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
+								parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommit(currentRawURL, commitId, parentCommitId));
 							}
 							filesBefore.put(fileName, parentRawFile);
 							filesCurrent.put(fileName, currentRawFile);
@@ -1725,9 +1709,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 								currentRawFile = streamToString(currentRawFileInputStream);
 							}
 							else {
-								URL currentRawURL = commitFile.getRawUrl();
-								InputStream currentRawFileInputStream = currentRawURL.openStream();
-								currentRawFile = streamToString(currentRawFileInputStream);
+								currentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 							}
 							filesCurrent.put(fileName, currentRawFile);
 							File currentFilePath = new File(rootFolder, repoName + "-" + currentCommitId + "/" + fileName);
@@ -1748,9 +1730,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 								parentRawFile = streamToString(parentRawFileInputStream);
 							}
 							else {
-								URL rawURL = commitFile.getRawUrl();
-								InputStream rawFileInputStream = rawURL.openStream();
-								parentRawFile = streamToString(rawFileInputStream);
+								parentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 							}
 							filesBefore.put(fileName, parentRawFile);
 							if(fileName.contains("/")) {
@@ -1780,13 +1760,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 							}
 							else {
 								URL currentRawURL = commitFile.getRawUrl();
-								InputStream currentRawFileInputStream = currentRawURL.openStream();
-								currentRawFile = streamToString(currentRawFileInputStream);
-								String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
-								String encodedPreviousFilename = URLEncoder.encode(previousFilename, StandardCharsets.UTF_8);
-								String rawURLInParentCommit = currentRawURL.toString().replace(commitId, parentCommitId).replace(encodedFileName, encodedPreviousFilename);
-								InputStream parentRawFileInputStream = new URL(rawURLInParentCommit).openStream();
-								parentRawFile = streamToString(parentRawFileInputStream);
+								currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
+								parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommitAndPath(currentRawURL, commitId, parentCommitId, fileName, previousFilename));
 							}
 							filesBefore.put(previousFilename, parentRawFile);
 							filesCurrent.put(fileName, currentRawFile);
@@ -2256,13 +2231,12 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 			Runnable r = () -> {
 				try {
 					URL currentRawURL = commitFile.getRawUrl();
-					String currentRawFile = fetchRawFileContent(currentRawURL);
+					String currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
 					List<String> patchLineList = createPatchLines(commitFile);
 					String parentRawFile;
 					if (patchLineList.isEmpty() && mergeBaseSha != null) {
 						// GitHub omitted the patch (very large diff); fetch the parent file directly at the merge base.
-						URL parentRawURL = new URL(currentRawURL.toString().replace(headSha, mergeBaseSha));
-						parentRawFile = fetchRawFileContent(parentRawURL);
+						parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommit(currentRawURL, headSha, mergeBaseSha));
 					}
 					else {
 						com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
@@ -2287,9 +2261,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 		else if (commitFile.getStatus().equals("added")) {
 			Runnable r = () -> {
 				try {
-					URL currentRawURL = commitFile.getRawUrl();
-					InputStream currentRawFileInputStream = currentRawURL.openStream();
-					String currentRawFile = streamToString(currentRawFileInputStream);
+					String currentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 					filesCurrent.put(fileName, currentRawFile);
 				}
 				catch(IOException e) {
@@ -2301,9 +2273,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 		else if (commitFile.getStatus().equals("removed")) {
 			Runnable r = () -> {
 				try {
-					URL rawURL = commitFile.getRawUrl();
-					InputStream rawFileInputStream = rawURL.openStream();
-					String parentRawFile = streamToString(rawFileInputStream);
+					String parentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 					filesBefore.put(fileName, parentRawFile);
 					if(fileName.contains("/")) {
 						deletedAndRenamedFileParentDirectories.add(fileName.substring(0, fileName.lastIndexOf("/")));
@@ -2321,14 +2291,13 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 				try {
 					String previousFilename = commitFile.getPreviousFilename();
 					URL currentRawURL = commitFile.getRawUrl();
-					String currentRawFile = fetchRawFileContent(currentRawURL);
+					String currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
 					List<String> patchLineList = createPatchLines(commitFile);
 					String parentRawFile;
 					if (patchLineList.isEmpty() && mergeBaseSha != null) {
 						// GitHub omitted the patch (very large diff); fetch the parent file directly at the merge base.
-						String parentRawURL = currentRawURL.toString().replace(headSha, mergeBaseSha)
-								.replace(encodeRawUrlPath(fileName), encodeRawUrlPath(previousFilename));
-						parentRawFile = fetchRawFileContent(new URL(parentRawURL));
+						parentRawFile = GitHubRawContentFetcher.fetch(
+								GitHubRawContentFetcher.atCommitAndPath(currentRawURL, headSha, mergeBaseSha, fileName, previousFilename));
 					}
 					else {
 						com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
@@ -2358,19 +2327,6 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 			};
 			pool.submit(r);
 		}
-	}
-
-	private String fetchRawFileContent(URL rawURL) throws IOException {
-		URLConnection connection = rawURL.openConnection();
-		connection.setRequestProperty("User-Agent", "Mozilla/5.0");
-		return streamToString(connection.getInputStream());
-	}
-
-	// Encodes a repository path the way GitHub encodes it inside a raw file URL (slashes become %2F).
-	// URLEncoder maps spaces to '+', whereas GitHub uses %20, so we convert those; a literal '+' in a
-	// path is encoded as %2B by URLEncoder, so this replacement only ever touches encoded spaces.
-	private static String encodeRawUrlPath(String path) {
-		return URLEncoder.encode(path, StandardCharsets.UTF_8).replace("+", "%20");
 	}
 
 	private List<String> createPatchLines(GHPullRequestFileDetail commitFile) {
@@ -2630,11 +2586,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 								}
 								else {
 									URL currentRawURL = commitFile.getRawUrl();
-									InputStream currentRawFileInputStream = currentRawURL.openStream();
-									currentRawFile = streamToString(currentRawFileInputStream);
-									String rawURLInParentCommit = currentRawURL.toString().replace(commitId, parentCommitId);
-									InputStream parentRawFileInputStream = new URL(rawURLInParentCommit).openStream();
-									parentRawFile = streamToString(parentRawFileInputStream);
+									currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
+									parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommit(currentRawURL, commitId, parentCommitId));
 								}
 								if(!filesBefore.containsKey(fileName))
 									filesBefore.put(fileName, parentRawFile);
@@ -2655,9 +2608,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 									currentRawFile = streamToString(currentRawFileInputStream);
 								}
 								else {
-									URL currentRawURL = commitFile.getRawUrl();
-									InputStream currentRawFileInputStream = currentRawURL.openStream();
-									currentRawFile = streamToString(currentRawFileInputStream);
+									currentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 								}
 								filesCurrent.put(fileName, currentRawFile);
 							}
@@ -2676,9 +2627,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 									parentRawFile = streamToString(parentRawFileInputStream);
 								}
 								else {
-									URL rawURL = commitFile.getRawUrl();
-									InputStream rawFileInputStream = rawURL.openStream();
-									parentRawFile = streamToString(rawFileInputStream);
+									parentRawFile = GitHubRawContentFetcher.fetch(commitFile.getRawUrl());
 								}
 								if(!filesBefore.containsKey(fileName))
 									filesBefore.put(fileName, parentRawFile);
@@ -2707,13 +2656,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 								}
 								else {
 									URL currentRawURL = commitFile.getRawUrl();
-									InputStream currentRawFileInputStream = currentRawURL.openStream();
-									currentRawFile = streamToString(currentRawFileInputStream);
-									String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
-									String encodedPreviousFilename = URLEncoder.encode(previousFilename, StandardCharsets.UTF_8);
-									String rawURLInParentCommit = currentRawURL.toString().replace(commitId, parentCommitId).replace(encodedFileName, encodedPreviousFilename);
-									InputStream parentRawFileInputStream = new URL(rawURLInParentCommit).openStream();
-									parentRawFile = streamToString(parentRawFileInputStream);
+									currentRawFile = GitHubRawContentFetcher.fetch(currentRawURL);
+									parentRawFile = GitHubRawContentFetcher.fetch(GitHubRawContentFetcher.atCommitAndPath(currentRawURL, commitId, parentCommitId, fileName, previousFilename));
 								}
 								if(!filesBefore.containsKey(fileName))
 									filesBefore.put(previousFilename, parentRawFile);

--- a/src/main/java/org/refactoringminer/util/GitHubRawContentFetcher.java
+++ b/src/main/java/org/refactoringminer/util/GitHubRawContentFetcher.java
@@ -1,0 +1,68 @@
+package org.refactoringminer.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+
+import com.vdurmont.emoji.EmojiParser;
+
+/**
+ * Helpers for retrieving raw file content from GitHub and for deriving the raw URL of the same file
+ * at a different commit (and, for renames, at a different path).
+ * <p>
+ * GitHub serves blobs without a size limit from its raw endpoint, whereas the Contents API
+ * ({@code GHRepository.getFileContent}) caps responses at ~1&nbsp;MB. These helpers are therefore
+ * used whenever a full file revision must be retrieved for a public repository, e.g. to obtain the
+ * parent version of a changed file by pointing the head raw URL at the parent/merge-base commit.
+ */
+public final class GitHubRawContentFetcher {
+
+	private GitHubRawContentFetcher() {
+	}
+
+	/** Downloads the content located at {@code rawURL}, stripping emojis and decoding it as UTF-8. */
+	public static String fetch(URL rawURL) throws IOException {
+		URLConnection connection = rawURL.openConnection();
+		// GitHub may answer raw requests without a User-Agent with HTTP 403.
+		connection.setRequestProperty("User-Agent", "Mozilla/5.0");
+		try (InputStream input = connection.getInputStream()) {
+			return read(input);
+		}
+	}
+
+	/** Reads {@code input} into a String, stripping emojis and decoding it as UTF-8. */
+	public static String read(InputStream input) throws IOException {
+		return EmojiParser.removeAllEmojis(IOUtils.toString(input, StandardCharsets.UTF_8));
+	}
+
+	/** Returns {@code rawURL} re-pointed from {@code fromCommitId} to {@code toCommitId}. */
+	public static URL atCommit(URL rawURL, String fromCommitId, String toCommitId) throws MalformedURLException {
+		return new URL(rawURL.toString().replace(fromCommitId, toCommitId));
+	}
+
+	/**
+	 * Returns {@code rawURL} re-pointed to {@code toCommitId} and to {@code toPath} (e.g. the
+	 * pre-rename name), used to obtain the parent revision of a renamed file.
+	 */
+	public static URL atCommitAndPath(URL rawURL, String fromCommitId, String toCommitId, String fromPath, String toPath)
+			throws MalformedURLException {
+		String url = rawURL.toString().replace(fromCommitId, toCommitId).replace(encodePath(fromPath), encodePath(toPath));
+		return new URL(url);
+	}
+
+	/**
+	 * Encodes a repository path the way GitHub encodes it inside a raw file URL (slashes become %2F).
+	 * {@link URLEncoder} maps spaces to {@code '+'}, whereas GitHub uses %20, so we convert those; a
+	 * literal {@code '+'} is encoded by {@link URLEncoder} as %2B, so this replacement only ever
+	 * touches encoded spaces.
+	 */
+	public static String encodePath(String path) {
+		return URLEncoder.encode(path, StandardCharsets.UTF_8).replace("+", "%20");
+	}
+}


### PR DESCRIPTION
## Problem

For files with a very large diff, GitHub's pull request [Files API](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files) **omits the `patch` field entirely** (`has("patch") == false`). `diffAtPullRequest` reconstructed each file's *parent* version by reverse-applying that patch to the head version, so when the patch is missing the reconstructed parent equals the head — producing an **empty diff** for that file.

Reproduction from #1108 — `JabRefCliPreferences.java` in JabRef PR #16101 (2081 changed lines):

```
$ gh api "repos/JabRef/jabref/pulls/16101/files?per_page=100" --paginate \
    --jq '.[] | select(.filename|endswith("JabRefCliPreferences.java"))
          | {status, changes, has_patch: has("patch")}'
{"status":"modified","changes":2081,"has_patch":false}
```

## Fix

When the patch is absent for a `modified` or `renamed` file, fetch the parent content **directly from its raw URL**, anchored at the pull request's **merge base**, instead of reconstructing it from the patch:

- The merge base is resolved once (and only when at least one file is missing its patch) via the compare API, matching the three-dot (`base...head`) diff semantics GitHub uses for the other files' patches, so the directly-fetched file stays consistent with the patch-reconstructed ones.
- The parent raw URL is derived from the head raw URL by swapping the head SHA for the merge-base SHA (the same technique the existing commit-based code already uses). This goes through `raw.githubusercontent.com`, so it has no Contents-API size limit — important precisely for the large files that trigger the bug.
- A small `encodeRawUrlPath` helper encodes the path the way GitHub does in raw URLs (slashes → `%2F`, spaces → `%20`) for the rename case.

When the patch *is* present, the original reverse-patch path is unchanged.

## Verification

End-to-end run of `diffAtPullRequest` on JabRef PR #16101:

- Before: the large file produced an empty diff.
- After: `JabRefCliPreferences.java` produces a real AST diff (1513 deleted + 1239 added trees, `isEmpty=false`); all 34 files diff correctly.

Fixes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)