### PR TITLE
Fetch parent file directly when GitHub omits the PR patch for large diffs

### DIFF
--- a/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
+++ b/src/main/java/org/refactoringminer/rm1/GitHistoryRefactoringMinerImpl.java
@@ -2151,6 +2151,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 			}
 		}
 		else {
+			//Merge-base of the PR; used to fetch the parent version of files whose patch is omitted by the GitHub API.
+			String mergeBaseCommitId = repository.getCompare(pullRequest.getBase().getSha(), pullRequest.getHead().getSha()).getMergeBaseCommit().getSHA1();
 			PagedIterable<GHPullRequestFileDetail> files = pullRequest.listFiles();
 			int changedFiles = pullRequest.getChangedFiles();
 			if(changedFiles == 0) {
@@ -2169,7 +2171,7 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 					}
 					multiThreadedFetch(filesBefore, filesCurrent, renamedFilesHint, repositoryDirectoriesBefore,
 							repositoryDirectoriesCurrent, deletedAndRenamedFileParentDirectories, commitFileNames, pool,
-							commitFile, fileName);
+							repository, mergeBaseCommitId, commitFile, fileName);
 					count++;
 				}
 			}
@@ -2231,7 +2233,8 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 	private void multiThreadedFetch(Map<String, String> filesBefore, Map<String, String> filesCurrent,
 			Map<String, String> renamedFilesHint, Set<String> repositoryDirectoriesBefore,
 			Set<String> repositoryDirectoriesCurrent, Set<String> deletedAndRenamedFileParentDirectories,
-			List<String> commitFileNames, ExecutorService pool, GHPullRequestFileDetail commitFile, String fileName) {
+			List<String> commitFileNames, ExecutorService pool, GHRepository repository, String mergeBaseCommitId,
+			GHPullRequestFileDetail commitFile, String fileName) {
 		if (commitFile.getStatus().equals("modified")) {
 			Runnable r = () -> {
 				try {
@@ -2240,10 +2243,19 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 					connection.setRequestProperty("User-Agent", "Mozilla/5.0");
 					InputStream currentRawFileInputStream = connection.getInputStream();
 					String currentRawFile = streamToString(currentRawFileInputStream);
-					List<String> patchLineList = createPatchLines(commitFile);
-					com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
-					List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
-					String parentRawFile = String.join("\n", parentRawFileLines);
+					String parentRawFile;
+					if(commitFile.getPatch() != null) {
+						List<String> patchLineList = createPatchLines(commitFile);
+						com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
+						List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
+						parentRawFile = String.join("\n", parentRawFileLines);
+					}
+					else {
+						//GitHub omits the patch for very large diffs; reverse-applying an empty patch would
+						//leave the parent equal to the current file. Fetch the parent version directly instead.
+						InputStream parentRawFileInputStream = repository.getFileContent(fileName, mergeBaseCommitId).read();
+						parentRawFile = streamToString(parentRawFileInputStream);
+					}
 					filesBefore.put(fileName, parentRawFile);
 					filesCurrent.put(fileName, currentRawFile);
 					String directory = new String(fileName);
@@ -2298,10 +2310,19 @@ public class GitHistoryRefactoringMinerImpl implements GitHistoryRefactoringMine
 					URL currentRawURL = commitFile.getRawUrl();
 					InputStream currentRawFileInputStream = currentRawURL.openStream();
 					String currentRawFile = streamToString(currentRawFileInputStream);
-					List<String> patchLineList = createPatchLines(commitFile);
-					com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
-					List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
-					String parentRawFile = String.join("\n", parentRawFileLines);
+					String parentRawFile;
+					if(commitFile.getPatch() != null) {
+						List<String> patchLineList = createPatchLines(commitFile);
+						com.github.difflib.patch.Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchLineList);
+						List<String> parentRawFileLines = DiffUtils.unpatch(Arrays.asList(currentRawFile.split("\\n")), patch);
+						parentRawFile = String.join("\n", parentRawFileLines);
+					}
+					else {
+						//GitHub omits the patch for very large diffs; fetch the parent version
+						//(under its previous name) directly at the merge-base commit.
+						InputStream parentRawFileInputStream = repository.getFileContent(previousFilename, mergeBaseCommitId).read();
+						parentRawFile = streamToString(parentRawFileInputStream);
+					}
 					filesBefore.put(previousFilename, parentRawFile);
 					filesCurrent.put(fileName, currentRawFile);
 					renamedFilesHint.put(previousFilename, fileName);


### PR DESCRIPTION
## Problem

Fixes #1108.

GitHub's pull request *files* API omits the per-file `patch` field for very large diffs (e.g. `JabRefCliPreferences.java` in JabRef/jabref#16101 has 2081 changes and no `patch`).

`diffAtPullRequest` (public-repo path) reconstructed the parent (before) version of `modified`/`renamed` files by **reverse-applying** that patch to the current raw file. When the patch is `null`, `createPatchLines` returns an empty list, the reverse-unpatch is a no-op, and `parentRawFile == currentRawFile` — so the file shows **no diff at all** ("mining for larger files is empty").

## Fix

In `GitHistoryRefactoringMinerImpl.multiThreadedFetch` (PR variant):

- Resolve the PR **merge-base** once per PR: `repository.getCompare(base, head).getMergeBaseCommit().getSHA1()` (matches GitHub's three-dot PR diff).
- Keep the existing reverse-patch path when `patch != null`.
- When `patch == null`, fetch the parent version directly at the merge-base via `GHRepository.getFileContent(path, mergeBaseCommitId)` — mirroring the commit-based `multiThreadedFetch`/private-repo path that already fetches before/after content directly. Renamed files use their previous filename.

This realizes the `diffAtCommitRange`/`diffAtCommit` workaround suggested in the issue, inline, so callers of `diffAtPullRequest` need no change.

## Verification

Ran `diffAtPullRequest("JabRef/jabref", 16101)` end-to-end:

```
key=jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
beforeLen=130813 afterLen=142455 equal=false
```

Before the fix `before == after` (empty diff); after the fix the parent content is fetched and the file diffs correctly. `compileJava` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)