### PR TITLE
Parse inactive C++ preprocessor declarations

### DIFF
--- a/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
@@ -3,18 +3,26 @@ package gr.uom.java.xmi;
 import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 
-import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
+import org.eclipse.cdt.core.dom.ast.IASTArrayDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTComment;
 import org.eclipse.cdt.core.dom.ast.IASTCompositeTypeSpecifier;
+import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTCompoundStatement;
 import org.eclipse.cdt.core.dom.ast.IASTDeclSpecifier;
@@ -22,6 +30,7 @@ import org.eclipse.cdt.core.dom.ast.IASTFileLocation;
 import org.eclipse.cdt.core.dom.ast.IASTFunctionDefinition;
 import org.eclipse.cdt.core.dom.ast.IASTFunctionDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTName;
+import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTParameterDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorElifStatement;
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorElseStatement;
@@ -46,6 +55,7 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCatchHandler;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCompositeTypeSpecifier;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCompositeTypeSpecifier.ICPPASTBaseSpecifier;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTConstructorChainInitializer;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFunctionDeclarator;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFunctionDefinition;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFunctionWithTryBlock;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTNamedTypeSpecifier;
@@ -102,6 +112,24 @@ public class CppFileProcessor {
 	private String filePath;
 	private String fileContent;
 	private UMLModel umlModel;
+	private List<int[]> conditionalBranches = new ArrayList<>();
+	private final Map<UMLOperation, IASTNode> operationOrigins = new IdentityHashMap<>();
+	private final Map<UMLOperation, String> operationTemplateIdentities = new IdentityHashMap<>();
+	private final Map<UMLOperation, List<String>> operationCanonicalParameterTypes = new IdentityHashMap<>();
+	private final Map<UMLOperation, String> operationQualifierIdentities = new IdentityHashMap<>();
+	private final Map<UMLAttribute, IASTNode> attributeOrigins = new IdentityHashMap<>();
+	private final Map<UMLImport, IASTNode> importOrigins = new IdentityHashMap<>();
+	private final Map<UMLTypeAlias, IASTNode> typeAliasOrigins = new IdentityHashMap<>();
+
+	private static class DeclarationGroup {
+		private final IASTDeclaration[] declarations;
+		private final Visibility initialVisibility;
+
+		private DeclarationGroup(IASTDeclaration[] declarations, Visibility initialVisibility) {
+			this.declarations = declarations;
+			this.initialVisibility = initialVisibility;
+		}
+	}
 
 	public CppFileProcessor(UMLModel umlModel) {
 		this.umlModel = umlModel;
@@ -110,6 +138,14 @@ public class CppFileProcessor {
 	public void processCppFile(String filePath, String fileContent, boolean astDiff) {
 		this.filePath = filePath;
 		this.fileContent = fileContent;
+		this.conditionalBranches = new ArrayList<>();
+		this.operationOrigins.clear();
+		this.operationTemplateIdentities.clear();
+		this.operationCanonicalParameterTypes.clear();
+		this.operationQualifierIdentities.clear();
+		this.attributeOrigins.clear();
+		this.importOrigins.clear();
+		this.typeAliasOrigins.clear();
 		try {
 			FileContent content = FileContent.create(filePath, fileContent.toCharArray());
 			Map<String, String> predefinedMacros = new HashMap<>();
@@ -130,15 +166,16 @@ public class CppFileProcessor {
 						scanInfo,
 						includeFiles,
 						EmptyCIndex.INSTANCE,
-						GPPLanguage.OPTION_IS_SOURCE_UNIT,
+						GPPLanguage.OPTION_IS_SOURCE_UNIT | GPPLanguage.OPTION_PARSE_INACTIVE_CODE,
 						new DefaultLogService()
 						);
 				String sourceFolder = extractCppSourceFolder();
 				List<UMLComment> comments = extractInternalComments(ast.getComments(), sourceFolder, filePath, fileContent);
 				this.umlModel.getCommentMap().put(filePath, comments);
 				UMLClass moduleClass = createModuleClass(ast, sourceFolder);
+				this.conditionalBranches = buildConditionalBranches(ast.getAllPreprocessorStatements());
 				processPreprocessorStatements(sourceFolder, moduleClass, ast.getAllPreprocessorStatements());
-				processDeclarations(moduleClass.getName(), sourceFolder, moduleClass, ast.getDeclarations(), comments, new ICPPASTTemplateParameter[0]);
+				processDeclarations(moduleClass.getName(), sourceFolder, moduleClass, ast.getDeclarations(true), comments, new ICPPASTTemplateParameter[0]);
 				this.umlModel.addClass(moduleClass);
 				//add remaining comments to moduleClass
 				//TODO consider assigning comments to individual preprocessor statements
@@ -165,6 +202,7 @@ public class CppFileProcessor {
 				List<UMLComment> comments = extractInternalComments(ast.getComments(), sourceFolder, filePath, fileContent);
 				this.umlModel.getCommentMap().put(filePath, comments);
 				UMLClass moduleClass = createModuleClass(ast, sourceFolder);
+				this.conditionalBranches = new ArrayList<>();
 				processPreprocessorStatements(sourceFolder, moduleClass, ast.getAllPreprocessorStatements());
 				processDeclarations(moduleClass.getName(), sourceFolder, moduleClass, ast.getDeclarations(), comments, new ICPPASTTemplateParameter[0]);
 				this.umlModel.addClass(moduleClass);
@@ -319,14 +357,536 @@ public class CppFileProcessor {
 	}
 
 	private void processDeclarations(String packageName, String sourceFolder, UMLAbstractClass parentContainer, IASTDeclaration[] declarations, List<UMLComment> comments, ICPPASTTemplateParameter[] templateParameters) {
-		Visibility currentVisibility = null;
-		for(IASTDeclaration declaration : declarations) {
-			currentVisibility = processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, declaration, templateParameters);
+		processDeclarationGroups(packageName, sourceFolder, parentContainer,
+				Collections.singletonList(new DeclarationGroup(declarations, null)), comments, templateParameters);
+	}
+
+	private void processDeclarationGroups(String packageName, String sourceFolder, UMLAbstractClass parentContainer,
+			List<DeclarationGroup> declarationGroups, List<UMLComment> comments, ICPPASTTemplateParameter[] templateParameters) {
+		List<IASTDeclaration> allDeclarations = new ArrayList<>();
+		for(DeclarationGroup group : declarationGroups) {
+			Collections.addAll(allDeclarations, group.declarations);
+		}
+		Map<IASTDeclaration, List<IASTDeclaration>> alternatives = new IdentityHashMap<>();
+		Set<IASTDeclaration> mergedInactiveContainers = Collections.newSetFromMap(new IdentityHashMap<>());
+		collectInactiveContainerAlternatives(allDeclarations.toArray(new IASTDeclaration[0]), alternatives, mergedInactiveContainers);
+		for(DeclarationGroup group : declarationGroups) {
+			Visibility currentVisibility = group.initialVisibility;
+			for(IASTDeclaration declaration : group.declarations) {
+				if(!mergedInactiveContainers.contains(declaration)) {
+					currentVisibility = processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility,
+							declaration, templateParameters, alternatives.getOrDefault(declaration, Collections.emptyList()));
+				}
+			}
 		}
 	}
-	
+
+	private void collectInactiveContainerAlternatives(IASTDeclaration[] declarations,
+			Map<IASTDeclaration, List<IASTDeclaration>> alternatives, Set<IASTDeclaration> mergedInactiveContainers) {
+		Map<String, List<IASTDeclaration>> activeContainers = new LinkedHashMap<>();
+		for(IASTDeclaration declaration : declarations) {
+			String key = containerKey(declaration);
+			IASTDeclaration unwrapped = unwrapDeclaration(declaration);
+			if(key != null && unwrapped.isActive()) {
+				activeContainers.computeIfAbsent(key, ignored -> new ArrayList<>()).add(declaration);
+			}
+		}
+		for(IASTDeclaration declaration : declarations) {
+			String key = containerKey(declaration);
+			IASTDeclaration unwrapped = unwrapDeclaration(declaration);
+			if(key == null || unwrapped.isActive()) {
+				continue;
+			}
+			for(IASTDeclaration activeContainer : activeContainers.getOrDefault(key, Collections.emptyList())) {
+				if(areSiblingBranches(unwrapped, unwrapDeclaration(activeContainer))) {
+					alternatives.computeIfAbsent(activeContainer, ignored -> new ArrayList<>()).add(declaration);
+					mergedInactiveContainers.add(declaration);
+					break;
+				}
+			}
+		}
+	}
+
+	private String containerKey(IASTDeclaration declaration) {
+		IASTDeclaration unwrapped = unwrapDeclaration(declaration);
+		if(unwrapped instanceof IASTSimpleDeclaration simpleDeclaration &&
+				simpleDeclaration.getDeclSpecifier() instanceof IASTCompositeTypeSpecifier compositeTypeSpecifier &&
+				compositeTypeSpecifier.getName() != null && !compositeTypeSpecifier.getName().toString().isBlank()) {
+			// Keep class-template parameter names in the key. Merging alpha-renamed class alternatives
+			// would otherwise attach inactive members that refer to U to an active class that declares T.
+			return "type " + compositeTypeSpecifier.getName() + templateParameterIdentity(declaration, true);
+		}
+		if(unwrapped instanceof CPPASTNamespaceDefinition namespaceDefinition) {
+			return "namespace " + namespaceDefinition.getName();
+		}
+		if(unwrapped instanceof CPPASTLinkageSpecification linkageSpecification) {
+			return "linkage " + linkageSpecification.getLiteral();
+		}
+		return null;
+	}
+
+	private String templateParameterIdentity(IASTDeclaration declaration, boolean includeNames) {
+		if(declaration instanceof CPPASTTemplateDeclaration templateDeclaration) {
+			return templateParameterIdentity(templateDeclaration.getTemplateParameters(), includeNames) +
+					templateParameterIdentity(templateDeclaration.getDeclaration(), includeNames);
+		}
+		if(declaration instanceof CPPASTTemplateSpecialization templateSpecialization) {
+			return templateParameterIdentity(templateSpecialization.getTemplateParameters(), includeNames) +
+					templateParameterIdentity(templateSpecialization.getDeclaration(), includeNames);
+		}
+		return "";
+	}
+
+	private String templateParameterIdentity(ICPPASTTemplateParameter[] parameters, boolean includeNames) {
+		if(parameters.length == 0) {
+			return "";
+		}
+		StringBuilder identity = new StringBuilder("<");
+		for(ICPPASTTemplateParameter parameter : parameters) {
+			if(parameter instanceof ICPPASTSimpleTypeTemplateParameter typeParameter) {
+				identity.append("type");
+				if(includeNames && typeParameter.getName() != null) {
+					identity.append(':').append(normalizeTemplateIdentity(typeParameter.getName().toString()));
+				}
+			}
+			else if(parameter instanceof ICPPASTParameterDeclaration nonTypeParameter) {
+				identity.append("value:")
+						.append(normalizeTemplateIdentity(nonTypeParameter.getDeclSpecifier().getRawSignature()))
+						.append(':')
+						.append(declaratorTypeIdentity(nonTypeParameter.getDeclarator()));
+				if(includeNames && nonTypeParameter.getDeclarator() != null && nonTypeParameter.getDeclarator().getName() != null) {
+					identity.append(':').append(normalizeTemplateIdentity(nonTypeParameter.getDeclarator().getName().toString()));
+				}
+			}
+			else if(parameter instanceof ICPPASTTemplatedTypeTemplateParameter templateTemplateParameter) {
+				identity.append("template")
+						.append(templateParameterIdentity(templateTemplateParameter.getTemplateParameters(), includeNames));
+				if(includeNames && templateTemplateParameter.getName() != null) {
+					identity.append(':').append(normalizeTemplateIdentity(templateTemplateParameter.getName().toString()));
+				}
+			}
+			else {
+				identity.append(normalizeTemplateIdentity(parameter.getRawSignature()));
+			}
+			if(parameter.isParameterPack()) {
+				identity.append("...");
+			}
+			identity.append(';');
+		}
+		return identity.append('>').toString();
+	}
+
+	private String declaratorTypeIdentity(IASTDeclarator declarator) {
+		if(declarator == null) {
+			return "";
+		}
+		String rawSignature = declarator.getRawSignature();
+		IASTFileLocation declaratorLocation = declarator.getFileLocation();
+		if(declaratorLocation == null) {
+			return normalizeTemplateIdentity(rawSignature);
+		}
+		List<IASTNode> excludedNodes = new ArrayList<>();
+		if(declarator.getName() != null) {
+			excludedNodes.add(declarator.getName());
+		}
+		if(declarator.getInitializer() != null) {
+			excludedNodes.add(declarator.getInitializer());
+		}
+		excludedNodes.sort((first, second) -> Integer.compare(
+				second.getFileLocation() != null ? second.getFileLocation().getNodeOffset() : Integer.MIN_VALUE,
+				first.getFileLocation() != null ? first.getFileLocation().getNodeOffset() : Integer.MIN_VALUE));
+		for(IASTNode excludedNode : excludedNodes) {
+			IASTFileLocation excludedLocation = excludedNode.getFileLocation();
+			if(excludedLocation == null) {
+				continue;
+			}
+			int start = excludedLocation.getNodeOffset() - declaratorLocation.getNodeOffset();
+			int end = start + excludedLocation.getNodeLength();
+			if(start >= 0 && end <= rawSignature.length()) {
+				rawSignature = rawSignature.substring(0, start) + rawSignature.substring(end);
+			}
+		}
+		return normalizeTemplateIdentity(rawSignature);
+	}
+
+	private String normalizeTemplateIdentity(String text) {
+		return text.replaceAll("\\s+", "");
+	}
+
+	private IASTDeclaration unwrapDeclaration(IASTDeclaration declaration) {
+		if(declaration instanceof CPPASTTemplateDeclaration templateDeclaration) {
+			return unwrapDeclaration(templateDeclaration.getDeclaration());
+		}
+		if(declaration instanceof CPPASTTemplateSpecialization templateSpecialization) {
+			return unwrapDeclaration(templateSpecialization.getDeclaration());
+		}
+		return declaration;
+	}
+
+	private List<IASTDeclaration> unwrapAlternatives(List<IASTDeclaration> alternatives) {
+		List<IASTDeclaration> unwrapped = new ArrayList<>();
+		for(IASTDeclaration alternative : alternatives) {
+			unwrapped.add(unwrapDeclaration(alternative));
+		}
+		return unwrapped;
+	}
+
+	private List<DeclarationGroup> containerDeclarationGroups(IASTDeclaration declaration, List<IASTDeclaration> alternatives) {
+		List<DeclarationGroup> groups = new ArrayList<>();
+		groups.add(containerDeclarationGroup(unwrapDeclaration(declaration)));
+		for(IASTDeclaration alternative : alternatives) {
+			groups.add(containerDeclarationGroup(unwrapDeclaration(alternative)));
+		}
+		return groups;
+	}
+
+	private DeclarationGroup containerDeclarationGroup(IASTDeclaration declaration) {
+		Visibility initialVisibility = null;
+		if(declaration instanceof IASTSimpleDeclaration simpleDeclaration &&
+				simpleDeclaration.getDeclSpecifier() instanceof IASTCompositeTypeSpecifier compositeTypeSpecifier) {
+			initialVisibility = compositeTypeSpecifier.getKey() == ICPPASTCompositeTypeSpecifier.k_class ?
+					Visibility.PRIVATE : Visibility.PUBLIC;
+		}
+		return new DeclarationGroup(containerDeclarations(declaration), initialVisibility);
+	}
+
+	private IASTDeclaration[] containerDeclarations(IASTDeclaration declaration) {
+		if(declaration instanceof IASTSimpleDeclaration simpleDeclaration &&
+				simpleDeclaration.getDeclSpecifier() instanceof IASTCompositeTypeSpecifier compositeTypeSpecifier) {
+			return compositeTypeSpecifier.getDeclarations(true);
+		}
+		if(declaration instanceof CPPASTNamespaceDefinition namespaceDefinition) {
+			return namespaceDefinition.getDeclarations(true);
+		}
+		if(declaration instanceof CPPASTLinkageSpecification linkageSpecification) {
+			return linkageSpecification.getDeclarations(true);
+		}
+		return new IASTDeclaration[0];
+	}
+
+	private Map<Integer, Integer> enclosingConditionalBranches(IASTNode node) {
+		Map<Integer, Integer> branches = new HashMap<>();
+		IASTFileLocation location = node.getFileLocation();
+		if(location == null || !node.isPartOfTranslationUnitFile()) {
+			return branches;
+		}
+		int offset = location.getNodeOffset();
+		for(int[] branch : conditionalBranches) {
+			if(offset >= branch[2] && offset < branch[3]) {
+				branches.put(branch[0], branch[1]);
+			}
+		}
+		return branches;
+	}
+
+	private boolean areSiblingBranches(IASTNode first, IASTNode second) {
+		Map<Integer, Integer> firstBranches = enclosingConditionalBranches(first);
+		Map<Integer, Integer> secondBranches = enclosingConditionalBranches(second);
+		for(Map.Entry<Integer, Integer> branch : firstBranches.entrySet()) {
+			Integer secondBranchIndex = secondBranches.get(branch.getKey());
+			if(secondBranchIndex != null && !secondBranchIndex.equals(branch.getValue())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	//Each entry is {conditional group id, branch index within the group, branch start offset, branch end offset}.
+	private List<int[]> buildConditionalBranches(IASTPreprocessorStatement[] statements) {
+		List<int[]> branches = new ArrayList<>();
+		Deque<int[]> openBranches = new ArrayDeque<>();
+		int nextGroupId = 0;
+		for(IASTPreprocessorStatement statement : statements) {
+			IASTFileLocation location = statement.getFileLocation();
+			if(location == null || !statement.isPartOfTranslationUnitFile()) {
+				continue;
+			}
+			int start = location.getNodeOffset();
+			int end = start + location.getNodeLength();
+			if(statement instanceof IASTPreprocessorIfStatement ||
+					statement instanceof IASTPreprocessorIfdefStatement ||
+					statement instanceof IASTPreprocessorIfndefStatement) {
+				openBranches.push(new int[] {nextGroupId++, 0, end});
+			}
+			else if(statement instanceof IASTPreprocessorElifStatement ||
+					statement instanceof IASTPreprocessorElseStatement) {
+				if(!openBranches.isEmpty()) {
+					int[] open = openBranches.pop();
+					branches.add(new int[] {open[0], open[1], open[2], start});
+					openBranches.push(new int[] {open[0], open[1] + 1, end});
+				}
+			}
+			else if(statement instanceof IASTPreprocessorEndifStatement) {
+				if(!openBranches.isEmpty()) {
+					int[] open = openBranches.pop();
+					branches.add(new int[] {open[0], open[1], open[2], start});
+				}
+			}
+		}
+		return branches;
+	}
+
+	private void addOperation(UMLAbstractClass parentContainer, UMLOperation operation, IASTNode origin,
+			ICPPASTTemplateParameter[] templateParameters) {
+		operationTemplateIdentities.put(operation, templateParameterIdentity(templateParameters, false));
+		operationCanonicalParameterTypes.put(operation, canonicalParameterTypes(operation, templateParameters, origin));
+		operationQualifierIdentities.put(operation, operationQualifierIdentity(origin));
+		if(retainModelElement(operation, origin, parentContainer.getOperations(), operationOrigins,
+				this::sameOperationIdentity, inactiveSibling -> {
+					parentContainer.removeOperation(inactiveSibling);
+					operationTemplateIdentities.remove(inactiveSibling);
+					operationCanonicalParameterTypes.remove(inactiveSibling);
+					operationQualifierIdentities.remove(inactiveSibling);
+				})) {
+			parentContainer.addOperation(operation);
+		}
+		else {
+			operationTemplateIdentities.remove(operation);
+			operationCanonicalParameterTypes.remove(operation);
+			operationQualifierIdentities.remove(operation);
+		}
+	}
+
+	private boolean sameOperationIdentity(UMLOperation first, UMLOperation second) {
+		return first.getClassName().equals(second.getClassName()) &&
+				first.getName().equals(second.getName()) &&
+				Objects.equals(operationTemplateIdentities.get(first), operationTemplateIdentities.get(second)) &&
+				Objects.equals(operationCanonicalParameterTypes.get(first), operationCanonicalParameterTypes.get(second)) &&
+				Objects.equals(operationQualifierIdentities.get(first), operationQualifierIdentities.get(second));
+	}
+
+	private String operationQualifierIdentity(IASTNode origin) {
+		IASTFunctionDeclarator declarator = functionDeclarator(origin);
+		if(declarator instanceof ICPPASTFunctionDeclarator cppDeclarator) {
+			return "const=" + cppDeclarator.isConst() +
+					",volatile=" + cppDeclarator.isVolatile() +
+					",ref=" + cppDeclarator.getRefQualifier();
+		}
+		return "";
+	}
+
+	private IASTFunctionDeclarator functionDeclarator(IASTNode origin) {
+		if(origin instanceof IASTFunctionDefinition functionDefinition) {
+			return functionDefinition.getDeclarator();
+		}
+		if(origin instanceof IASTFunctionDeclarator functionDeclarator) {
+			return functionDeclarator;
+		}
+		return null;
+	}
+
+	private List<String> canonicalParameterTypes(UMLOperation operation, ICPPASTTemplateParameter[] templateParameters,
+			IASTNode origin) {
+		Map<String, Integer> parameterPositions = templateParameterPositions(templateParameters);
+		List<IASTParameterDeclaration> parameterDeclarations = modeledParameterDeclarations(origin);
+		List<String> canonicalTypes = new ArrayList<>();
+		List<UMLType> parameterTypes = operation.getParameterTypeList();
+		for(int i = 0; i < parameterTypes.size(); i++) {
+			UMLType parameterType = parameterTypes.get(i);
+			if(parameterType == null) {
+				canonicalTypes.add("{unknown-parameter-type}");
+				continue;
+			}
+			String canonicalType = parameterType.toQualifiedString();
+			if(i < parameterDeclarations.size()) {
+				canonicalType = normalizeTopLevelParameterCv(canonicalType, parameterDeclarations.get(i));
+			}
+			canonicalTypes.add(canonicalizeTemplateParameterNames(canonicalType, parameterPositions));
+		}
+		return canonicalTypes;
+	}
+
+	private List<IASTParameterDeclaration> modeledParameterDeclarations(IASTNode origin) {
+		IASTFunctionDeclarator declarator = functionDeclarator(origin);
+		if(!(declarator instanceof IASTStandardFunctionDeclarator standardDeclarator)) {
+			return Collections.emptyList();
+		}
+		IASTParameterDeclaration[] parameters = standardDeclarator.getParameters();
+		if(parameters.length == 1 && UMLType.cleanTypeText(parameters[0].getDeclSpecifier().getRawSignature()).equals("void")) {
+			return Collections.emptyList();
+		}
+		return List.of(parameters);
+	}
+
+	private String normalizeTopLevelParameterCv(String type, IASTParameterDeclaration parameter) {
+		IASTDeclarator declarator = parameter.getDeclarator();
+		if(declarator == null) {
+			return type;
+		}
+		boolean hasPointerOrReference = false;
+		boolean hasArray = false;
+		IASTDeclarator nestedDeclarator = declarator;
+		while(nestedDeclarator != null) {
+			hasPointerOrReference |= nestedDeclarator.getPointerOperators().length > 0;
+			hasArray |= nestedDeclarator instanceof IASTArrayDeclarator;
+			nestedDeclarator = nestedDeclarator.getNestedDeclarator();
+		}
+		if(hasPointerOrReference) {
+			return removeTrailingCvQualifiers(type);
+		}
+		if(hasArray) {
+			return type;
+		}
+		String normalized = type;
+		if(parameter.getDeclSpecifier().isConst()) {
+			normalized = removeTopLevelQualifier(normalized, "const");
+		}
+		if(parameter.getDeclSpecifier().isVolatile()) {
+			normalized = removeTopLevelQualifier(normalized, "volatile");
+		}
+		return normalized;
+	}
+
+	private String removeTrailingCvQualifiers(String type) {
+		String normalized = type.trim();
+		while(normalized.matches(".*\\b(?:const|volatile)\\s*$")) {
+			normalized = normalized.replaceFirst("\\s*\\b(?:const|volatile)\\s*$", "").trim();
+		}
+		return normalized;
+	}
+
+	private String removeTopLevelQualifier(String type, String qualifier) {
+		int templateDepth = 0;
+		for(int offset = 0; offset < type.length();) {
+			int codePoint = type.codePointAt(offset);
+			if(codePoint == '<') {
+				templateDepth++;
+			}
+			else if(codePoint == '>' && templateDepth > 0) {
+				templateDepth--;
+			}
+			else if(templateDepth == 0 && (codePoint == '_' || Character.isUnicodeIdentifierStart(codePoint))) {
+				int end = offset + Character.charCount(codePoint);
+				while(end < type.length()) {
+					int nextCodePoint = type.codePointAt(end);
+					if(!Character.isUnicodeIdentifierPart(nextCodePoint)) {
+						break;
+					}
+					end += Character.charCount(nextCodePoint);
+				}
+				if(type.substring(offset, end).equals(qualifier)) {
+					return (type.substring(0, offset) + type.substring(end)).replaceAll("\\s+", " ").trim();
+				}
+				offset = end;
+				continue;
+			}
+			offset += Character.charCount(codePoint);
+		}
+		return type;
+	}
+
+	private Map<String, Integer> templateParameterPositions(ICPPASTTemplateParameter[] templateParameters) {
+		Map<String, Integer> positions = new HashMap<>();
+		for(int i = 0; i < templateParameters.length; i++) {
+			String name = templateParameterName(templateParameters[i]);
+			if(name != null && !name.isBlank()) {
+				positions.put(name, i);
+			}
+		}
+		return positions;
+	}
+
+	private String templateParameterName(ICPPASTTemplateParameter parameter) {
+		if(parameter instanceof ICPPASTSimpleTypeTemplateParameter typeParameter && typeParameter.getName() != null) {
+			return typeParameter.getName().toString();
+		}
+		if(parameter instanceof ICPPASTParameterDeclaration nonTypeParameter && nonTypeParameter.getDeclarator() != null &&
+				nonTypeParameter.getDeclarator().getName() != null) {
+			return nonTypeParameter.getDeclarator().getName().toString();
+		}
+		if(parameter instanceof ICPPASTTemplatedTypeTemplateParameter templateTemplateParameter && templateTemplateParameter.getName() != null) {
+			return templateTemplateParameter.getName().toString();
+		}
+		return null;
+	}
+
+	private String canonicalizeTemplateParameterNames(String type, Map<String, Integer> parameterPositions) {
+		StringBuilder canonicalType = new StringBuilder();
+		for(int offset = 0; offset < type.length();) {
+			int codePoint = type.codePointAt(offset);
+			if(codePoint == '_' || Character.isUnicodeIdentifierStart(codePoint)) {
+				int end = offset + Character.charCount(codePoint);
+				while(end < type.length()) {
+					int nextCodePoint = type.codePointAt(end);
+					if(!Character.isUnicodeIdentifierPart(nextCodePoint)) {
+						break;
+					}
+					end += Character.charCount(nextCodePoint);
+				}
+				String identifier = type.substring(offset, end);
+				Integer position = parameterPositions.get(identifier);
+				canonicalType.append(position != null ? "{template-parameter:" + position + "}" : identifier);
+				offset = end;
+			}
+			else {
+				canonicalType.appendCodePoint(codePoint);
+				offset += Character.charCount(codePoint);
+			}
+		}
+		return canonicalType.toString();
+	}
+
+	private void addAttribute(UMLAbstractClass parentContainer, UMLAttribute attribute, IASTNode origin) {
+		if(retainModelElement(attribute, origin, parentContainer.getAttributes(), attributeOrigins,
+				(first, second) -> first.getName().equals(second.getName()),
+				inactiveSibling -> removeByIdentity(parentContainer.getAttributes(), inactiveSibling))) {
+			parentContainer.addAttribute(attribute);
+		}
+	}
+
+	private void addImport(UMLAbstractClass parentContainer, UMLImport umlImport, IASTNode origin) {
+		if(retainModelElement(umlImport, origin, parentContainer.getImportedTypes(), importOrigins, UMLImport::equals,
+				inactiveSibling -> removeByIdentity(parentContainer.getImportedTypes(), inactiveSibling))) {
+			parentContainer.getImportedTypes().add(umlImport);
+		}
+	}
+
+	private void addTypeAlias(UMLClass umlClass, UMLTypeAlias typeAlias, IASTNode origin) {
+		if(retainModelElement(typeAlias, origin, umlClass.getTypeAliasList(), typeAliasOrigins,
+				(first, second) -> first.getName().equals(second.getName()),
+				inactiveSibling -> removeByIdentity(umlClass.getTypeAliasList(), inactiveSibling))) {
+			umlClass.addTypeAlias(typeAlias);
+		}
+	}
+
+	private <T> boolean retainModelElement(T element, IASTNode origin, List<T> existingElements,
+			Map<T, IASTNode> origins, BiPredicate<T, T> sameIdentity, Consumer<T> removeElement) {
+		boolean activeSiblingExists = false;
+		List<T> inactiveSiblings = new ArrayList<>();
+		for(T existing : existingElements) {
+			IASTNode existingOrigin = origins.get(existing);
+			if(existingOrigin != null && sameIdentity.test(existing, element) && areSiblingBranches(existingOrigin, origin)) {
+				if(existingOrigin.isActive()) {
+					activeSiblingExists = true;
+				}
+				else if(origin.isActive()) {
+					inactiveSiblings.add(existing);
+				}
+			}
+		}
+		if(!origin.isActive() && activeSiblingExists) {
+			return false;
+		}
+		for(T inactiveSibling : inactiveSiblings) {
+			removeElement.accept(inactiveSibling);
+			origins.remove(inactiveSibling);
+		}
+		origins.put(element, origin);
+		return true;
+	}
+
+	private <T> void removeByIdentity(List<T> elements, T element) {
+		for(int i = 0; i < elements.size(); i++) {
+			if(elements.get(i) == element) {
+				elements.remove(i);
+				return;
+			}
+		}
+	}
+
 	private Visibility processDeclaration(String packageName, String sourceFolder, UMLAbstractClass parentContainer,
-			List<UMLComment> comments, Visibility currentVisibility, IASTDeclaration declaration, ICPPASTTemplateParameter[] templateParameters) {
+			List<UMLComment> comments, Visibility currentVisibility, IASTDeclaration declaration, ICPPASTTemplateParameter[] templateParameters,
+			List<IASTDeclaration> inactiveContainerAlternatives) {
 		if(declaration instanceof CPPASTStructuredBindingDeclaration cppStructuredBindingDeclaration) {
 			//A structured binding declaration is a feature introduced in C++17 that allows you to unpack or decompose a target object into individual named variables.
 			//Similar to destructuring or unpacking in languages like JavaScript and Python, it directly binds specified identifiers to the sub-objects, members, or elements of an initializer.
@@ -342,15 +902,17 @@ public class CppFileProcessor {
 				variableDeclaration.setAttribute(true);
 				umlAttribute.setVariableDeclaration(variableDeclaration);
 				addTemplateParameters(umlAttribute, templateParameters, sourceFolder);
-				parentContainer.addAttribute(umlAttribute);
+				addAttribute(parentContainer, umlAttribute, name);
 				distributeComments(comments, locationInfo, umlAttribute.getComments());
 			}
 		}
 		else if(declaration instanceof CPPASTSimpleDeclaration cppSimpleDeclaration) {
-			processSimpleDeclaration(cppSimpleDeclaration, packageName, sourceFolder, parentContainer, currentVisibility, comments, templateParameters);
+			processSimpleDeclaration(cppSimpleDeclaration, packageName, sourceFolder, parentContainer, currentVisibility, comments,
+					templateParameters, inactiveContainerAlternatives);
 		}
 		else if(declaration instanceof CASTSimpleDeclaration cSimpleDeclaration) {
-			processSimpleDeclaration(cSimpleDeclaration, packageName, sourceFolder, parentContainer, currentVisibility, comments, templateParameters);
+			processSimpleDeclaration(cSimpleDeclaration, packageName, sourceFolder, parentContainer, currentVisibility, comments,
+					templateParameters, Collections.emptyList());
 		}
 		else if(declaration instanceof CPPASTAmbiguousSimpleDeclaration cppAmbiguousSimpleDeclaration) {
 			
@@ -360,13 +922,13 @@ public class CppFileProcessor {
 		}
 		else if(declaration instanceof CASTFunctionDefinition cFunctionDefinition) {
 			UMLOperation operation = processFunctionDefinition(cFunctionDefinition, packageName, sourceFolder, parentContainer, currentVisibility, comments, templateParameters);
-			parentContainer.addOperation(operation);
+			addOperation(parentContainer, operation, cFunctionDefinition, templateParameters);
 		}
 		else if(declaration instanceof CPPASTFunctionDefinition cppFunctionDefinition) {
 			//org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFunctionWithTryBlock is a subclass
 			//Function-Try-Block should be handled similar to Kotlin, which allows functions to have a try-expression as a body
 			UMLOperation operation = processFunctionDefinition(cppFunctionDefinition, packageName, sourceFolder, parentContainer, currentVisibility, comments, templateParameters);
-			parentContainer.addOperation(operation);
+			addOperation(parentContainer, operation, cppFunctionDefinition, templateParameters);
 		}
 		else if(declaration instanceof CPPASTAliasDeclaration cppAliasDeclaration) {
 			//A C++ alias declaration (introduced in C++11) uses the using keyword to create a readable, interchangeable synonym for an existing type or template. It is the modern, preferred alternative to typedef.
@@ -389,18 +951,21 @@ public class CppFileProcessor {
 			//templates are typically defined in separate header files (.hpp) and are instantiated as a 'template class'
 			//Explicit template instantiation forces the C++ compiler to generate code for a template with specific arguments. This allows you to split template definitions into separate .h and .cpp files.
 			IASTDeclaration nestedDeclaration = cppTemplateInstantiation.getDeclaration();
-			processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, nestedDeclaration, new ICPPASTTemplateParameter[0]);
+			processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, nestedDeclaration,
+					new ICPPASTTemplateParameter[0], Collections.emptyList());
 		}
 		else if(declaration instanceof CPPASTTemplateDeclaration cppTemplateDeclaration) {
 			IASTDeclaration nestedDeclaration = cppTemplateDeclaration.getDeclaration();
-			processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, nestedDeclaration, cppTemplateDeclaration.getTemplateParameters());
+			processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, nestedDeclaration,
+					cppTemplateDeclaration.getTemplateParameters(), unwrapAlternatives(inactiveContainerAlternatives));
 		}
 		else if(declaration instanceof CPPASTTemplateSpecialization cppTemplateSpecialization) {
 			//Template specialization allows you to override the generic behavior of a C++ template and define a custom implementation for specific data types or conditions.
 			//While primary templates provide a blueprint for all types, specialization handles unique edge cases—such as treating const char* or bool differently for performance or behavioral optimizations.
 			//C++ supports two types of template specialization: Explicit (Full) Specialization and Partial Specialization.
 			IASTDeclaration nestedDeclaration = cppTemplateSpecialization.getDeclaration();
-			processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, nestedDeclaration, cppTemplateSpecialization.getTemplateParameters());
+			processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility, nestedDeclaration,
+					cppTemplateSpecialization.getTemplateParameters(), unwrapAlternatives(inactiveContainerAlternatives));
 		}
 		else if(declaration instanceof CPPASTInitCapture cppInitCapture) {
 			//Init capture (also called generalized lambda capture) was introduced in C++14 to let you declare and initialize new variables directly inside a lambda's capture brackets [...]
@@ -409,7 +974,8 @@ public class CppFileProcessor {
 			//C++ linkage specifications (extern "C") direct the compiler to use specific linkage and calling conventions for different programming languages. By preventing C++ name mangling, it allows seamless calls between C++ and C code.
 			//C++ supports features like function overloading, which requires the compiler to "mangle" (decorate) function names with argument types so the linker can tell them apart.
 			//A C compiler doesn't do this, meaning C++ object code cannot normally find a C library's function. A linkage specification disables C++ mangling for that block of code, ensuring the exact function name is emitted for the linker.
-			processDeclarations(packageName, sourceFolder, parentContainer, cppLinkageSpecification.getDeclarations(), comments, templateParameters);
+			processDeclarationGroups(packageName, sourceFolder, parentContainer,
+					containerDeclarationGroups(cppLinkageSpecification, inactiveContainerAlternatives), comments, templateParameters);
 		}
 		else if(declaration instanceof CPPASTNamespaceAlias cppNamespaceAlias) {
 			//In C++, a namespace alias allows you to create a shorter or alternative name for a long or deeply nested namespace. You define it using the syntax namespace alias_name = existing_namespace;
@@ -419,9 +985,9 @@ public class CppFileProcessor {
 			//In C++, a namespace is a declarative region that provides a distinct scope to identifiers (such as names of types, functions, variables, and classes) to prevent naming collisions and organize code into logical groups.
 			IASTName name = cppNamespaceDefinition.getName();
 			String namespace = name.getRawSignature();
-			IASTDeclaration[] nameSpaceDeclarations = cppNamespaceDefinition.getDeclarations();
 			String qualifiedNamespace = packageName + "." + namespace;
-			processDeclarations(qualifiedNamespace, sourceFolder, parentContainer, nameSpaceDeclarations, comments, templateParameters);
+			processDeclarationGroups(qualifiedNamespace, sourceFolder, parentContainer,
+					containerDeclarationGroups(cppNamespaceDefinition, inactiveContainerAlternatives), comments, templateParameters);
 		}
 		else if(declaration instanceof CPPASTStaticAssertionDeclaration cppStaticAssertionDeclaration) {
 			//In C++, a static_assert declaration tests a software condition at compile time. If the condition evaluates to false, the compiler stops and issues a compilation error.
@@ -466,7 +1032,9 @@ public class CppFileProcessor {
 		return umlClass;
 	}
 
-	private void processSimpleDeclaration(IASTSimpleDeclaration simpleDeclaration, String packageName, String sourceFolder, UMLAbstractClass parentContainer, Visibility currentVisibility, List<UMLComment> comments, ICPPASTTemplateParameter[] templateParameters) {
+	private void processSimpleDeclaration(IASTSimpleDeclaration simpleDeclaration, String packageName, String sourceFolder,
+			UMLAbstractClass parentContainer, Visibility currentVisibility, List<UMLComment> comments,
+			ICPPASTTemplateParameter[] templateParameters, List<IASTDeclaration> inactiveContainerAlternatives) {
 		IASTDeclSpecifier declSpecifier = simpleDeclaration.getDeclSpecifier();
 		if(declSpecifier instanceof IASTCompositeTypeSpecifier compositeTypeSpecifier) {
 			if(compositeTypeSpecifier.getName() == null) {
@@ -508,7 +1076,8 @@ public class CppFileProcessor {
 			if(rawSignature.contains("{"))
 				rawSignature = rawSignature.substring(0, rawSignature.indexOf("{") + 1);
 			umlClass.setActualSignature(rawSignature);
-			processDeclarations(packageName + "." + className, sourceFolder, umlClass, compositeTypeSpecifier.getMembers(), comments, templateParameters);
+			processDeclarationGroups(packageName + "." + className, sourceFolder, umlClass,
+					containerDeclarationGroups(simpleDeclaration, inactiveContainerAlternatives), comments, templateParameters);
 			this.umlModel.addClass(umlClass);
 			distributeComments(comments, locationInfo, umlClass.getComments());
 		}
@@ -519,7 +1088,7 @@ public class CppFileProcessor {
 				}
 				else if(declarator instanceof IASTFunctionDeclarator functionDeclarator) {
 					UMLOperation operation = processFunctionDeclSpecifier(simpleDeclSpecifier, functionDeclarator, packageName, sourceFolder, parentContainer, currentVisibility, comments, templateParameters);
-					parentContainer.addOperation(operation);
+					addOperation(parentContainer, operation, functionDeclarator, templateParameters);
 				}
 			}
 		}
@@ -543,7 +1112,7 @@ public class CppFileProcessor {
 		variableDeclaration.setAttribute(true);
 		umlAttribute.setVariableDeclaration(variableDeclaration);
 		addTemplateParameters(umlAttribute, templateParameters, sourceFolder);
-		parentContainer.addAttribute(umlAttribute);
+		addAttribute(parentContainer, umlAttribute, declarator);
 		distributeComments(comments, locationInfo, umlAttribute.getComments());
 	}
 
@@ -686,7 +1255,7 @@ public class CppFileProcessor {
 		}
 		String importName = name.toString().replace("::", ".");
 		LocationInfo locationInfo = new LocationInfo(sourceFolder, filePath, declaration, CodeElementType.IMPORT_DECLARATION, fileContent);
-		parentContainer.getImportedTypes().add(new UMLImport(importName, onDemand, false, locationInfo));
+		addImport(parentContainer, new UMLImport(importName, onDemand, false, locationInfo), declaration);
 	}
 
 	private void processCppAliasDeclaration(CPPASTAliasDeclaration aliasDeclaration, String sourceFolder, UMLAbstractClass parentContainer, ICPPASTTemplateParameter[] templateParameters) {
@@ -698,7 +1267,7 @@ public class CppFileProcessor {
 			return;
 		}
 		addTemplateParameters(umlTypeAlias, templateParameters, sourceFolder);
-		umlClass.addTypeAlias(umlTypeAlias);
+		addTypeAlias(umlClass, umlTypeAlias, aliasDeclaration);
 	}
 
 	private UMLTypeAlias createCppTypeAlias(CPPASTAliasDeclaration aliasDeclaration, String sourceFolder) {

--- a/src/main/java/gr/uom/java/xmi/UMLAbstractClass.java
+++ b/src/main/java/gr/uom/java/xmi/UMLAbstractClass.java
@@ -159,6 +159,23 @@ public abstract class UMLAbstractClass implements AnnotationProvider, CommentPro
 		}
 	}
 
+	void removeOperation(UMLOperation operation) {
+		for(int i = 0; i < operations.size(); i++) {
+			if(operations.get(i) == operation) {
+				operations.remove(i);
+				List<String> signature = operation.getSignatureIdentifiers();
+				Integer instances = operationIdentifierSignatureMap.get(signature);
+				if(instances != null && instances > 1) {
+					operationIdentifierSignatureMap.put(signature, instances - 1);
+				}
+				else {
+					operationIdentifierSignatureMap.remove(signature);
+				}
+				return;
+			}
+		}
+	}
+
 	public void setContainer(ModuleContainer container) {
 		this.container = Optional.of(container);
 	}

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -16,6 +16,7 @@ import gr.uom.java.xmi.decomposition.AbstractCodeFragment;
 import gr.uom.java.xmi.decomposition.CompositeStatementObject;
 import gr.uom.java.xmi.decomposition.TryStatementObject;
 import gr.uom.java.xmi.decomposition.VariableDeclaration;
+import gr.uom.java.xmi.diff.UMLModelDiff;
 
 
 class CppFileProcessorTest {
@@ -138,6 +139,644 @@ class CppFileProcessorTest {
 		assertEquals("int", add.getReturnParameter().getType().toString());
 		assertEquals(List.of("lhs", "rhs"), add.getParameterNameList());
 		assertEquals(List.of("int", "int"), parameterTypeNames(add));
+	}
+
+	@Test
+	void processesCppDeclarationsInInactivePreprocessorBlocks() {
+		String filePath = "src/features.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_FEATURE)",
+				"namespace feature {",
+				"struct Matcher {",
+				"  bool match() {",
+				"    return true;",
+				"  }",
+				"};",
+				"extern \"C\" {",
+				"  void inactiveBranch() {",
+				"  }",
+				"}",
+				"}",
+				"#endif",
+				"void activeBranch() {",
+				"}") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+		UMLClass moduleClass = findClass(model.getClassList(), "features");
+
+		assertEquals(List.of("inactiveBranch", "activeBranch"), moduleClass.getOperations().stream()
+				.map(UMLOperation::getName)
+				.toList());
+		assertEquals(List.of("match"), findClass(model.getClassList(), "Matcher").getOperations().stream()
+				.map(UMLOperation::getName)
+				.toList());
+	}
+
+	@Test
+	void processesCatch2ShapedDeclarationsInInactiveCppBlock() {
+		String filePath = "tests/SelfTest/UsageTests/Matchers.tests.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(CATCH_INTERNAL_CONSTEXPR_MATCHERS_ENABLED)",
+				"namespace {",
+				"struct MatchAllMatcher final : public Catch::Matchers::MatcherGenericBase {",
+				"public:",
+				"  template <typename Any>",
+				"  constexpr bool match(Any&&) const { return true; }",
+				"  std::string describe() const override { return {}; }",
+				"};",
+				"constexpr MatchAllMatcher MatchAll() { return MatchAllMatcher(); }",
+				"}",
+				"#endif") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+		UMLClass matcher = findClass(model.getClassList(), "MatchAllMatcher");
+		UMLOperation match = findOperation(matcher.getOperations(), "match");
+
+		assertEquals(List.of("Any"), match.getTypeParameterNames());
+		assertEquals(1, match.getParameterTypeList().size());
+		assertTrue(match.getParameterTypeList().get(0).toString().contains("Any"));
+		assertNotNull(findOperation(findClass(model.getClassList(), "Matchers.tests").getOperations(), "MatchAll"));
+	}
+
+	@Test
+	void prefersActiveCppOperationOverInactiveSiblingPreprocessorBranch() {
+		String filePath = "src/platform.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_FEATURE)",
+				"int mode() {",
+				"  return 1;",
+				"}",
+				"#else",
+				"int mode() {",
+				"  return 2;",
+				"}",
+				"#endif",
+				"#if defined(UNDEFINED_FEATURE)",
+				"void inactiveOnly() {",
+				"}",
+				"#endif") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+		UMLClass moduleClass = findClass(model.getClassList(), "platform");
+
+		// Same-signature definitions in mutually exclusive branches collapse to the active one,
+		// while inactive declarations without an active counterpart are preserved.
+		assertEquals(List.of("mode", "inactiveOnly"), moduleClass.getOperations().stream()
+				.map(UMLOperation::getName)
+				.toList());
+		UMLOperation mode = findOperation(moduleClass.getOperations(), "mode");
+		assertTrue(mode.getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+	}
+
+	@Test
+	void prefersActiveCppOperationWhenActiveBranchComesFirst() {
+		String filePath = "src/active-first.cpp";
+		String fileContent = String.join("\n",
+				"#if 1",
+				"int mode() { return 2; }",
+				"#else",
+				"int mode() { return 1; }",
+				"#endif") + "\n";
+
+		List<UMLOperation> modes = findClass(processCppModel(filePath, fileContent).getClassList(), "active-first").getOperations().stream()
+				.filter(operation -> operation.getName().equals("mode"))
+				.toList();
+
+		assertEquals(1, modes.size());
+		assertTrue(modes.get(0).getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+	}
+
+	@Test
+	void prefersActiveCppOperationWhenSiblingBranchParameterNamesDiffer() {
+		String filePath = "src/buffer.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_FEATURE)",
+				"int total(int c[count]) {",
+				"  return 1;",
+				"}",
+				"#else",
+				"int total(int n[count]) {",
+				"  return 2;",
+				"}",
+				"#endif") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+		UMLClass moduleClass = findClass(model.getClassList(), "buffer");
+
+		// Parameter names differ across sibling branches and appear as substrings of other declarator
+		// tokens, but the modeled identity depends only on the parameter type.
+		assertEquals(List.of("total"), moduleClass.getOperations().stream()
+				.map(UMLOperation::getName)
+				.toList());
+		assertTrue(findOperation(moduleClass.getOperations(), "total").getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+	}
+
+	@Test
+	void normalizesOnlyTopLevelCvQualifiersInCppOperationIdentity() {
+		String filePath = "src/cv-parameters.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"void value(const int input);",
+				"void wrapped(const int (input));",
+				"void state(volatile int input);",
+				"void pointer(int* const input);",
+				"void pointee(const int* input);",
+				"#else",
+				"void value(int input);",
+				"void wrapped(int input);",
+				"void state(int input);",
+				"void pointer(int* input);",
+				"void pointee(int* input);",
+				"#endif") + "\n";
+
+		List<UMLOperation> operations = findClass(processCppModel(filePath, fileContent).getClassList(), "cv-parameters").getOperations();
+
+		assertEquals(1, operations.stream().filter(operation -> operation.getName().equals("value")).count());
+		assertEquals(1, operations.stream().filter(operation -> operation.getName().equals("wrapped")).count());
+		assertEquals(1, operations.stream().filter(operation -> operation.getName().equals("state")).count());
+		assertEquals(1, operations.stream().filter(operation -> operation.getName().equals("pointer")).count());
+		assertEquals(2, operations.stream().filter(operation -> operation.getName().equals("pointee")).count());
+	}
+
+	@Test
+	void prefersActiveCppClassOverInactiveSiblingPreprocessorBranch() {
+		String filePath = "src/config.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_FEATURE)",
+				"struct Settings {",
+				"  int cacheSize;",
+				"};",
+				"#else",
+				"struct Settings {",
+				"  long cacheSize;",
+				"};",
+				"#endif") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+
+		List<UMLClass> settingsClasses = model.getClassList().stream()
+				.filter(umlClass -> umlClass.getName().endsWith("Settings"))
+				.toList();
+		assertEquals(1, settingsClasses.size());
+		assertEquals("long", findAttribute(settingsClasses.get(0).getAttributes(), "cacheSize").getType().toString());
+	}
+
+	@Test
+	void preservesActiveCppVisibilityAcrossInactivePreprocessorAlternatives() {
+		String filePath = "src/widget.cpp";
+		String fileContent = String.join("\n",
+				"class Widget {",
+				"#if 1",
+				"public:",
+				"#else",
+				"private:",
+				"#endif",
+				"  void visible() {",
+				"  }",
+				"};") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+
+		assertEquals(Visibility.PUBLIC, findOperation(findClass(model.getClassList(), "Widget").getOperations(), "visible")
+				.getVisibility());
+	}
+
+	@Test
+	void mergesInactiveOnlyMembersIntoActiveCppSiblingClass() {
+		String filePath = "src/backend.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_PLATFORM)",
+				"struct Backend {",
+				"  int common() { return 1; }",
+				"  void windowsOnly() {}",
+				"};",
+				"#else",
+				"struct Backend {",
+				"  int common() { return 2; }",
+				"  void posixOnly() {}",
+				"};",
+				"#endif") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+		List<UMLClass> backends = model.getClassList().stream()
+				.filter(umlClass -> umlClass.getName().equals("Backend") || umlClass.getName().endsWith(".Backend"))
+				.toList();
+
+		assertEquals(1, backends.size(), model.getClassList().stream().map(UMLClass::getName).toList().toString());
+		List<String> operationNames = backends.get(0).getOperations().stream()
+				.map(UMLOperation::getName)
+				.toList();
+		assertEquals(3, operationNames.size());
+		assertEquals(1, operationNames.stream().filter("common"::equals).count());
+		assertTrue(operationNames.containsAll(List.of("common", "windowsOnly", "posixOnly")));
+		assertTrue(findOperation(backends.get(0).getOperations(), "common").getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+	}
+
+	@Test
+	void mergesCppNamespaceSiblingBranchesAtDeclarationGranularity() {
+		String filePath = "src/platform.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_PLATFORM)",
+				"namespace platform {",
+				"  int common() { return 1; }",
+				"  void inactiveOnly() {}",
+				"}",
+				"#else",
+				"namespace platform {",
+				"  int common() { return 2; }",
+				"  void activeOnly() {}",
+				"}",
+				"#endif") + "\n";
+
+		UMLClass moduleClass = findClass(processCppModel(filePath, fileContent).getClassList(), "platform");
+		List<String> operationNames = moduleClass.getOperations().stream()
+				.map(UMLOperation::getName)
+				.toList();
+
+		assertEquals(3, operationNames.size());
+		assertEquals(1, operationNames.stream().filter("common"::equals).count());
+		assertTrue(operationNames.containsAll(List.of("common", "inactiveOnly", "activeOnly")));
+		assertTrue(findOperation(moduleClass.getOperations(), "common").getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+	}
+
+	@Test
+	void doesNotReportChangesForCppSiblingCollisionSelfDiff() throws Exception {
+		String filePath = "src/platform.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_PLATFORM)",
+				"int mode() { return 1; }",
+				"struct Settings { int first; };",
+				"#else",
+				"int mode() { return 2; }",
+				"struct Settings { int second; };",
+				"#endif") + "\n";
+
+		UMLModelDiff diff = processCppModel(filePath, fileContent).diff(processCppModel(filePath, fileContent));
+
+		assertTrue(diff.getRefactorings().isEmpty());
+		assertTrue(diff.getAddedClasses().isEmpty());
+		assertTrue(diff.getRemovedClasses().isEmpty());
+		assertNotNull(diff.getUMLClassDiff("platform"));
+		assertEquals(1, diff.getUMLClassDiff("platform").getOperationBodyMapperList().stream()
+				.filter(mapper -> mapper.getOperation1().getName().equals("mode"))
+				.count());
+	}
+
+	@Test
+	void preservesCppDeclarationDefinitionPairAcrossIndependentConditionals() {
+		String filePath = "src/platform.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"int mode();",
+				"#endif",
+				"#if 1",
+				"int mode() { return 2; }",
+				"#endif") + "\n";
+
+		List<UMLOperation> modes = findClass(processCppModel(filePath, fileContent).getClassList(), "platform").getOperations().stream()
+				.filter(operation -> operation.getName().equals("mode"))
+				.toList();
+
+		assertEquals(2, modes.size());
+		assertEquals(1, modes.stream().filter(operation -> operation.getBody() == null).count());
+		assertEquals(1, modes.stream().filter(operation -> operation.getBody() != null).count());
+	}
+
+	@Test
+	void filtersCppSiblingCollisionsWithinEachClass() {
+		String filePath = "src/containers.cpp";
+		String fileContent = String.join("\n",
+				"class ActiveContainer {",
+				"#if 0",
+				"  int value() { return 1; }",
+				"#else",
+				"  int value() { return 2; }",
+				"#endif",
+				"};",
+				"class InactiveOnlyContainer {",
+				"#if 0",
+				"  int value() { return 3; }",
+				"#endif",
+				"};") + "\n";
+
+		UMLModel model = processCppModel(filePath, fileContent);
+		UMLClass activeContainer = findClass(model.getClassList(), "ActiveContainer");
+		UMLClass inactiveOnlyContainer = findClass(model.getClassList(), "InactiveOnlyContainer");
+
+		assertEquals(1, activeContainer.getOperations().stream().filter(operation -> operation.getName().equals("value")).count());
+		assertTrue(findOperation(activeContainer.getOperations(), "value").getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+		assertEquals(1, inactiveOnlyContainer.getOperations().stream().filter(operation -> operation.getName().equals("value")).count());
+	}
+
+	@Test
+	void filtersCppSiblingFieldsAtDeclaratorGranularity() {
+		String filePath = "src/fields.cpp";
+		String fileContent = String.join("\n",
+				"struct Fields {",
+				"#if 0",
+				"  int shared, inactiveOnly;",
+				"#else",
+				"  long shared;",
+				"#endif",
+				"};") + "\n";
+
+		UMLClass fields = findClass(processCppModel(filePath, fileContent).getClassList(), "Fields");
+		List<String> attributeNames = fields.getAttributes().stream()
+				.map(UMLAttribute::getName)
+				.toList();
+
+		assertEquals(2, attributeNames.size());
+		assertEquals(1, attributeNames.stream().filter("shared"::equals).count());
+		assertTrue(attributeNames.contains("inactiveOnly"));
+		assertEquals("long", findAttribute(fields.getAttributes(), "shared").getType().toString());
+	}
+
+	@Test
+	void filtersCppUsingDirectivesInSiblingBranches() {
+		String filePath = "src/imports.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"using namespace shared;",
+				"#else",
+				"using namespace shared;",
+				"#endif") + "\n";
+
+		UMLClass moduleClass = findClass(processCppModel(filePath, fileContent).getClassList(), "imports");
+
+		assertEquals(1, moduleClass.getImportedTypes().stream()
+				.filter(umlImport -> umlImport.getName().equals("shared"))
+				.count());
+	}
+
+	@Test
+	void preservesCppSiblingTemplatesWithDifferentTemplateParameters() {
+		String filePath = "src/templates.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"template <typename T>",
+				"void configure(int value) {}",
+				"#else",
+				"template <int N>",
+				"void configure(int value) {}",
+				"#endif") + "\n";
+
+		List<UMLOperation> configureOperations = findClass(processCppModel(filePath, fileContent).getClassList(), "templates").getOperations().stream()
+				.filter(operation -> operation.getName().equals("configure"))
+				.toList();
+
+		assertEquals(2, configureOperations.size());
+		assertTrue(configureOperations.stream().anyMatch(operation -> operation.getTypeParameterNames().contains("T")));
+		assertTrue(configureOperations.stream().anyMatch(operation -> operation.getTypeParameterNames().contains("N")));
+	}
+
+	@Test
+	void preservesCppSiblingFunctionTemplatesWithDifferentParameterKinds() {
+		String filePath = "src/template-kinds.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"template <typename T>",
+				"void configure(int value) {}",
+				"#else",
+				"template <int T>",
+				"void configure(int value) {}",
+				"#endif") + "\n";
+
+		long configureCount = findClass(processCppModel(filePath, fileContent).getClassList(), "template-kinds").getOperations().stream()
+				.filter(operation -> operation.getName().equals("configure"))
+				.count();
+
+		assertEquals(2, configureCount);
+	}
+
+	@Test
+	void prefersActiveCppFunctionTemplateAcrossParameterRenames() {
+		String filePath = "src/template-renames.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"template <typename _Tp>",
+				"int configure(_Tp value) { return 1; }",
+				"#else",
+				"template <typename _Up>",
+				"int configure(_Up value) { return 2; }",
+				"#endif") + "\n";
+
+		List<UMLOperation> configureOperations = findClass(processCppModel(filePath, fileContent).getClassList(), "template-renames").getOperations().stream()
+				.filter(operation -> operation.getName().equals("configure"))
+				.toList();
+
+		assertEquals(1, configureOperations.size());
+		assertTrue(configureOperations.get(0).getBody().getCompositeStatement().getLeaves().stream()
+				.anyMatch(leaf -> leaf.getString().contains("return 2")));
+	}
+
+	@Test
+	void preservesCppFunctionTemplatesWhenNamedParametersOccupyDifferentPositions() {
+		String filePath = "src/template-positions.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"template <typename T, typename>",
+				"void configure(T value) {}",
+				"#else",
+				"template <typename, typename U>",
+				"void configure(U value) {}",
+				"#endif") + "\n";
+
+		long configureCount = findClass(processCppModel(filePath, fileContent).getClassList(), "template-positions").getOperations().stream()
+				.filter(operation -> operation.getName().equals("configure"))
+				.count();
+
+		assertEquals(2, configureCount);
+	}
+
+	@Test
+	void preservesCppSiblingClassTemplatesWithDifferentTemplateParameters() {
+		String filePath = "src/template-classes.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"template <typename T>",
+				"struct Box { T inactiveOnly(); };",
+				"#else",
+				"template <int N>",
+				"struct Box { int activeOnly(); };",
+				"#endif") + "\n";
+
+		List<UMLClass> boxes = processCppModel(filePath, fileContent).getClassList().stream()
+				.filter(umlClass -> umlClass.getName().equals("Box") || umlClass.getName().endsWith(".Box"))
+				.toList();
+
+		assertEquals(2, boxes.size());
+		assertTrue(boxes.stream().anyMatch(umlClass -> umlClass.getTypeParameterNames().contains("T")));
+		assertTrue(boxes.stream().anyMatch(umlClass -> umlClass.getTypeParameterNames().contains("N")));
+	}
+
+	@Test
+	void keepsAlphaRenamedCppClassTemplatesSeparateWithoutMixingMemberTypes() {
+		String filePath = "src/renamed-template-classes.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"template <typename U>",
+				"struct Box { U inactiveValue; };",
+				"#else",
+				"template <typename T>",
+				"struct Box { T activeValue; };",
+				"#endif") + "\n";
+
+		List<UMLClass> boxes = processCppModel(filePath, fileContent).getClassList().stream()
+				.filter(umlClass -> umlClass.getName().equals("Box") || umlClass.getName().endsWith(".Box"))
+				.toList();
+
+		assertEquals(2, boxes.size());
+		assertEquals("U", findAttribute(boxes.stream()
+				.filter(umlClass -> umlClass.getTypeParameterNames().contains("U"))
+				.findFirst().orElseThrow().getAttributes(), "inactiveValue").getType().toString());
+		assertEquals("T", findAttribute(boxes.stream()
+				.filter(umlClass -> umlClass.getTypeParameterNames().contains("T"))
+				.findFirst().orElseThrow().getAttributes(), "activeValue").getType().toString());
+	}
+
+	@Test
+	void keepsVisibilityStateSeparateAcrossMergedCppClassAlternatives() {
+		String filePath = "src/access.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"struct Access {",
+				"public:",
+				"  void inactiveOnly();",
+				"};",
+				"#else",
+				"struct Access {",
+				"private:",
+				"  void activeOnly();",
+				"};",
+				"#endif") + "\n";
+
+		UMLClass access = findClass(processCppModel(filePath, fileContent).getClassList(), "Access");
+
+		assertEquals(Visibility.PRIVATE, findOperation(access.getOperations(), "activeOnly").getVisibility());
+		assertEquals(Visibility.PUBLIC, findOperation(access.getOperations(), "inactiveOnly").getVisibility());
+	}
+
+	@Test
+	void usesPrivateDefaultVisibilityForMergedCppClassAlternative() {
+		String filePath = "src/class-access.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"class Access {",
+				"  void inactiveOnly();",
+				"};",
+				"#else",
+				"class Access {",
+				"public:",
+				"  void activeOnly();",
+				"};",
+				"#endif") + "\n";
+
+		UMLClass access = findClass(processCppModel(filePath, fileContent).getClassList(), "Access");
+
+		assertEquals(Visibility.PUBLIC, findOperation(access.getOperations(), "activeOnly").getVisibility());
+		assertEquals(Visibility.PRIVATE, findOperation(access.getOperations(), "inactiveOnly").getVisibility());
+	}
+
+	@Test
+	void keepsDefaultVisibilitySpecificToEachMergedCppCompositeAlternative() {
+		String filePath = "src/mixed-composite-access.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"struct Access {",
+				"  void inactiveOnly();",
+				"};",
+				"#else",
+				"class Access {",
+				"public:",
+				"  void activeOnly();",
+				"};",
+				"#endif") + "\n";
+
+		UMLClass access = findClass(processCppModel(filePath, fileContent).getClassList(), "Access");
+
+		assertEquals(Visibility.PUBLIC, findOperation(access.getOperations(), "activeOnly").getVisibility());
+		assertEquals(Visibility.PUBLIC, findOperation(access.getOperations(), "inactiveOnly").getVisibility());
+	}
+
+	@Test
+	void preservesCppSiblingMemberFunctionsWithDifferentCvAndRefQualifiers() {
+		String filePath = "src/qualified-members.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"struct Reader {",
+				"  int value() const;",
+				"  int access() &;",
+				"};",
+				"#else",
+				"struct Reader {",
+				"  int value();",
+				"  int access() &&;",
+				"};",
+				"#endif") + "\n";
+
+		UMLClass reader = findClass(processCppModel(filePath, fileContent).getClassList(), "Reader");
+
+		assertEquals(2, reader.getOperations().stream().filter(operation -> operation.getName().equals("value")).count());
+		assertEquals(2, reader.getOperations().stream().filter(operation -> operation.getName().equals("access")).count());
+	}
+
+	@Test
+	void preservesCppSiblingDeclarationsWhenNoBranchIsActive() {
+		String filePath = "src/unselected.cpp";
+		String fileContent = String.join("\n",
+				"#if defined(UNDEFINED_A)",
+				"void mode();",
+				"#elif defined(UNDEFINED_B)",
+				"void mode();",
+				"#endif") + "\n";
+
+		long modeCount = findClass(processCppModel(filePath, fileContent).getClassList(), "unselected").getOperations().stream()
+				.filter(operation -> operation.getName().equals("mode"))
+				.count();
+
+		assertEquals(2, modeCount);
+	}
+
+	@Test
+	void prefersActiveCppOperationWhenOnlyDefaultArgumentDiffers() {
+		String filePath = "src/defaults.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"void configure(int value = 1);",
+				"#else",
+				"void configure(int value = 2);",
+				"#endif") + "\n";
+
+		List<UMLOperation> configureOperations = findClass(processCppModel(filePath, fileContent).getClassList(), "defaults").getOperations().stream()
+				.filter(operation -> operation.getName().equals("configure"))
+				.toList();
+
+		assertEquals(1, configureOperations.size());
+		assertTrue(configureOperations.get(0).getActualSignature().contains("= 2"));
+	}
+
+	@Test
+	void prefersActiveCppAliasOverInactiveSiblingBranch() {
+		String filePath = "src/conditional-alias.cpp";
+		String fileContent = String.join("\n",
+				"#if 0",
+				"using Size = int;",
+				"#else",
+				"using Size = long;",
+				"#endif") + "\n";
+
+		List<UMLTypeAlias> aliases = findClass(processCppModel(filePath, fileContent).getClassList(), "conditional-alias").getTypeAliasList().stream()
+				.filter(alias -> alias.getName().equals("Size"))
+				.toList();
+
+		assertEquals(1, aliases.size());
+		assertEquals("long", aliases.get(0).getRightType().toString());
 	}
 
 	@Test


### PR DESCRIPTION
Closes #1117.

CDT was configured to skip declarations in inactive preprocessor branches. This enables its inactive-code mode for C++ and walks those declarations at the translation-unit, namespace, linkage, and class or struct levels.

Parsing both sides of a conditional creates duplicate model elements, so the processor reconciles sibling branches before diffing. The active declaration wins when both branches describe the same operation, field, import, alias, or matching container. Declarations that exist only in inactive code stay in the model, as do declarations from independent conditionals. If no branch is active, both alternatives are kept because there is no reliable winner. That can leave identical inactive signatures ambiguous to downstream matching, but dropping one would lose a source declaration.

Matching non-template containers are merged member by member. Alpha-renamed class templates stay separate so their type parameter names are not mixed. The C parser path is unchanged.

CDT provides inactive function signatures but not statements from inactive bodies. It can also omit inactive access labels. In that case, members use the normal C++ default for their declaration: `public` in a `struct` and `private` in a `class`.

The regression suite includes a reduced version of the Catch2 case from the issue, nested containers, both sibling orders, C++ overload identity, templates, fields, imports and aliases, visibility defaults, and independent or unselected conditionals.

Tested with:

```shell
./gradlew --no-daemon test --rerun-tasks \
  --tests 'gr.uom.java.xmi.CppFileProcessorTest' \
  --tests 'gr.uom.java.xmi.LocationInfoCppTest' \
  --tests 'org.refactoringminer.astDiff.tests.CppDiffTest'
```
