### PR TITLE
fix: bypass UMLOperation equals in parameters mapping

### DIFF
--- a/src/main/java/org/refactoringminer/astDiff/graph/UMLs.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/UMLs.java
@@ -10,7 +10,7 @@ public class UMLs {
     public Set<UMLOperation> umlOperations = new HashSet<>();
     public Set<UMLAttribute> umlAttributes = new HashSet<>();
     public Set<VariableDeclaration> variableDeclarations = new HashSet<>();
-    public Map<UMLOperation, Set<VariableDeclaration>> operationParameters = new HashMap<>();
+    public Map<UMLOperation, Set<VariableDeclaration>> operationParameters = new IdentityHashMap<>();
 
     UMLs() {}
   }


### PR DESCRIPTION
As UMLOperation has overridden equals, it leads to some collisions in parameters mapping. This PR bypasses the equals to map parameters to their own UMLOperation.