### PR TITLE
feat: add semantic context for ellipsis and slice

### DIFF
--- a/src/main/java/org/refactoringminer/astDiff/graph/Context.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/Context.java
@@ -143,6 +143,12 @@ public class Context {
     if (treeType.equals(constants.ASSERT_STATEMENT)) {
       return List.of(constants.BLOCK, constants.METHOD_DECLARATION);
     }
+    if (treeType.equals(constants.ELLIPSIS)) {
+      return List.of(constants.SUBSCRIPT);
+    }
+    if (treeType.equals("slice")) {
+      return List.of(constants.SUBSCRIPT);
+    }
     return null;
   }
 

--- a/src/main/java/org/refactoringminer/astDiff/graph/Context.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/Context.java
@@ -143,7 +143,7 @@ public class Context {
     if (treeType.equals(constants.ASSERT_STATEMENT)) {
       return List.of(constants.BLOCK, constants.METHOD_DECLARATION);
     }
-    if (treeType.equals(constants.ELLIPSIS)) {
+    if (treeType.equals("ellipsis")) {
       return List.of(constants.SUBSCRIPT);
     }
     if (treeType.equals("slice")) {

--- a/src/main/java/org/refactoringminer/astDiff/utils/Constants.java
+++ b/src/main/java/org/refactoringminer/astDiff/utils/Constants.java
@@ -606,7 +606,7 @@ public class Constants {
     public final String FIELD_EXPRESSION = "field_expression";
     public final String SUBSCRIPT_EXPRESSION = "subscript_expression";
     public final String ENUMERATOR = "enumerator";
-    public final String ELLIPSIS = "...";
+    public final String ELLIPSIS = "ellipsis";
     public final String STORAGE_CLASS_SPECIFIER = "storage_class_specifier";
     public final String DEFAULT_METHOD_CLAUSE = "default_method_clause";
     public final String DELETE_METHOD_CLAUSE = "delete_method_clause";

--- a/src/main/java/org/refactoringminer/astDiff/utils/Constants.java
+++ b/src/main/java/org/refactoringminer/astDiff/utils/Constants.java
@@ -606,7 +606,7 @@ public class Constants {
     public final String FIELD_EXPRESSION = "field_expression";
     public final String SUBSCRIPT_EXPRESSION = "subscript_expression";
     public final String ENUMERATOR = "enumerator";
-    public final String ELLIPSIS = "ellipsis";
+    public final String ELLIPSIS = "...";
     public final String STORAGE_CLASS_SPECIFIER = "storage_class_specifier";
     public final String DEFAULT_METHOD_CLAUSE = "default_method_clause";
     public final String DELETE_METHOD_CLAUSE = "delete_method_clause";


### PR DESCRIPTION
This PR adds the semantic context found useful for `ellipsis` and `slice` tree types in [this commit](https://github.com/dit/dit/commit/55f6f1ab292abe7a10a93982fa6df48f8d4c4854). The effect of adding this context is to put together these two changes that are contextually relevant:
<img width="839" height="536" alt="image" src="https://github.com/user-attachments/assets/a1161bbc-9da8-448c-842e-828b6415ae92" />
