### PR TITLE
Fix #1124: report TypeScript type alias as its own type declaration kind

### DIFF
--- a/src/main/java/gr/uom/java/xmi/UMLClass.java
+++ b/src/main/java/gr/uom/java/xmi/UMLClass.java
@@ -85,6 +85,8 @@ public class UMLClass extends UMLAbstractClass implements Comparable<UMLClass>, 
     		return "object";
     	else if(isStruct)
     		return "struct";
+    	else if(isTypeAlias)
+    		return "type alias";
     	else
     		return "class";
     }

--- a/src/test/java/org/refactoringminer/test/TestTypeScriptTypeDeclarationKind.java
+++ b/src/test/java/org/refactoringminer/test/TestTypeScriptTypeDeclarationKind.java
@@ -1,0 +1,83 @@
+package org.refactoringminer.test;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.refactoringminer.api.Refactoring;
+import org.refactoringminer.api.RefactoringType;
+import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
+
+import gr.uom.java.xmi.UMLModel;
+import gr.uom.java.xmi.diff.ChangeTypeDeclarationKindRefactoring;
+import gr.uom.java.xmi.diff.UMLModelDiff;
+
+/**
+ * Regression tests for issue #1124.
+ * A TypeScript type alias has its own declaration kind and must not be
+ * reported as a class.
+ */
+public class TestTypeScriptTypeDeclarationKind {
+
+	private static ChangeTypeDeclarationKindRefactoring detect(String before, String after) throws Exception {
+		String path = "src/app/account/account.types.ts";
+		Map<String, String> fileContentsBefore = new LinkedHashMap<String, String>();
+		Map<String, String> fileContentsCurrent = new LinkedHashMap<String, String>();
+		fileContentsBefore.put(path, before);
+		fileContentsCurrent.put(path, after);
+		UMLModel parentUMLModel = GitHistoryRefactoringMinerImpl.createModel(fileContentsBefore, new LinkedHashSet<String>());
+		UMLModel currentUMLModel = GitHistoryRefactoringMinerImpl.createModel(fileContentsCurrent, new LinkedHashSet<String>());
+		UMLModelDiff modelDiff = parentUMLModel.diff(currentUMLModel);
+		ChangeTypeDeclarationKindRefactoring found = null;
+		for(Refactoring ref : modelDiff.getRefactorings()) {
+			if(ref.getRefactoringType().equals(RefactoringType.CHANGE_TYPE_DECLARATION_KIND)) {
+				Assertions.assertNull(found, "more than one Change Type Declaration Kind reported");
+				found = (ChangeTypeDeclarationKindRefactoring) ref;
+			}
+		}
+		return found;
+	}
+
+	@Test
+	public void testInterfaceToTypeAliasIsNotReportedAsClass() throws Exception {
+		String before =
+				"import { User } from '@/app/admin/users/users.types';\n" +
+				"\n" +
+				"export interface Account extends User {}\n";
+		String after =
+				"import { User } from '@/app/admin/users/users.types';\n" +
+				"\n" +
+				"export type Account = User;\n";
+		ChangeTypeDeclarationKindRefactoring ref = detect(before, after);
+		Assertions.assertNotNull(ref);
+		Assertions.assertEquals("interface", ref.getOriginalTypeDeclarationKind());
+		Assertions.assertEquals("type alias", ref.getChangedTypeDeclarationKind());
+		// toString() separates the refactoring name from its arguments with a tab
+		Assertions.assertEquals(
+				"Change Type Declaration Kind\tinterface to type alias in type account.types.Account",
+				ref.toString());
+	}
+
+	@Test
+	public void testTypeAliasToInterface() throws Exception {
+		String before =
+				"export type Account = { id: string; name: string };\n";
+		String after =
+				"export interface Account { id: string; name: string }\n";
+		ChangeTypeDeclarationKindRefactoring ref = detect(before, after);
+		Assertions.assertNotNull(ref);
+		Assertions.assertEquals("type alias", ref.getOriginalTypeDeclarationKind());
+		Assertions.assertEquals("interface", ref.getChangedTypeDeclarationKind());
+	}
+
+	@Test
+	public void testTypeAliasToTypeAliasIsNotReported() throws Exception {
+		String before =
+				"export type Account = { id: string };\n";
+		String after =
+				"export type Account = { id: string; name: string };\n";
+		Assertions.assertNull(detect(before, after));
+	}
+}


### PR DESCRIPTION
Fixes #1124.

## Problem

In TypeScript, converting an `interface` to a **type alias** was reported as
`Change Type Declaration Kind interface to class`. No class is involved — the
target is a type alias, and the reproduction project (`BearStudio/start-ui-web`,
a React codebase using function components) contains essentially no classes.

Reproduction commit `e94236ec73141a036b1ada0c77a8d892a6a61313`,
`src/app/account/account.types.ts`:

```ts
// before
export interface Account extends User {}
// after
export type Account = User;
```

## Root cause

`UMLClass.getTypeDeclarationKind()` never consulted the `isTypeAlias` flag, so
type aliases fell through the if-chain to the `"class"` fallback.

The model already carried the information. `UMLClass` has an `isTypeAlias`
field, and `TypeScriptOperationBody` sets it in the `Swc4jAstTsTypeAliasDecl`
branch, exactly as it calls `setInterface(true)` for `Swc4jAstTsInterfaceDecl`.
Only the getter was missing the case.

`UMLAbstractClassDiff.getRefactorings()` then compares the two kind strings and
emits `ChangeTypeDeclarationKindRefactoring` when they differ, producing
`interface` vs. fallthrough-`class`.

## Fix

```java
else if(isTypeAlias)
    return "type alias";
```

`RefactoringType.CHANGE_TYPE_DECLARATION_KIND` uses the regex
`Change Type Declaration Kind (.+) to (.+) in type (.+)`, so a two-word kind
parses fine.

## Verification

CLI on the reproduction commit, before and after the fix:

| | total refactorings | Change Type Declaration Kind |
|---|---|---|
| before | 75 | 49 × `interface to class` |
| after  | 75 | 49 × `interface to type alias` |

Pure relabelling — no change in detection counts.

## Tests

`TestTypeScriptTypeDeclarationKind` covers three cases via in-memory models:

1. `interface` → `type alias` — kinds and description string
2. `type alias` → `interface` — the reverse direction
3. `type alias` → `type alias` differing only in members — no refactoring reported

No regressions in `TestJavaScriptDatasetRefactorings` or
`TestKotlinDatasetRefactorings`. The 62 oracle entries mentioning this
refactoring type are all Java or Kotlin, and `ChangeTypeDeclarationKind` is not
in the type mask of `TestJavaScriptDatasetRefactorings`, so no oracle
expectations shift.

## Correction to the issue

The issue reports **160** instances in that commit, measured with 3.1.4. The
number 160 is real, but it is a **whole-history total on a current-master
build**, not a per-commit count and not 3.1.4. I am correcting the issue.
Measured directly on `BearStudio/start-ui-web`:

| run | total refactorings | Change Type Declaration Kind | commits carrying it |
|---|---|---|---|
| 3.1.4, `-c` on `e94236ec`  | 3     | 3 (all `interface to class`) | 1 |
| master, `-c` on `e94236ec` | 75    | 49 | 1 |
| 3.1.4, `-a` full history   | 1,225 | 112 | 29 |
| master, `-a` full history  | 2,335 | **160** | **31** |

The master whole-history breakdown: 107 `object to interface`, 49
`interface to type alias` (all in `e94236ec`), 2 `object to class`, 1
`class to object`, 1 `object to type alias`.

So two claims in the issue need correcting: the per-commit scale is **49, not
160**, and "every single instance comes from this one commit" is wrong — 31
commits carry this refactoring type, and the plurality transition
(`object to interface`, 107) is unrelated to this bug. 3.1.4 also detects only 3
of the 5 examples listed in the issue; `AuthContext.AuthContextValue` and
`index.PageTopBarProps` do not appear in its output at all, which is what
identifies the reported numbers as master-era rather than 3.1.4.

The bug itself is unaffected by any of this, and the fix stands.

## Known behaviour changes beyond relabelling

Two consequences worth reviewer attention, neither triggered on the
reproduction commit:

1. **Enum matching.** `UMLClassDiff` (lines 22 and 49) branches when one side is
   `"enum"`. TypeScript models enums (`Swc4jAstTsEnumDecl` → `setEnum(true)`), so
   `enum → type alias` previously read as `enum → class` and triggered an
   enum-constant matching heuristic. It no longer does. This looks correct — a
   type alias has no enum constants — but it is a real change.

2. **Anonymous class suppression.** `UMLAbstractClassDiff:1248` suppresses
   anonymous-class noise by string suffix:
   `originalClass.getTypeDeclarationKind().endsWith("class") && nextClass...endsWith("class")`.
   Both `"anonymous class"` and `"class"` match that guard; `"type alias"` does
   not. An anonymous class paired against a TS type alias was previously
   suppressed and now falls through. I did not observe this on the reproduction
   commit and have no commit that triggers it, so I have not added a test or
   widened the guard. Happy to do either if you would prefer.
