### PR TITLE
feat: intelligently track inter-chapter dependencies

### DIFF
--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/NarrativeElement.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/NarrativeElement.java
@@ -1,21 +1,70 @@
 package org.refactoringminer.astDiff.graph.cluster.traverse;
 
+import org.jgrapht.Graph;
+import org.refactoringminer.astDiff.graph.Edge;
+import org.refactoringminer.astDiff.graph.EdgeType;
 import org.refactoringminer.astDiff.graph.Node;
 
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
-public record NarrativeElement(
-    String content,
-    ElementType type,
-    Set<Node> mains,
-    Set<Node> sides
-) {
+public class NarrativeElement {
+    private final String content;
+    private final Set<Node> mains;
+    private final Set<Node> sides;
+
+    NarrativeElement(String content, Set<Node> mains, Graph<Node, Edge> clusterGraph) {
+        this.content = content;
+        this.mains = mains;
+        this.sides = getSides(mains, clusterGraph);
+    }
+
     public int lineCount() {
         return content.split("\n").length;
-    };
+    }
 
-    public enum ElementType {
-        DEPENDENCY,   // Global context/dependencies
-        SUB_CHAPTER   // Actual content block
+    public String getContent() {
+        return content;
+    }
+
+    public Set<Node> getMains() {
+        return mains;
+    }
+
+    public Set<Node> getSides() {
+        return sides;
+    }
+
+    private static Set<Node> getSides(Set<Node> mains, Graph<Node, Edge> clusterGraph) {
+        Set<Node> sides = new HashSet<>();
+
+        List<Node> usedNodes = mains.stream()
+                .map(main -> clusterGraph.incomingEdgesOf(main).stream()
+                        .filter(edge -> edge.getType().equals(EdgeType.DEF_USE)).toList())
+                .flatMap(List::stream)
+                .map(clusterGraph::getEdgeSource).toList();
+        Set<Node> trackingNodes = new HashSet<>(usedNodes);
+        while (true) {
+            trackingNodes.addAll(trackingNodes.stream()
+                    .map(trackingNode -> trackingNode.getMappingSources(clusterGraph))
+                    .flatMap(List::stream).toList());
+            trackingNodes.addAll(trackingNodes.stream()
+                    .map(trackingNode -> trackingNode.getMappingTargets(clusterGraph))
+                    .flatMap(List::stream).toList());
+
+            sides.addAll(trackingNodes.stream().filter(trackingNode -> !trackingNode.isContext()).toList());
+
+            trackingNodes = trackingNodes.stream().filter(Node::isContext).collect(Collectors.toSet());
+            if (trackingNodes.isEmpty()) {
+                break;
+            }
+
+            trackingNodes = trackingNodes.stream()
+                    .map(trackingNode -> clusterGraph.incomingEdgesOf(trackingNode).stream()
+                            .filter(edge -> edge.getType().equals(EdgeType.CONTEXT)).toList())
+                    .flatMap(List::stream).map(clusterGraph::getEdgeSource).collect(Collectors.toSet());
+        }
+
+        return sides;
     }
 }

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/Narrator.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/Narrator.java
@@ -229,9 +229,9 @@ public class Narrator {
                     for (List<NarrativeElement> split : splits) {
                         ChapterUnit chu = new ChapterUnit();
                         for (NarrativeElement ne : split) {
-                            chu.append(ne.content());
-                            chu.addMains(ne.mains());
-                            chu.addSides(ne.sides());
+                            chu.append(ne.getContent());
+                            chu.addMains(ne.getMains());
+                            chu.addSides(ne.getSides());
                         }
 
                         units.add(chu);
@@ -239,9 +239,9 @@ public class Narrator {
                 } else {
                     ChapterUnit chu = new ChapterUnit();
                     for (NarrativeElement ne : elements) {
-                        chu.append(ne.content());
-                        chu.addMains(ne.mains());
-                        chu.addSides(ne.sides());
+                        chu.append(ne.getContent());
+                        chu.addMains(ne.getMains());
+                        chu.addSides(ne.getSides());
                     }
 
                     units.add(chu);
@@ -481,5 +481,4 @@ public class Narrator {
             return getContent().split("\n").length;
         }
     }
-
 }

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/TraversalPattern.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/TraversalPattern.java
@@ -10,7 +10,6 @@ import org.refactoringminer.astDiff.graph.cluster.GraphWrapper;
 import org.jgrapht.Graph;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class TraversalPattern extends GraphWrapper {
     protected Graph<Node, Edge> clusterGraph;
@@ -21,10 +20,6 @@ public class TraversalPattern extends GraphWrapper {
     protected Node cachedLead = null;
     protected NodeType nodeType;
     private List<TraversalPattern> cachedFlatten = null;
-
-    public Graph<Node, Edge> getClusterGraph() {
-        return clusterGraph;
-    }
 
     public void setClusterGraph(Graph<Node, Edge> clusterGraph) {
         this.clusterGraph = clusterGraph;
@@ -90,17 +85,16 @@ public class TraversalPattern extends GraphWrapper {
         return narrator;
     }
 
-     public String extended(List<TraversalPattern> filterPatterns) {
-        return String.join("\n", getElements(filterPatterns).stream().map(NarrativeElement::content).toList());
+    public String extended(List<TraversalPattern> filterPatterns) {
+        return String.join("\n", getElements(filterPatterns).stream().map(NarrativeElement::getContent).toList());
     }
 
     public List<NarrativeElement> getElements(List<TraversalPattern> filterPatterns) {
         List<Node> aggMains = getMains();
 
-        // Merge Mains by Mapping
         List<MappingGroup> mappingGroups = aggregateByMapping(aggMains);
 
-        // Get Group Contexts
+        // Merge Groups by Context
         Map<MappingGroup, Set<Node>> mappingGroupContexts = new HashMap<>();
         for (MappingGroup mg : mappingGroups) {
             Set<Node> contexts = new HashSet<>();
@@ -122,8 +116,6 @@ public class TraversalPattern extends GraphWrapper {
             }
             mappingGroupContexts.put(mg, filterLargest(contexts));
         }
-
-        // Merge Groups by Context
         List<MergedGroup> mergedGroups = new ArrayList<>();
         for (Map.Entry<MappingGroup, Set<Node>> entry : mappingGroupContexts.entrySet()) {
             MappingGroup mg = entry.getKey();
@@ -148,7 +140,6 @@ public class TraversalPattern extends GraphWrapper {
 
         List<TraversalPattern> leaves = this.getNarrator().getNarrative(GrainLevel.LEAF);
 
-        // Side to Mains Mappings
         Set<Node> allMains = new HashSet<>(aggMains);
         if (filterPatterns != null) {
             for (TraversalPattern fp : filterPatterns) {
@@ -173,13 +164,10 @@ public class TraversalPattern extends GraphWrapper {
             }
         }
 
-        // Main to Group Mappings (Each Main Maps to Only 1 Group)
         Map<Node, MergedGroup> mainToGroup = new HashMap<>();
         for (MergedGroup mg : mergedGroups) {
             for (Node n : mg.nodes()) mainToGroup.put(n, mg);
         }
-
-        // Identify Group Dependencies
         Set<Node> globalSides = new HashSet<>();
         Map<MergedGroup, List<Node>> localSidesMap = new HashMap<>();
         for (Map.Entry<Node, Set<Node>> entry : sideToMains.entrySet()) {
@@ -203,22 +191,16 @@ public class TraversalPattern extends GraphWrapper {
         Map<MergedGroup, Integer> groupLatestIndex = new HashMap<>();
         for (MergedGroup mg : mergedGroups) {
             int maxIdx = -1;
-            for (MappingGroup group : mg.groups) {
-                for (Node n : group.sources()) {
-                    for (int i = leaves.size() - 1; i >= 0; i--) {
-                        if (leaves.get(i).getMains().contains(n)) {
-                            maxIdx = Math.max(maxIdx, i);
-                        }
-                    }
-                }
-                for (Node n : group.targets()) {
-                    for (int i = leaves.size() - 1; i >= 0; i--) {
-                        if (leaves.get(i).getMains().contains(n)) {
-                            maxIdx = Math.max(maxIdx, i);
-                        }
+
+            for (Node n : mg.nodes()) {
+                for (int i = leaves.size() - 1; i >= 0; i--) {
+                    if (leaves.get(i).getMains().contains(n)) {
+                        maxIdx = Math.max(maxIdx, i);
+                        break;
                     }
                 }
             }
+
             groupLatestIndex.put(mg, maxIdx);
         }
 
@@ -231,7 +213,7 @@ public class TraversalPattern extends GraphWrapper {
             for (Node s : leaf.getSides()) {
                 if (globalSides.contains(s) && !outputtedSides.contains(s)) {
                     String content = "<dependency>\n    " + s.baseXml(clusterGraph).replace("\n", "\n    ") + "\n</dependency>";
-                    elements.add(new NarrativeElement(content, NarrativeElement.ElementType.DEPENDENCY, Set.of(s), new HashSet<>()));
+                    elements.add(new NarrativeElement(content, Set.of(s), clusterGraph));
                     outputtedSides.add(s);
                 }
             }
@@ -239,10 +221,7 @@ public class TraversalPattern extends GraphWrapper {
                 if (groupLatestIndex.get(mg) == i && !outputtedGroups.contains(mg)) {
                     String content = buildSubChapterXml(mg, leaves, localSidesMap);
                     Set<Node> mgMains = mg.nodes();
-                    Set<Node> mgSides = sideToMains.entrySet().stream()
-                            .filter(entry -> mgMains.stream().anyMatch(mgMain -> entry.getValue().contains(mgMain)))
-                            .map(Map.Entry::getKey).collect(Collectors.toSet());
-                    elements.add(new NarrativeElement(content, NarrativeElement.ElementType.SUB_CHAPTER, mgMains, mgSides));
+                    elements.add(new NarrativeElement(content, mgMains, clusterGraph));
                     outputtedGroups.add(mg);
                 }
             }
@@ -470,7 +449,7 @@ public class TraversalPattern extends GraphWrapper {
             this.context = context;
         }
 
-        public  Set<Node> nodes() {
+        public Set<Node> nodes() {
             Set<Node> result = new HashSet<>();
             for (MappingGroup group : groups) {
                 result.addAll(group.nodes());


### PR DESCRIPTION
When we are reviewing a chapter, instead of providing the understanding of all the previous chapters, we want to provide only the dependency chapters (chapters including at least one dependency of the current chapter). This PR tracks the relations between chapters, no matter how we split them.