### PR TITLE
Support C++ control-flow statements in operation bodies

### DIFF
--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -307,9 +307,22 @@ public class CppOperationBody extends OperationBody {
 	// Normalizes the C++ range-for declaration into the same enhanced-for shape used by other languages:
 	// loop variable declarations plus parameter-name expressions on the loop composite.
 	private void addRangeBasedForDeclaration(String sourceFolder, String filePath, CompositeStatementObject child, IASTDeclaration declaration, String fileContent) {
-		if(declaration instanceof ICPPASTStructuredBindingDeclaration) {
+		if(declaration instanceof ICPPASTStructuredBindingDeclaration structuredBindingDeclaration) {
 			AbstractExpression destructuringDeclaration = new AbstractExpression(sourceFolder, filePath, declaration, CodeElementType.ENHANCED_FOR_STATEMENT_DESTRUCTURING_DECLARATION, container, activeVariableDeclarations, fileContent);
 			child.addExpression(destructuringDeclaration);
+			for(IASTDeclarator declarator : structuredBindingDeclaration.getDeclarators()) {
+				VariableDeclaration variableDeclaration =
+			            new VariableDeclaration(
+			                sourceFolder,
+			                filePath,
+			                declarator,
+			                structuredBindingDeclaration.getDeclSpecifier(),
+			                container,
+			                activeVariableDeclarations,
+			                fileContent
+			            );
+		        child.addVariableDeclaration(variableDeclaration);
+			}
 		}
 		else if(declaration instanceof IASTSimpleDeclaration simpleDeclaration) {
 			for(IASTDeclarator declarator : simpleDeclaration.getDeclarators()) {

--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -28,7 +28,6 @@ import org.eclipse.cdt.core.dom.ast.IASTStatement;
 import org.eclipse.cdt.core.dom.ast.IASTSwitchStatement;
 import org.eclipse.cdt.core.dom.ast.IASTWhileStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCatchHandler;
-import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCompoundStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTForStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTIfStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTRangeBasedForStatement;
@@ -82,13 +81,9 @@ public class CppOperationBody extends OperationBody {
 	private void processStatement(String sourceFolder, String filePath, CompositeStatementObject parent, IASTStatement statement, String fileContent) {
 		//https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.cdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fcdt%2Fcore%2Fdom%2Fast%2FIASTStatement.html
 		if(statement instanceof IASTCompoundStatement compoundStatement) {
-			// IASTCompoundStatement is the base block API; ICPPASTCompoundStatement is the C++ block form with implicit destructor-name ownership.
 			IASTStatement[] blockStatements = compoundStatement.getStatements();
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, compoundStatement, parent.getDepth()+1, CodeElementType.BLOCK, fileContent);
 			parent.addStatement(child);
-			if(compoundStatement instanceof ICPPASTCompoundStatement cppCompoundStatement) {
-				// TODO: model cppCompoundStatement.getImplicitDestructorNames() when C++ implicit destructor calls are represented in operation bodies.
-			}
 			addStatementInVariableScopes(child);
 			for(IASTStatement blockStatement : blockStatements) {
 				processStatement(sourceFolder, filePath, child, blockStatement, fileContent);
@@ -113,7 +108,7 @@ public class CppOperationBody extends OperationBody {
 			StatementObject child = new StatementObject(sourceFolder, filePath, declarationStatement, parent.getDepth()+1, CodeElementType.VARIABLE_DECLARATION_STATEMENT, container, activeVariableDeclarations, fileContent);
 			parent.addStatement(child);
 			addStatementInVariableScopes(child);
-			// TODO: teach CppVisitor to extract C++ local variable declarations so this updates active scope.
+			// TODO: handle non-simple C++ local declarations such as structured bindings.
 			addAllInActiveVariableDeclarations(child.getVariableDeclarations());
 		}
 		else if(statement instanceof IASTDefaultStatement defaultStatement) {
@@ -139,20 +134,19 @@ public class CppOperationBody extends OperationBody {
 			addStatementInVariableScopes(child);
 		}
 		else if(statement instanceof IASTForStatement forStatement) {
-			// IASTForStatement models a generic for loop; ICPPASTForStatement adds C++ condition declarations and implicit destructor names.
+			// IASTForStatement models a generic for loop; ICPPASTForStatement adds C++ condition declarations.
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, forStatement, parent.getDepth()+1, CodeElementType.FOR_STATEMENT, fileContent);
 			parent.addStatement(child);
 			if(forStatement.getInitializerStatement() instanceof IASTExpressionStatement initializerStatement && initializerStatement.getExpression() != null) {
 				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, initializerStatement.getExpression(), CodeElementType.FOR_STATEMENT_INITIALIZER, container, activeVariableDeclarations, fileContent);
 				child.addExpression(abstractExpression);
 			}
-			else if(forStatement.getInitializerStatement() != null) {
-				// TODO: teach CppVisitor to extract C++ declaration initializers so variables declared in for initializers are scoped to this for statement.
+			else if(forStatement.getInitializerStatement() != null && !addDeclarationStatementExpression(sourceFolder, filePath, child, forStatement.getInitializerStatement(), CodeElementType.FOR_STATEMENT_INITIALIZER, fileContent)) {
 				processStatement(sourceFolder, filePath, child, forStatement.getInitializerStatement(), fileContent);
 			}
 			if(forStatement instanceof ICPPASTForStatement cppForStatement) {
 				if(cppForStatement.getConditionDeclaration() != null) {
-					// TODO: teach CppVisitor to extract C++ condition declarations so variables declared in for conditions are scoped to this for statement.
+					addDeclarationExpression(sourceFolder, filePath, child, cppForStatement.getConditionDeclaration(), CodeElementType.FOR_STATEMENT_CONDITION, fileContent);
 				}
 			}
 			if(forStatement.getConditionExpression() != null) {
@@ -181,11 +175,11 @@ public class CppOperationBody extends OperationBody {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, ifStatement, parent.getDepth()+1, CodeElementType.IF_STATEMENT, fileContent);
 			parent.addStatement(child);
 			if(ifStatement instanceof ICPPASTIfStatement cppIfStatement) {
-				if(cppIfStatement.getInitializerStatement() != null) {
+				if(cppIfStatement.getInitializerStatement() != null && !addDeclarationStatementExpression(sourceFolder, filePath, child, cppIfStatement.getInitializerStatement(), CodeElementType.IF_STATEMENT_CONDITION, fileContent)) {
 					processStatement(sourceFolder, filePath, child, cppIfStatement.getInitializerStatement(), fileContent);
 				}
 				if(cppIfStatement.getConditionDeclaration() != null) {
-					// TODO: teach CppVisitor to extract C++ condition declarations so variables declared in if conditions are scoped to this if statement.
+					addDeclarationExpression(sourceFolder, filePath, child, cppIfStatement.getConditionDeclaration(), CodeElementType.IF_STATEMENT_CONDITION, fileContent);
 				}
 			}
 			if(ifStatement.getConditionExpression() != null) {
@@ -193,12 +187,15 @@ public class CppOperationBody extends OperationBody {
 				child.addExpression(abstractExpression);
 			}
 			addStatementInVariableScopes(child);
+			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
+			addAllInActiveVariableDeclarations(variableDeclarations);
 			if(ifStatement.getThenClause() != null) {
 				processStatement(sourceFolder, filePath, child, ifStatement.getThenClause(), fileContent);
 			}
 			if(ifStatement.getElseClause() != null) {
 				processStatement(sourceFolder, filePath, child, ifStatement.getElseClause(), fileContent);
 			}
+			removeAllFromActiveVariableDeclarations(variableDeclarations);
 		}
 		else if(statement instanceof IASTLabelStatement labelStatement) {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, labelStatement, parent.getDepth()+1, CodeElementType.LABELED_STATEMENT.setName(labelStatement.getName().toString()), fileContent);
@@ -228,11 +225,11 @@ public class CppOperationBody extends OperationBody {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, switchStatement, parent.getDepth()+1, CodeElementType.SWITCH_STATEMENT, fileContent);
 			parent.addStatement(child);
 			if(switchStatement instanceof ICPPASTSwitchStatement cppSwitchStatement) {
-				if(cppSwitchStatement.getInitializerStatement() != null) {
+				if(cppSwitchStatement.getInitializerStatement() != null && !addDeclarationStatementExpression(sourceFolder, filePath, child, cppSwitchStatement.getInitializerStatement(), CodeElementType.SWITCH_STATEMENT_CONDITION, fileContent)) {
 					processStatement(sourceFolder, filePath, child, cppSwitchStatement.getInitializerStatement(), fileContent);
 				}
 				if(cppSwitchStatement.getControllerDeclaration() != null) {
-					// TODO: teach CppVisitor to extract C++ controller declarations so variables declared in switch controllers are scoped to this switch statement.
+					addDeclarationExpression(sourceFolder, filePath, child, cppSwitchStatement.getControllerDeclaration(), CodeElementType.SWITCH_STATEMENT_CONDITION, fileContent);
 				}
 			}
 			if(switchStatement.getControllerExpression() != null) {
@@ -240,9 +237,12 @@ public class CppOperationBody extends OperationBody {
 				child.addExpression(abstractExpression);
 			}
 			addStatementInVariableScopes(child);
+			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
+			addAllInActiveVariableDeclarations(variableDeclarations);
 			if(switchStatement.getBody() != null) {
 				processStatement(sourceFolder, filePath, child, switchStatement.getBody(), fileContent);
 			}
+			removeAllFromActiveVariableDeclarations(variableDeclarations);
 		}
 		else if(statement instanceof IASTWhileStatement whileStatement) {
 			// IASTWhileStatement uses a condition expression; ICPPASTWhileStatement also supports C++ condition declarations and scope.
@@ -250,7 +250,7 @@ public class CppOperationBody extends OperationBody {
 			parent.addStatement(child);
 			if(whileStatement instanceof ICPPASTWhileStatement cppWhileStatement) {
 				if(cppWhileStatement.getConditionDeclaration() != null) {
-					// TODO: teach CppVisitor to extract C++ condition declarations so variables declared in while conditions are scoped to this while statement.
+					addDeclarationExpression(sourceFolder, filePath, child, cppWhileStatement.getConditionDeclaration(), CodeElementType.WHILE_STATEMENT_CONDITION, fileContent);
 				}
 			}
 			if(whileStatement.getCondition() != null) {
@@ -258,9 +258,12 @@ public class CppOperationBody extends OperationBody {
 				child.addExpression(abstractExpression);
 			}
 			addStatementInVariableScopes(child);
+			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
+			addAllInActiveVariableDeclarations(variableDeclarations);
 			if(whileStatement.getBody() != null) {
 				processStatement(sourceFolder, filePath, child, whileStatement.getBody(), fileContent);
 			}
+			removeAllFromActiveVariableDeclarations(variableDeclarations);
 		}
 		else if(statement instanceof ICPPASTRangeBasedForStatement rangeBasedForStatement) {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, rangeBasedForStatement, parent.getDepth()+1, CodeElementType.ENHANCED_FOR_STATEMENT, fileContent);
@@ -337,6 +340,21 @@ public class CppOperationBody extends OperationBody {
 					catchClause.addExpression(variableDeclarationName);
 				}
 			}
+		}
+	}
+	// Checks whether the statement is a declaration statement, like: int i = 0;
+	private boolean addDeclarationStatementExpression(String sourceFolder, String filePath, CompositeStatementObject child, IASTStatement statement, CodeElementType codeElementType, String fileContent) {
+		if(statement instanceof IASTDeclarationStatement declarationStatement) {
+			addDeclarationExpression(sourceFolder, filePath, child, declarationStatement.getDeclaration(), codeElementType, fileContent);
+			return true;
+		}
+		return false;
+	}
+	// Helper for turning a CDT declaration node into an AbstractExpression.
+	private void addDeclarationExpression(String sourceFolder, String filePath, CompositeStatementObject child, IASTDeclaration declaration, CodeElementType codeElementType, String fileContent) {
+		if(declaration != null) {
+			AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, declaration, codeElementType, container, activeVariableDeclarations, fileContent);
+			child.addExpression(abstractExpression);
 		}
 	}
 	// Given the body of a try or catch, process its contents under the try/catch node. If it is a block, unwrap the block and process each statement inside

--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -9,17 +9,21 @@ import org.eclipse.cdt.core.dom.ast.IASTBreakStatement;
 import org.eclipse.cdt.core.dom.ast.IASTCaseStatement;
 import org.eclipse.cdt.core.dom.ast.IASTCompoundStatement;
 import org.eclipse.cdt.core.dom.ast.IASTContinueStatement;
+import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarationStatement;
 import org.eclipse.cdt.core.dom.ast.IASTDefaultStatement;
+import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTDoStatement;
 import org.eclipse.cdt.core.dom.ast.IASTExpressionStatement;
 import org.eclipse.cdt.core.dom.ast.IASTForStatement;
 import org.eclipse.cdt.core.dom.ast.IASTGotoStatement;
 import org.eclipse.cdt.core.dom.ast.IASTIfStatement;
 import org.eclipse.cdt.core.dom.ast.IASTLabelStatement;
+import org.eclipse.cdt.core.dom.ast.IASTName;
 import org.eclipse.cdt.core.dom.ast.IASTNullStatement;
 import org.eclipse.cdt.core.dom.ast.IASTProblemStatement;
 import org.eclipse.cdt.core.dom.ast.IASTReturnStatement;
+import org.eclipse.cdt.core.dom.ast.IASTSimpleDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTStatement;
 import org.eclipse.cdt.core.dom.ast.IASTSwitchStatement;
 import org.eclipse.cdt.core.dom.ast.IASTWhileStatement;
@@ -28,6 +32,7 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCompoundStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTForStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTIfStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTRangeBasedForStatement;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTStructuredBindingDeclaration;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTSwitchStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTTryBlockStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTWhileStatement;
@@ -261,7 +266,20 @@ public class CppOperationBody extends OperationBody {
 			// composite
 		}
 		else if(statement instanceof ICPPASTRangeBasedForStatement rangeBasedForStatement) {
-			// composite
+			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, rangeBasedForStatement, parent.getDepth()+1, CodeElementType.ENHANCED_FOR_STATEMENT, fileContent);
+			parent.addStatement(child);
+			addRangeBasedForDeclaration(sourceFolder, filePath, child, rangeBasedForStatement.getDeclaration(), fileContent);
+			if(rangeBasedForStatement.getInitializerClause() != null) {
+				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, rangeBasedForStatement.getInitializerClause(), CodeElementType.ENHANCED_FOR_STATEMENT_EXPRESSION, container, activeVariableDeclarations, fileContent);
+				child.addExpression(abstractExpression);
+			}
+			addStatementInVariableScopes(child);
+			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
+			addAllInActiveVariableDeclarations(variableDeclarations);
+			if(rangeBasedForStatement.getBody() != null) {
+				processStatement(sourceFolder, filePath, child, rangeBasedForStatement.getBody(), fileContent);
+			}
+			removeAllFromActiveVariableDeclarations(variableDeclarations);
 		}
 		else if(statement instanceof ICPPASTTryBlockStatement tryBlockStatement) {
 			// composite
@@ -270,6 +288,25 @@ public class CppOperationBody extends OperationBody {
 			StatementObject child = new StatementObject(sourceFolder, filePath, gnuGotoStatement, parent.getDepth()+1, CodeElementType.GOTO_STATEMENT, container, activeVariableDeclarations, fileContent);
 			parent.addStatement(child);
 			addStatementInVariableScopes(child);
+		}
+	}
+	// Normalizes the C++ range-for declaration into the same enhanced-for shape used by other languages:
+	// loop variable declarations plus parameter-name expressions on the loop composite.
+	private void addRangeBasedForDeclaration(String sourceFolder, String filePath, CompositeStatementObject child, IASTDeclaration declaration, String fileContent) {
+		if(declaration instanceof ICPPASTStructuredBindingDeclaration) {
+			AbstractExpression destructuringDeclaration = new AbstractExpression(sourceFolder, filePath, declaration, CodeElementType.ENHANCED_FOR_STATEMENT_DESTRUCTURING_DECLARATION, container, activeVariableDeclarations, fileContent);
+			child.addExpression(destructuringDeclaration);
+		}
+		else if(declaration instanceof IASTSimpleDeclaration simpleDeclaration) {
+			for(IASTDeclarator declarator : simpleDeclaration.getDeclarators()) {
+				VariableDeclaration variableDeclaration = new VariableDeclaration(sourceFolder, filePath, declarator, simpleDeclaration.getDeclSpecifier(), container, activeVariableDeclarations, fileContent);
+				child.addVariableDeclaration(variableDeclaration);
+				IASTName name = declarator.getName();
+				if(name != null) {
+					AbstractExpression variableDeclarationName = new AbstractExpression(sourceFolder, filePath, name, CodeElementType.ENHANCED_FOR_STATEMENT_PARAMETER_NAME, container, activeVariableDeclarations, fileContent);
+					child.addExpression(variableDeclarationName);
+				}
+			}
 		}
 	}
 }

--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -262,9 +262,6 @@ public class CppOperationBody extends OperationBody {
 				processStatement(sourceFolder, filePath, child, whileStatement.getBody(), fileContent);
 			}
 		}
-		else if(statement instanceof ICPPASTCatchHandler catchHandler) {
-			// composite
-		}
 		else if(statement instanceof ICPPASTRangeBasedForStatement rangeBasedForStatement) {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, rangeBasedForStatement, parent.getDepth()+1, CodeElementType.ENHANCED_FOR_STATEMENT, fileContent);
 			parent.addStatement(child);
@@ -282,7 +279,25 @@ public class CppOperationBody extends OperationBody {
 			removeAllFromActiveVariableDeclarations(variableDeclarations);
 		}
 		else if(statement instanceof ICPPASTTryBlockStatement tryBlockStatement) {
-			// composite
+			TryStatementObject child = new TryStatementObject(sourceFolder, filePath, tryBlockStatement, parent.getDepth()+1, fileContent);
+			parent.addStatement(child);
+			addStatementInVariableScopes(child);
+			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
+			addAllInActiveVariableDeclarations(variableDeclarations);
+			processChildStatements(sourceFolder, filePath, child, tryBlockStatement.getTryBody(), fileContent);
+			removeAllFromActiveVariableDeclarations(variableDeclarations);
+			for(ICPPASTCatchHandler catchHandler : tryBlockStatement.getCatchHandlers()) {
+				CompositeStatementObject catchClauseStatementObject = new CompositeStatementObject(sourceFolder, filePath, catchHandler, parent.getDepth()+1, CodeElementType.CATCH_CLAUSE, fileContent);
+				child.addCatchClause(catchClauseStatementObject);
+				parent.addStatement(catchClauseStatementObject);
+				catchClauseStatementObject.setTryContainer(child);
+				addCatchHandlerDeclaration(sourceFolder, filePath, catchClauseStatementObject, catchHandler.getDeclaration(), fileContent);
+				addStatementInVariableScopes(catchClauseStatementObject);
+				List<VariableDeclaration> catchClauseVariableDeclarations = catchClauseStatementObject.getVariableDeclarations();
+				addAllInActiveVariableDeclarations(catchClauseVariableDeclarations);
+				processChildStatements(sourceFolder, filePath, catchClauseStatementObject, catchHandler.getCatchBody(), fileContent);
+				removeAllFromActiveVariableDeclarations(catchClauseVariableDeclarations);
+			}
 		}
 		else if(statement instanceof IGNUASTGotoStatement gnuGotoStatement) {
 			StatementObject child = new StatementObject(sourceFolder, filePath, gnuGotoStatement, parent.getDepth()+1, CodeElementType.GOTO_STATEMENT, container, activeVariableDeclarations, fileContent);
@@ -307,6 +322,32 @@ public class CppOperationBody extends OperationBody {
 					child.addExpression(variableDeclarationName);
 				}
 			}
+		}
+	}
+
+	// Take the C++ catch header declaration and attach it to the catch clause node.
+	private void addCatchHandlerDeclaration(String sourceFolder, String filePath, CompositeStatementObject catchClause, IASTDeclaration declaration, String fileContent) {
+		if(declaration instanceof IASTSimpleDeclaration simpleDeclaration) {
+			for(IASTDeclarator declarator : simpleDeclaration.getDeclarators()) {
+				IASTName name = declarator.getName();
+				if(name != null && !name.toString().isEmpty()) {
+					VariableDeclaration variableDeclaration = new VariableDeclaration(sourceFolder, filePath, declarator, simpleDeclaration.getDeclSpecifier(), container, activeVariableDeclarations, fileContent);
+					catchClause.addVariableDeclaration(variableDeclaration);
+					AbstractExpression variableDeclarationName = new AbstractExpression(sourceFolder, filePath, name, CodeElementType.CATCH_CLAUSE_EXCEPTION_NAME, container, activeVariableDeclarations, fileContent);
+					catchClause.addExpression(variableDeclarationName);
+				}
+			}
+		}
+	}
+	// Given the body of a try or catch, process its contents under the try/catch node. If it is a block, unwrap the block and process each statement inside
+	private void processChildStatements(String sourceFolder, String filePath, CompositeStatementObject parent, IASTStatement statement, String fileContent) {
+		if(statement instanceof IASTCompoundStatement compoundStatement) {
+			for(IASTStatement blockStatement : compoundStatement.getStatements()) {
+				processStatement(sourceFolder, filePath, parent, blockStatement, fileContent);
+			}
+		}
+		else if(statement != null) {
+			processStatement(sourceFolder, filePath, parent, statement, fileContent);
 		}
 	}
 }

--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -283,7 +283,12 @@ public class CppOperationBody extends OperationBody {
 			addStatementInVariableScopes(child);
 			List<VariableDeclaration> variableDeclarations = child.getVariableDeclarations();
 			addAllInActiveVariableDeclarations(variableDeclarations);
-			processChildStatements(sourceFolder, filePath, child, tryBlockStatement.getTryBody(), fileContent);
+			IASTStatement tryBody = tryBlockStatement.getTryBody();
+			if(tryBody instanceof IASTCompoundStatement compoundStatement) {
+				for(IASTStatement blockStatement : compoundStatement.getStatements()) {
+					processStatement(sourceFolder, filePath, child, blockStatement, fileContent);
+				}
+			}
 			removeAllFromActiveVariableDeclarations(variableDeclarations);
 			for(ICPPASTCatchHandler catchHandler : tryBlockStatement.getCatchHandlers()) {
 				CompositeStatementObject catchClauseStatementObject = new CompositeStatementObject(sourceFolder, filePath, catchHandler, parent.getDepth()+1, CodeElementType.CATCH_CLAUSE, fileContent);
@@ -294,7 +299,12 @@ public class CppOperationBody extends OperationBody {
 				addStatementInVariableScopes(catchClauseStatementObject);
 				List<VariableDeclaration> catchClauseVariableDeclarations = catchClauseStatementObject.getVariableDeclarations();
 				addAllInActiveVariableDeclarations(catchClauseVariableDeclarations);
-				processChildStatements(sourceFolder, filePath, catchClauseStatementObject, catchHandler.getCatchBody(), fileContent);
+				IASTStatement catchBody = catchHandler.getCatchBody();
+				if(catchBody instanceof IASTCompoundStatement compoundStatement) {
+					for(IASTStatement blockStatement : compoundStatement.getStatements()) {
+						processStatement(sourceFolder, filePath, catchClauseStatementObject, blockStatement, fileContent);
+					}
+				}
 				removeAllFromActiveVariableDeclarations(catchClauseVariableDeclarations);
 			}
 		}
@@ -356,17 +366,6 @@ public class CppOperationBody extends OperationBody {
 		if(declaration != null) {
 			AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, declaration, codeElementType, container, activeVariableDeclarations, fileContent);
 			child.addExpression(abstractExpression);
-		}
-	}
-	// Given the body of a try or catch, process its contents under the try/catch node. If it is a block, unwrap the block and process each statement inside
-	private void processChildStatements(String sourceFolder, String filePath, CompositeStatementObject parent, IASTStatement statement, String fileContent) {
-		if(statement instanceof IASTCompoundStatement compoundStatement) {
-			for(IASTStatement blockStatement : compoundStatement.getStatements()) {
-				processStatement(sourceFolder, filePath, parent, blockStatement, fileContent);
-			}
-		}
-		else if(statement != null) {
-			processStatement(sourceFolder, filePath, parent, statement, fileContent);
 		}
 	}
 }

--- a/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/CppOperationBody.java
@@ -137,11 +137,7 @@ public class CppOperationBody extends OperationBody {
 			// IASTForStatement models a generic for loop; ICPPASTForStatement adds C++ condition declarations.
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, forStatement, parent.getDepth()+1, CodeElementType.FOR_STATEMENT, fileContent);
 			parent.addStatement(child);
-			if(forStatement.getInitializerStatement() instanceof IASTExpressionStatement initializerStatement && initializerStatement.getExpression() != null) {
-				AbstractExpression abstractExpression = new AbstractExpression(sourceFolder, filePath, initializerStatement.getExpression(), CodeElementType.FOR_STATEMENT_INITIALIZER, container, activeVariableDeclarations, fileContent);
-				child.addExpression(abstractExpression);
-			}
-			else if(forStatement.getInitializerStatement() != null && !addDeclarationStatementExpression(sourceFolder, filePath, child, forStatement.getInitializerStatement(), CodeElementType.FOR_STATEMENT_INITIALIZER, fileContent)) {
+			if(forStatement.getInitializerStatement() != null) {
 				processStatement(sourceFolder, filePath, child, forStatement.getInitializerStatement(), fileContent);
 			}
 			if(forStatement instanceof ICPPASTForStatement cppForStatement) {
@@ -175,7 +171,7 @@ public class CppOperationBody extends OperationBody {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, ifStatement, parent.getDepth()+1, CodeElementType.IF_STATEMENT, fileContent);
 			parent.addStatement(child);
 			if(ifStatement instanceof ICPPASTIfStatement cppIfStatement) {
-				if(cppIfStatement.getInitializerStatement() != null && !addDeclarationStatementExpression(sourceFolder, filePath, child, cppIfStatement.getInitializerStatement(), CodeElementType.IF_STATEMENT_CONDITION, fileContent)) {
+				if(cppIfStatement.getInitializerStatement() != null) {
 					processStatement(sourceFolder, filePath, child, cppIfStatement.getInitializerStatement(), fileContent);
 				}
 				if(cppIfStatement.getConditionDeclaration() != null) {
@@ -225,7 +221,7 @@ public class CppOperationBody extends OperationBody {
 			CompositeStatementObject child = new CompositeStatementObject(sourceFolder, filePath, switchStatement, parent.getDepth()+1, CodeElementType.SWITCH_STATEMENT, fileContent);
 			parent.addStatement(child);
 			if(switchStatement instanceof ICPPASTSwitchStatement cppSwitchStatement) {
-				if(cppSwitchStatement.getInitializerStatement() != null && !addDeclarationStatementExpression(sourceFolder, filePath, child, cppSwitchStatement.getInitializerStatement(), CodeElementType.SWITCH_STATEMENT_CONDITION, fileContent)) {
+				if(cppSwitchStatement.getInitializerStatement() != null) {
 					processStatement(sourceFolder, filePath, child, cppSwitchStatement.getInitializerStatement(), fileContent);
 				}
 				if(cppSwitchStatement.getControllerDeclaration() != null) {
@@ -341,14 +337,6 @@ public class CppOperationBody extends OperationBody {
 				}
 			}
 		}
-	}
-	// Checks whether the statement is a declaration statement, like: int i = 0;
-	private boolean addDeclarationStatementExpression(String sourceFolder, String filePath, CompositeStatementObject child, IASTStatement statement, CodeElementType codeElementType, String fileContent) {
-		if(statement instanceof IASTDeclarationStatement declarationStatement) {
-			addDeclarationExpression(sourceFolder, filePath, child, declarationStatement.getDeclaration(), codeElementType, fileContent);
-			return true;
-		}
-		return false;
 	}
 	// Helper for turning a CDT declaration node into an AbstractExpression.
 	private void addDeclarationExpression(String sourceFolder, String filePath, CompositeStatementObject child, IASTDeclaration declaration, CodeElementType codeElementType, String fileContent) {

--- a/src/main/java/gr/uom/java/xmi/decomposition/TryStatementObject.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/TryStatementObject.java
@@ -3,6 +3,7 @@ package gr.uom.java.xmi.decomposition;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.cdt.core.dom.ast.IASTStatement;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Statement;
 import org.jetbrains.kotlin.psi.KtFile;
@@ -35,6 +36,11 @@ public class TryStatementObject extends CompositeStatementObject {
 	}
 
 	public TryStatementObject(String sourceFolder, String filePath, Swc4jAstTryStmt statement, int depth, String fileContent) {
+		super(sourceFolder, filePath, statement, depth, CodeElementType.TRY_STATEMENT, fileContent);
+		this.catchClauses = new ArrayList<CompositeStatementObject>();
+	}
+
+	public TryStatementObject(String sourceFolder, String filePath, IASTStatement statement, int depth, String fileContent) {
 		super(sourceFolder, filePath, statement, depth, CodeElementType.TRY_STATEMENT, fileContent);
 		this.catchClauses = new ArrayList<CompositeStatementObject>();
 	}

--- a/src/main/java/gr/uom/java/xmi/decomposition/TryStatementObject.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/TryStatementObject.java
@@ -3,7 +3,7 @@ package gr.uom.java.xmi.decomposition;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.cdt.core.dom.ast.IASTStatement;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTTryBlockStatement;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Statement;
 import org.jetbrains.kotlin.psi.KtFile;
@@ -40,7 +40,7 @@ public class TryStatementObject extends CompositeStatementObject {
 		this.catchClauses = new ArrayList<CompositeStatementObject>();
 	}
 
-	public TryStatementObject(String sourceFolder, String filePath, IASTStatement statement, int depth, String fileContent) {
+	public TryStatementObject(String sourceFolder, String filePath, ICPPASTTryBlockStatement statement, int depth, String fileContent) {
 		super(sourceFolder, filePath, statement, depth, CodeElementType.TRY_STATEMENT, fileContent);
 		this.catchClauses = new ArrayList<CompositeStatementObject>();
 	}

--- a/src/main/java/gr/uom/java/xmi/decomposition/VariableDeclaration.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/VariableDeclaration.java
@@ -11,6 +11,8 @@ import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTName;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTParameterDeclaration;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCatchHandler;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTRangeBasedForStatement;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTCompositeTypeSpecifier;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTDeclarationStatement;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFunctionDeclarator;
@@ -18,7 +20,6 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNamespaceDefinition;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTParameterDeclaration;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTTranslationUnit;
-import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTRangeBasedForStatement;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -193,8 +194,10 @@ public class VariableDeclaration implements LocationInfoProvider, VariableDeclar
 			else if(declarator.getParent().getParent() instanceof ICPPASTRangeBasedForStatement) {
 				return declarator.getParent().getParent();
 			}
+			else if(declarator.getParent().getParent() instanceof ICPPASTCatchHandler) {
+				return declarator.getParent().getParent();
+			}
 		}
-		//if the variable is declared in the foreach/range-for header, adjust its scope to the whole loop so body statements can resolve it.
 		else if(declarator.getParent() instanceof CPPASTParameterDeclaration && declarator.getParent().getParent() instanceof CPPASTFunctionDeclarator) {
 			return declarator.getParent().getParent().getParent();
 		}

--- a/src/main/java/gr/uom/java/xmi/decomposition/VariableDeclaration.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/VariableDeclaration.java
@@ -12,7 +12,11 @@ import org.eclipse.cdt.core.dom.ast.IASTName;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTParameterDeclaration;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCatchHandler;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTForStatement;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTIfStatement;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTRangeBasedForStatement;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTSwitchStatement;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTWhileStatement;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTCompositeTypeSpecifier;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTDeclarationStatement;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFunctionDeclarator;
@@ -195,6 +199,18 @@ public class VariableDeclaration implements LocationInfoProvider, VariableDeclar
 				return declarator.getParent().getParent();
 			}
 			else if(declarator.getParent().getParent() instanceof ICPPASTCatchHandler) {
+				return declarator.getParent().getParent();
+			}
+			else if(declarator.getParent().getParent() instanceof ICPPASTForStatement) {
+				return declarator.getParent().getParent();
+			}
+			else if(declarator.getParent().getParent() instanceof ICPPASTIfStatement) {
+				return declarator.getParent().getParent();
+			}
+			else if(declarator.getParent().getParent() instanceof ICPPASTSwitchStatement) {
+				return declarator.getParent().getParent();
+			}
+			else if(declarator.getParent().getParent() instanceof ICPPASTWhileStatement) {
 				return declarator.getParent().getParent();
 			}
 		}

--- a/src/main/java/gr/uom/java/xmi/decomposition/VariableDeclaration.java
+++ b/src/main/java/gr/uom/java/xmi/decomposition/VariableDeclaration.java
@@ -18,6 +18,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNamespaceDefinition;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTParameterDeclaration;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTTranslationUnit;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTRangeBasedForStatement;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -189,7 +190,11 @@ public class VariableDeclaration implements LocationInfoProvider, VariableDeclar
 			else if(declarator.getParent().getParent() instanceof CPPASTNamespaceDefinition) {
 				return declarator.getParent().getParent();
 			}
+			else if(declarator.getParent().getParent() instanceof ICPPASTRangeBasedForStatement) {
+				return declarator.getParent().getParent();
+			}
 		}
+		//if the variable is declared in the foreach/range-for header, adjust its scope to the whole loop so body statements can resolve it.
 		else if(declarator.getParent() instanceof CPPASTParameterDeclaration && declarator.getParent().getParent() instanceof CPPASTFunctionDeclarator) {
 			return declarator.getParent().getParent().getParent();
 		}

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -283,6 +283,43 @@ class CppFileProcessorTest {
 				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals("ex")));
 	}
 
+	@Test
+	void scopesCppControlStatementDeclarationsToTheirBodies() {
+		String filePath = "src/controls.cpp";
+		String fileContent = String.join("\n",
+				"void controls() {",
+				"  if (int flag = 1) {",
+				"    flag += 1;",
+				"  }",
+				"  while (int item = 1) {",
+				"    item += 1;",
+				"    break;",
+				"  }",
+				"  switch (int code = 1) {",
+				"    case 1:",
+				"      code += 1;",
+				"      break;",
+				"  }",
+				"  for (int i = 0; int keep = i < 1; ++i) {",
+				"    keep += 1;",
+				"  }",
+				"}") + "\n";
+
+		UMLModel model = new UMLModel(Set.of("src"));
+		CppFileProcessor processor = new CppFileProcessor(model);
+
+		processor.processCppFile(filePath, fileContent, false);
+
+		UMLClass moduleClass = findClass(model.getClassList(), "controls");
+		UMLOperation controls = findOperation(moduleClass.getOperations(), "controls");
+
+		assertVariableInScope(controls, "flag += 1", "flag");
+		assertVariableInScope(controls, "item += 1", "item");
+		assertVariableInScope(controls, "code += 1", "code");
+		assertVariableInScope(controls, "keep += 1", "keep");
+		assertVariableInScope(controls, "keep += 1", "i");
+	}
+
 	private static UMLOperation findOperation(List<UMLOperation> operations, String name) {
 		return operations.stream()
 				.filter(operation -> operation.getName().equals(name))
@@ -301,5 +338,14 @@ class CppFileProcessorTest {
 		return operation.getParameterTypeList().stream()
 				.map(Object::toString)
 				.toList();
+	}
+
+	private static void assertVariableInScope(UMLOperation operation, String statementText, String variableName) {
+		AbstractCodeFragment statement = operation.getBody().getCompositeStatement().getLeaves().stream()
+				.filter(leaf -> leaf.getString().contains(statementText))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Expected statement: " + statementText));
+		assertTrue(operation.getVariableDeclarationsInScope(statement.getLocationInfo()).stream()
+				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals(variableName)));
 	}
 }

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -10,6 +10,11 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import gr.uom.java.xmi.LocationInfo.CodeElementType;
+import gr.uom.java.xmi.decomposition.AbstractCodeFragment;
+import gr.uom.java.xmi.decomposition.CompositeStatementObject;
+import gr.uom.java.xmi.decomposition.VariableDeclaration;
+
 class CppFileProcessorTest {
 	@Test
 	void processesCFunctionDefinitionsIntoModuleOperations() {
@@ -188,6 +193,45 @@ class CppFileProcessorTest {
 		assertEquals(Visibility.PUBLIC, findOperation(widget.getOperations(), "visible").getVisibility());
 		assertEquals(Visibility.PROTECTED, findOperation(widget.getOperations(), "inherited").getVisibility());
 		assertEquals(Visibility.PRIVATE, findOperation(widget.getOperations(), "hidden").getVisibility());
+	}
+
+	@Test
+	void processesCppRangeBasedForStatementsAsEnhancedForStatements() {
+		String filePath = "src/ranges.cpp";
+		String fileContent = String.join("\n",
+				"void visit() {",
+				"  int values[3] = {1, 2, 3};",
+				"  for (int value : values) {",
+				"    value += 1;",
+				"  }",
+				"}") + "\n";
+
+		UMLModel model = new UMLModel(Set.of("src"));
+		CppFileProcessor processor = new CppFileProcessor(model);
+
+		processor.processCppFile(filePath, fileContent, false);
+
+		UMLClass moduleClass = findClass(model.getClassList(), "ranges");
+		UMLOperation visit = findOperation(moduleClass.getOperations(), "visit");
+
+		List<CompositeStatementObject> enhancedForStatements = visit.getBody().getCompositeStatement().getInnerNodes().stream()
+				.filter(statement -> statement.getLocationInfo().getCodeElementType().equals(CodeElementType.ENHANCED_FOR_STATEMENT))
+				.toList();
+		assertEquals(1, enhancedForStatements.size());
+
+		CompositeStatementObject enhancedFor = enhancedForStatements.get(0);
+		assertEquals(List.of("value"), enhancedFor.getVariableDeclarations().stream()
+				.map(VariableDeclaration::getVariableName)
+				.toList());
+		assertTrue(enhancedFor.getExpressions().stream()
+				.anyMatch(expression -> expression.getLocationInfo().getCodeElementType().equals(CodeElementType.ENHANCED_FOR_STATEMENT_EXPRESSION)));
+
+		AbstractCodeFragment loopBodyStatement = enhancedFor.getLeaves().stream()
+				.filter(statement -> statement.getString().contains("value += 1"))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Expected range-for body statement"));
+		assertTrue(visit.getVariableDeclarationsInScope(loopBodyStatement.getLocationInfo()).stream()
+				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals("value")));
 	}
 
 	private static UMLOperation findOperation(List<UMLOperation> operations, String name) {

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -3,6 +3,7 @@ package gr.uom.java.xmi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import gr.uom.java.xmi.LocationInfo.CodeElementType;
 import gr.uom.java.xmi.decomposition.AbstractCodeFragment;
 import gr.uom.java.xmi.decomposition.CompositeStatementObject;
+import gr.uom.java.xmi.decomposition.TryStatementObject;
 import gr.uom.java.xmi.decomposition.VariableDeclaration;
 
 class CppFileProcessorTest {
@@ -232,6 +234,53 @@ class CppFileProcessorTest {
 				.orElseThrow(() -> new AssertionError("Expected range-for body statement"));
 		assertTrue(visit.getVariableDeclarationsInScope(loopBodyStatement.getLocationInfo()).stream()
 				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals("value")));
+	}
+
+	@Test
+	void processesCppTryStatementsWithCatchClauses() {
+		String filePath = "src/errors.cpp";
+		String fileContent = String.join("\n",
+				"void handle() {",
+				"  try {",
+				"    risky();",
+				"  } catch (const int& ex) {",
+				"    recover(ex);",
+				"  }",
+				"}") + "\n";
+
+		UMLModel model = new UMLModel(Set.of("src"));
+		CppFileProcessor processor = new CppFileProcessor(model);
+
+		processor.processCppFile(filePath, fileContent, false);
+
+		UMLClass moduleClass = findClass(model.getClassList(), "errors");
+		UMLOperation handle = findOperation(moduleClass.getOperations(), "handle");
+
+		List<CompositeStatementObject> tryStatements = handle.getBody().getCompositeStatement().getInnerNodes().stream()
+				.filter(statement -> statement.getLocationInfo().getCodeElementType().equals(CodeElementType.TRY_STATEMENT))
+				.toList();
+		assertEquals(1, tryStatements.size());
+		TryStatementObject tryStatement = (TryStatementObject) tryStatements.get(0);
+
+		List<CompositeStatementObject> catchClauses = handle.getBody().getCompositeStatement().getInnerNodes().stream()
+				.filter(statement -> statement.getLocationInfo().getCodeElementType().equals(CodeElementType.CATCH_CLAUSE))
+				.toList();
+		assertEquals(1, catchClauses.size());
+
+		CompositeStatementObject catchClause = catchClauses.get(0);
+		assertEquals(List.of(catchClause), tryStatement.getCatchClauses());
+		assertTrue(catchClause.getTryContainer().isPresent());
+		assertSame(tryStatement, catchClause.getTryContainer().get());
+		assertEquals(List.of("ex"), catchClause.getVariableDeclarations().stream()
+				.map(VariableDeclaration::getVariableName)
+				.toList());
+
+		AbstractCodeFragment catchBodyStatement = catchClause.getLeaves().stream()
+				.filter(statement -> statement.getString().contains("recover"))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Expected catch body statement"));
+		assertTrue(handle.getVariableDeclarationsInScope(catchBodyStatement.getLocationInfo()).stream()
+				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals("ex")));
 	}
 
 	private static UMLOperation findOperation(List<UMLOperation> operations, String name) {

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -214,9 +214,9 @@ class CppFileProcessorTest {
 		processor.processCppFile(filePath, fileContent, false);
 
 		UMLClass moduleClass = findClass(model.getClassList(), "ranges");
-		UMLOperation visit = findOperation(moduleClass.getOperations(), "visit");
+		UMLOperation testedOperation = findOperation(moduleClass.getOperations(), "visit");
 
-		List<CompositeStatementObject> enhancedForStatements = visit.getBody().getCompositeStatement().getInnerNodes().stream()
+		List<CompositeStatementObject> enhancedForStatements = testedOperation.getBody().getCompositeStatement().getInnerNodes().stream()
 				.filter(statement -> statement.getLocationInfo().getCodeElementType().equals(CodeElementType.ENHANCED_FOR_STATEMENT))
 				.toList();
 		assertEquals(1, enhancedForStatements.size());
@@ -232,7 +232,7 @@ class CppFileProcessorTest {
 				.filter(statement -> statement.getString().contains("value += 1"))
 				.findFirst()
 				.orElseThrow(() -> new AssertionError("Expected range-for body statement"));
-		assertTrue(visit.getVariableDeclarationsInScope(loopBodyStatement.getLocationInfo()).stream()
+		assertTrue(testedOperation.getVariableDeclarationsInScope(loopBodyStatement.getLocationInfo()).stream()
 				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals("value")));
 	}
 
@@ -254,15 +254,15 @@ class CppFileProcessorTest {
 		processor.processCppFile(filePath, fileContent, false);
 
 		UMLClass moduleClass = findClass(model.getClassList(), "errors");
-		UMLOperation handle = findOperation(moduleClass.getOperations(), "handle");
+		UMLOperation testedOperation = findOperation(moduleClass.getOperations(), "handle");
 
-		List<CompositeStatementObject> tryStatements = handle.getBody().getCompositeStatement().getInnerNodes().stream()
+		List<CompositeStatementObject> tryStatements = testedOperation.getBody().getCompositeStatement().getInnerNodes().stream()
 				.filter(statement -> statement.getLocationInfo().getCodeElementType().equals(CodeElementType.TRY_STATEMENT))
 				.toList();
 		assertEquals(1, tryStatements.size());
 		TryStatementObject tryStatement = (TryStatementObject) tryStatements.get(0);
 
-		List<CompositeStatementObject> catchClauses = handle.getBody().getCompositeStatement().getInnerNodes().stream()
+		List<CompositeStatementObject> catchClauses = testedOperation.getBody().getCompositeStatement().getInnerNodes().stream()
 				.filter(statement -> statement.getLocationInfo().getCodeElementType().equals(CodeElementType.CATCH_CLAUSE))
 				.toList();
 		assertEquals(1, catchClauses.size());
@@ -279,7 +279,7 @@ class CppFileProcessorTest {
 				.filter(statement -> statement.getString().contains("recover"))
 				.findFirst()
 				.orElseThrow(() -> new AssertionError("Expected catch body statement"));
-		assertTrue(handle.getVariableDeclarationsInScope(catchBodyStatement.getLocationInfo()).stream()
+		assertTrue(testedOperation.getVariableDeclarationsInScope(catchBodyStatement.getLocationInfo()).stream()
 				.anyMatch(variableDeclaration -> variableDeclaration.getVariableName().equals("ex")));
 	}
 


### PR DESCRIPTION
Adds support for C++ range-based for statements by mapping ICPPASTRangeBasedForStatement to ENHANCED_FOR_STATEMENT.

Extracts range-for loop declarations and scopes loop variables inside the loop body.

Adds support for C++ try / catch blocks through ICPPASTTryBlockStatement and ICPPASTCatchHandler.

Adds a CDT-backed constructor to TryStatementObject.

Links catch clauses back to their parent try statement and scopes catch exception declarations inside the catch body.

Handles C++ declarations inside control-flow headers:if (int x = ...)
while (int x = ...)
switch (int x = ...)
for (int i = ...; int keep = ...; ++i)

Updates VariableDeclaration scope resolution so variables declared in C++ control-flow headers are scoped to the correct statement node.

Adds focused C++ processor tests for range-for statements, try/catch handling, and control-flow declaration scoping.