### PR TITLE
Issue #1169 Fix

### DIFF
--- a/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
@@ -338,7 +338,7 @@ public class CppFileProcessor {
 	private String[] getIncludePaths(String filePath) {
 		Set<String> includePaths = new LinkedHashSet<>();
 		includePaths.add(".");
-		//includePaths.add(System.getProperty("user.dir") + "/include");
+		includePaths.add(System.getProperty("user.dir") + "/include");
 		/*
 		if(this.fileContent.contains("#include \"gtest/")) {
 			includePaths.add(System.getProperty("user.dir") + "/include/gtest");

--- a/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
@@ -337,7 +337,7 @@ public class CppFileProcessor {
 	private String[] getIncludePaths(String filePath) {
 		Set<String> includePaths = new LinkedHashSet<>();
 		includePaths.add(".");
-		//includePaths.add(System.getProperty("user.dir") + "/include");
+		includePaths.add(System.getProperty("user.dir") + "/include");
 		/*
 		if(this.fileContent.contains("#include \"gtest/")) {
 			includePaths.add(System.getProperty("user.dir") + "/include/gtest");

--- a/src/main/java/gr/uom/java/xmi/LocationInfo.java
+++ b/src/main/java/gr/uom/java/xmi/LocationInfo.java
@@ -237,8 +237,8 @@ public class LocationInfo {
 	}
 
 	private boolean initFromMacroNodeLocations(String fileContent, IASTNodeLocation[] locations) {
-		IASTFileLocation startLocation = null;
-		IASTFileLocation endLocation = null;
+		IASTFileLocation earliestFileLocation = null;
+		IASTFileLocation latestFileLocation = null;
 		boolean hasMacroLocation = false;
 		int startOffset = Integer.MAX_VALUE;
 		int endOffset = Integer.MIN_VALUE;
@@ -250,17 +250,17 @@ public class LocationInfo {
 				int locationEnd = locationStart + fileLocation.getNodeLength();
 				if(locationStart < startOffset) {
 					startOffset = locationStart;
-					startLocation = fileLocation;
+					earliestFileLocation = fileLocation;
 				}
 				if(locationEnd > endOffset) {
 					endOffset = locationEnd;
-					endLocation = fileLocation;
+					latestFileLocation = fileLocation;
 				}
 			}
 		}
-		if(hasMacroLocation && startLocation != null && endLocation != null && endOffset >= startOffset) {
+		if(hasMacroLocation && earliestFileLocation != null && latestFileLocation != null && endOffset >= startOffset) {
 			init(fileContent, startOffset, endOffset - startOffset,
-					startLocation.getStartingLineNumber(), endLocation.getEndingLineNumber());
+					earliestFileLocation.getStartingLineNumber(), latestFileLocation.getEndingLineNumber());
 			return true;
 		}
 		return false;

--- a/src/main/java/gr/uom/java/xmi/LocationInfo.java
+++ b/src/main/java/gr/uom/java/xmi/LocationInfo.java
@@ -226,33 +226,55 @@ public class LocationInfo {
 		this.filePath = filePath;
 		this.codeElementType = codeElementType;
 		IASTNodeLocation[] locations = node.getNodeLocations();
-		if (locations.length == 1 && locations[0] instanceof IASTMacroExpansionLocation) {
-			IASTMacroExpansionLocation macroLoc = (IASTMacroExpansionLocation) locations[0];
-			//macroLoc.asFileLocation()
-			//macroLoc.getExpansion().getFileLocation()
-			//macroLoc.getExpansion().getMacroReference().getFileLocation()
-			//macroLoc.getExpansion().getMacroDefinition().getName().getImageLocation()
-			init(fileContent, macroLoc.asFileLocation());
+		if(initFromMacroNodeLocations(fileContent, locations)) {
+			return;
 		}
-		else {
-			init(fileContent, node.getFileLocation());
+		IASTFileLocation fileLocation = node.getFileLocation();
+		if(fileLocation != null) {
+			init(fileContent, fileLocation.getNodeOffset(), fileLocation.getNodeLength(),
+					fileLocation.getStartingLineNumber(), fileLocation.getEndingLineNumber());
 		}
 	}
 
-	private void init(String fileContent, IASTFileLocation fileLocation) {
-		if(fileLocation != null) {
-			// Stores where node starts
-			this.startOffset = fileLocation.getNodeOffset();
-			// Stores characters belonging to node.
-			this.length = fileLocation.getNodeLength();
-			this.endOffset = startOffset + length;
-			this.startLine = fileLocation.getStartingLineNumber();
-			this.endLine = fileLocation.getEndingLineNumber();
-			// Columns are derived from the original file content so CodeRange remains UI-friendly.
-			this.startColumn = computeColumn(fileContent, startOffset);
-			this.endColumn = computeColumn(fileContent, Math.max(startOffset, endOffset - 1));
-			this.compilationUnitLength = computeCompilationUnitLength(fileContent);
+	private boolean initFromMacroNodeLocations(String fileContent, IASTNodeLocation[] locations) {
+		IASTFileLocation startLocation = null;
+		IASTFileLocation endLocation = null;
+		boolean hasMacroLocation = false;
+		int startOffset = Integer.MAX_VALUE;
+		int endOffset = Integer.MIN_VALUE;
+		for(IASTNodeLocation location : locations) {
+			hasMacroLocation |= location instanceof IASTMacroExpansionLocation;
+			IASTFileLocation fileLocation = location.asFileLocation();
+			if(fileLocation != null) {
+				int locationStart = fileLocation.getNodeOffset();
+				int locationEnd = locationStart + fileLocation.getNodeLength();
+				if(locationStart < startOffset) {
+					startOffset = locationStart;
+					startLocation = fileLocation;
+				}
+				if(locationEnd > endOffset) {
+					endOffset = locationEnd;
+					endLocation = fileLocation;
+				}
+			}
 		}
+		if(hasMacroLocation && startLocation != null && endLocation != null && endOffset >= startOffset) {
+			init(fileContent, startOffset, endOffset - startOffset,
+					startLocation.getStartingLineNumber(), endLocation.getEndingLineNumber());
+			return true;
+		}
+		return false;
+	}
+
+	private void init(String fileContent, int startOffset, int length, int startLine, int endLine) {
+		this.startOffset = startOffset;
+		this.length = length;
+		this.endOffset = startOffset + length;
+		this.startLine = startLine;
+		this.endLine = endLine;
+		this.startColumn = computeColumn(fileContent, startOffset);
+		this.endColumn = computeColumn(fileContent, Math.max(startOffset, endOffset - 1));
+		this.compilationUnitLength = computeCompilationUnitLength(fileContent);
 	}
 
 	private int computeColumn(String fileContent, int offset) {

--- a/src/main/java/org/refactoringminer/astDiff/actions/classifier/ExtendedOnlyRootsClassifier.java
+++ b/src/main/java/org/refactoringminer/astDiff/actions/classifier/ExtendedOnlyRootsClassifier.java
@@ -2,7 +2,6 @@ package org.refactoringminer.astDiff.actions.classifier;
 
 import com.github.gumtreediff.actions.model.*;
 import com.github.gumtreediff.tree.Tree;
-import org.refactoringminer.astDiff.actions.classifier.ExtendedAbstractITreeClassifier;
 import org.refactoringminer.astDiff.actions.model.MoveIn;
 import org.refactoringminer.astDiff.actions.model.MoveOut;
 import org.refactoringminer.astDiff.actions.model.MultiMove;
@@ -61,9 +60,9 @@ public class ExtendedOnlyRootsClassifier extends ExtendedAbstractITreeClassifier
             else if (a instanceof MultiMove)
             {
                 srcMmTrees.computeIfAbsent(a.getNode(), k -> new ArrayList<>()).add(a);
-                for (Tree tree : astDiff.getAllMappings().getDsts(a.getNode())) {
-                    dstMmTrees.computeIfAbsent(tree, k -> new ArrayList<>()).add(a);
-                }
+                Tree dstTree = ((MultiMove) a).getParent();
+                if (dstTree != null)
+                    dstMmTrees.computeIfAbsent(dstTree, k -> new ArrayList<>()).add(a);
             }
             else if (a instanceof MoveIn)
             {

--- a/src/main/java/org/refactoringminer/astDiff/actions/editscript/MultiMoveActionGenerator.java
+++ b/src/main/java/org/refactoringminer/astDiff/actions/editscript/MultiMoveActionGenerator.java
@@ -34,29 +34,80 @@ public class MultiMoveActionGenerator implements ExtendedEditScriptGenerator {
 	}
 
 	public void addMapping(Set<Tree> srcTrees, Set<Tree> dstTrees) {
+		if (isOrderPreservingEquivalentGroup(srcTrees, dstTrees))
+			return;
 		for (Tree srcTree : srcTrees) {
-			if (srcTree == null)
-				continue;
 			for (Tree dstTree : dstTrees) {
-				if (dstTree == null)
+				if (!shouldAddMultiMove(srcTree, dstTree, srcTrees, dstTrees))
 					continue;
-				boolean updated = false;
-				if (srcTree.isLeaf() && dstTree.isLeaf())
-					updated = (srcTree.getMetrics().hash != dstTree.getMetrics().hash);
-				MultiMove action = new MultiMove(srcTree, dstTree, -1, counter + 1, updated);
+				MultiMove action = new MultiMove(srcTree, dstTree, -1, counter + 1, false);
 				if (!actions.contains(action)) {
 					actions.add(action);
-					if (!actionMapSrc.containsKey(srcTree))
-						actionMapSrc.put(srcTree, new ArrayList<>());
-					if (!actionMapDst.containsKey(dstTree))
-						actionMapDst.put(dstTree, new ArrayList<>());
-
-					actionMapSrc.get(srcTree).add(action);
-					actionMapDst.get(dstTree).add(action);
+					actionMapSrc.computeIfAbsent(srcTree, key -> new ArrayList<>()).add(action);
+					actionMapDst.computeIfAbsent(dstTree, key -> new ArrayList<>()).add(action);
 				}
 			}
 		}
 		counter += 1;
+	}
+
+	private boolean shouldAddMultiMove(Tree srcTree, Tree dstTree, Set<Tree> srcTrees, Set<Tree> dstTrees) {
+		return srcTree != null
+				&& dstTree != null
+				&& srcTree.getMetrics().hash == dstTree.getMetrics().hash
+				&& isComparableMultiMove(srcTree, dstTree)
+				&& !hasMatchingAlternative(srcTree, dstTrees, dstTree)
+				&& !hasMatchingAlternative(dstTree, srcTrees, srcTree);
+	}
+
+	private boolean isOrderPreservingEquivalentGroup(Set<Tree> srcTrees, Set<Tree> dstTrees) {
+		if (srcTrees.size() != dstTrees.size() || srcTrees.isEmpty())
+			return false;
+		List<Tree> sortedSrcTrees = sortedByPosition(srcTrees);
+		List<Tree> sortedDstTrees = sortedByPosition(dstTrees);
+		for (int i = 0; i < sortedSrcTrees.size(); i++) {
+			Tree srcTree = sortedSrcTrees.get(i);
+			Tree dstTree = sortedDstTrees.get(i);
+			if (srcTree == null || dstTree == null)
+				return false;
+			if (!sameType(srcTree, dstTree) || srcTree.getMetrics().hash != dstTree.getMetrics().hash)
+				return false;
+		}
+		return true;
+	}
+
+	private List<Tree> sortedByPosition(Set<Tree> trees) {
+		List<Tree> sortedTrees = new ArrayList<>(trees);
+		sortedTrees.sort(Comparator.comparingInt(Tree::getPos).thenComparingInt(Tree::getEndPos));
+		return sortedTrees;
+	}
+
+	private boolean isComparableMultiMove(Tree srcTree, Tree dstTree) {
+		if (!sameType(srcTree, dstTree) || !sameParentType(srcTree, dstTree))
+			return false;
+		if (srcTree.isLeaf() || dstTree.isLeaf())
+			return Objects.equals(srcTree.getLabel(), dstTree.getLabel());
+		return true;
+	}
+
+	private boolean hasMatchingAlternative(Tree tree, Set<Tree> candidates, Tree excludedCandidate) {
+		for (Tree candidate : candidates) {
+			if (candidate == excludedCandidate)
+				continue;
+			if (sameType(tree, candidate) && tree.getMetrics().hash == candidate.getMetrics().hash)
+				return true;
+		}
+		return false;
+	}
+
+	private boolean sameParentType(Tree srcTree, Tree dstTree) {
+		Tree srcParent = srcTree.getParent();
+		Tree dstParent = dstTree.getParent();
+		return srcParent != null && dstParent != null && sameType(srcParent, dstParent);
+	}
+
+	private boolean sameType(Tree srcTree, Tree dstTree) {
+		return Objects.equals(srcTree.getType(), dstTree.getType());
 	}
 
 	protected static EditScript toEditScript(List<Action> actions) {

--- a/src/test/java/gr/uom/java/xmi/LocationInfoCppTest.java
+++ b/src/test/java/gr/uom/java/xmi/LocationInfoCppTest.java
@@ -2,12 +2,15 @@ package gr.uom.java.xmi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
 import org.eclipse.cdt.core.dom.ast.ASTVisitor;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
+import org.eclipse.cdt.core.dom.ast.IASTMacroExpansionLocation;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
+import org.eclipse.cdt.core.dom.ast.IASTNodeLocation;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.model.ILanguage;
 import org.eclipse.cdt.core.dom.ast.gnu.cpp.GPPLanguage;
@@ -111,6 +114,40 @@ class LocationInfoCppTest {
 		assertEquals(0, location.getEndColumn());
 		assertEquals(0, location.getCompilationUnitLength());
 	}
+	@Test
+	void mapsMixedMacroExpansionLocationsToOriginalCppSourceSpan() throws Exception {
+		String source = String.join("\n",
+				"#define TEST(suite, name) void suite##_##name()",
+				"",
+				"TEST(DynamicUpdateSliceOpTest, SimpleTestF32InPlaceInput) {",
+				"  int value = 1;",
+				"}") + "\n";
+		IASTNode function = findDeclaration(source, String.join("\n",
+				"TEST(DynamicUpdateSliceOpTest, SimpleTestF32InPlaceInput) {",
+				"  int value = 1;",
+				"}"));
+
+		boolean hasMacroExpansionLocation = false;
+		for(IASTNodeLocation nodeLocation : function.getNodeLocations()) {
+			if(nodeLocation instanceof IASTMacroExpansionLocation) {
+				hasMacroExpansionLocation = true;
+			}
+		}
+
+		LocationInfo location = new LocationInfo(SRC_FOLDER, FILE_PATH, function,
+				LocationInfo.CodeElementType.METHOD_DECLARATION, source);
+
+		int startOffset = source.indexOf("TEST(DynamicUpdateSliceOpTest, SimpleTestF32InPlaceInput)");
+		int endOffset = source.indexOf("}", startOffset) + 1;
+		assertTrue(function.getNodeLocations().length > 1);
+		assertTrue(hasMacroExpansionLocation);
+		assertEquals(startOffset, location.getStartOffset());
+		assertEquals(endOffset, location.getEndOffset());
+		assertEquals(3, location.getStartLine());
+		assertEquals(5, location.getEndLine());
+		assertEquals(1, location.getStartColumn());
+		assertEquals(1, location.getEndColumn());
+	}
 
 	//Search parsed C++ AST for specific declaration and return its node
 	private static IASTNode findDeclaration(String source, String rawSignature) throws CoreException {
@@ -124,7 +161,6 @@ class LocationInfoCppTest {
 		assertNotNull(visitor.getMatch(), "Could not find C++ declaration: " + rawSignature);
 		return visitor.getMatch();
 	}
-	
 	private static class MyVisitor extends ASTVisitor {
 		private IASTNode match;
 		private String rawSignature;

--- a/src/test/java/org/refactoringminer/astDiff/tests/CppDiffTest.java
+++ b/src/test/java/org/refactoringminer/astDiff/tests/CppDiffTest.java
@@ -1,6 +1,7 @@
 package org.refactoringminer.astDiff.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.refactoringminer.astDiff.utils.ExportUtils.getFileNameFromSrcDiff;
 import static org.refactoringminer.astDiff.utils.ExportUtils.getFinalFilePath;
@@ -11,16 +12,23 @@ import static org.refactoringminer.astDiff.utils.UtilMethods.getProjectDiffLocal
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import com.github.gumtreediff.actions.TreeClassifier;
+import com.github.gumtreediff.tree.Tree;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.refactoringminer.astDiff.actions.classifier.ExtendedTreeClassifier;
 import org.refactoringminer.astDiff.models.ASTDiff;
 import org.refactoringminer.astDiff.utils.CaseInfo;
 import org.refactoringminer.astDiff.utils.MappingExportModel;
@@ -34,6 +42,126 @@ import net.joshka.junit.json.params.JsonFileSource;
 public class CppDiffTest {
 	public static final String REPOS = System.getProperty("user.dir") + "/src/test/resources/oracle/commits/cpp";
 	public static final String MAPPING_PATH = System.getProperty("user.dir") + "/src/test/resources/astDiff/cpp";
+
+	@Test
+	void doesNotMarkUnchangedShiftedMacroTestBodyAsChanged(@TempDir Path tempDir) throws IOException {
+		Path before = tempDir.resolve("before");
+		Path after = tempDir.resolve("after");
+		Files.createDirectories(before.resolve("src"));
+		Files.createDirectories(after.resolve("src"));
+		String beforeCode = String.join("\n",
+				"#define TEST(suite, name) void suite##_##name()",
+				"#define EXPECT_EQ(lhs, rhs) if (!((lhs) == (rhs))) return",
+				"#define EXPECT_THAT(lhs, rhs) if (!(lhs)) return",
+				"#define ElementsAreArray(values) values",
+				"#define ArrayFloatNear(values) values",
+				"",
+				"TEST(DynamicUpdateSliceOpTest, SimpleTestF32InPlaceInput) {",
+				"  int model = 0;",
+				"  const int kInplaceInputTensorIdx = 0;",
+				"  const int kInplaceOutputTensorIdx = 0;",
+				"  EXPECT_THAT(model, ElementsAreArray(ArrayFloatNear({1, 2, 3})));",
+				"  EXPECT_EQ(kInplaceOutputTensorIdx, kInplaceInputTensorIdx);",
+				"}",
+				"",
+				"TEST(DynamicUpdateSliceOpTest, SimpleTestF16InPlaceInput) {",
+				"  int model = 0;",
+				"  const int kInplaceInputTensorIdx = 0;",
+				"  const int kInplaceOutputTensorIdx = 0;",
+				"  EXPECT_THAT(model, ElementsAreArray(ArrayFloatNear({1, 2, 3})));",
+				"  EXPECT_EQ(kInplaceOutputTensorIdx, kInplaceInputTensorIdx);",
+				"}") + "\n";
+		String afterCode = String.join("\n",
+				"#define TEST(suite, name) void suite##_##name()",
+				"#define EXPECT_EQ(lhs, rhs) if (!((lhs) == (rhs))) return",
+				"#define EXPECT_THAT(lhs, rhs) if (!(lhs)) return",
+				"#define ElementsAreArray(values) values",
+				"#define ArrayFloatNear(values) values",
+				"",
+				"void helper() {",
+				"}",
+				"",
+				"TEST(DynamicUpdateSliceOpTest, SimpleTestF32InPlaceInput) {",
+				"  int model = 0;",
+				"  const int kInplaceInputTensorIdx = 0;",
+				"  const int kInplaceOutputTensorIdx = 0;",
+				"  EXPECT_THAT(model, ElementsAreArray(ArrayFloatNear({1, 2, 3})));",
+				"  EXPECT_EQ(kInplaceOutputTensorIdx, kInplaceInputTensorIdx);",
+				"}",
+				"",
+				"TEST(DynamicUpdateSliceOpTest, SimpleTestF16InPlaceInput) {",
+				"  int model = 0;",
+				"  const int kInplaceInputTensorIdx = 0;",
+				"  const int kInplaceOutputTensorIdx = 0;",
+				"  EXPECT_THAT(model, ElementsAreArray(ArrayFloatNear({1, 2, 3})));",
+				"  EXPECT_EQ(kInplaceOutputTensorIdx, kInplaceInputTensorIdx);",
+				"}") + "\n";
+		Files.writeString(before.resolve("src/sample.cc"), beforeCode, StandardCharsets.UTF_8);
+		Files.writeString(after.resolve("src/sample.cc"), afterCode, StandardCharsets.UTF_8);
+
+		Set<ASTDiff> astDiffs = new GitHistoryRefactoringMinerImpl().diffAtDirectories(before, after).getDiffSet();
+		ASTDiff astDiff = astDiffs.stream()
+				.filter(diff -> diff.getSrcPath().equals("src/sample.cc"))
+				.findFirst()
+				.orElseThrow();
+		TreeClassifier classifier = astDiff.createRootNodesClassifier();
+		int testStart = beforeCode.indexOf("TEST(DynamicUpdateSliceOpTest, SimpleTestF32InPlaceInput)");
+		int testEnd = beforeCode.indexOf("}", testStart) + 1;
+
+		assertTrue(noTreeInRange(classifier.getUpdatedSrcs(), testStart, testEnd),
+				"Unexpected updates in unchanged macro test body");
+		assertTrue(noTreeInRange(classifier.getMovedSrcs(), testStart, testEnd),
+				"Unexpected moves in unchanged macro test body");
+		assertTrue(noTreeInRange(((ExtendedTreeClassifier) classifier).getMultiMapSrc().keySet(), testStart, testEnd),
+				"Unexpected multi-moves in unchanged macro test body");
+	}
+
+	@Test
+	void marksActuallyReorderedMacroTestBodyAsMoved(@TempDir Path tempDir) throws IOException {
+		Path before = tempDir.resolve("before");
+		Path after = tempDir.resolve("after");
+		Files.createDirectories(before.resolve("src"));
+		Files.createDirectories(after.resolve("src"));
+		String beforeCode = String.join("\n",
+				"#define TEST(suite, name) void suite##_##name()",
+				"",
+				"TEST(SampleTest, FirstCase) {",
+				"  int first = 1;",
+				"}",
+				"",
+				"TEST(SampleTest, SecondCase) {",
+				"  int second = 2;",
+				"}") + "\n";
+		String afterCode = String.join("\n",
+				"#define TEST(suite, name) void suite##_##name()",
+				"",
+				"TEST(SampleTest, SecondCase) {",
+				"  int second = 2;",
+				"}",
+				"",
+				"TEST(SampleTest, FirstCase) {",
+				"  int first = 1;",
+				"}") + "\n";
+		Files.writeString(before.resolve("src/sample.cc"), beforeCode, StandardCharsets.UTF_8);
+		Files.writeString(after.resolve("src/sample.cc"), afterCode, StandardCharsets.UTF_8);
+
+		Set<ASTDiff> astDiffs = new GitHistoryRefactoringMinerImpl().diffAtDirectories(before, after).getDiffSet();
+		ASTDiff astDiff = astDiffs.stream()
+				.filter(diff -> diff.getSrcPath().equals("src/sample.cc"))
+				.findFirst()
+				.orElseThrow();
+		TreeClassifier classifier = astDiff.createRootNodesClassifier();
+		int firstTestStart = beforeCode.indexOf("TEST(SampleTest, FirstCase)");
+		int firstTestEnd = beforeCode.indexOf("}", firstTestStart) + 1;
+
+		assertTrue(!noTreeInRange(classifier.getMovedSrcs(), firstTestStart, firstTestEnd)
+						|| !noTreeInRange(((ExtendedTreeClassifier) classifier).getMultiMapSrc().keySet(), firstTestStart, firstTestEnd),
+				"Actually reordered macro test body should still be reported as moved");
+	}
+
+	private static boolean noTreeInRange(Collection<Tree> trees, int start, int end) {
+		return trees.stream().noneMatch(tree -> tree.getPos() >= start && tree.getEndPos() <= end);
+	}
 
 	@Test
 	public void testSubTreeMappings() throws JsonProcessingException {


### PR DESCRIPTION
This PR fixes incorrect AST diff highlighting for C++ macro-expanded code, especially TEST(...) / TEST_F(...) blocks.

CDT can return mixed node locations for macro-generated function definitions. Before, LocationInfo only handled the simple case where a node had exactly one IASTMacroExpansionLocation. In real C++ test files, macro-expanded nodes can contain multiple locations, which caused RefactoringMiner to map nodes to incorrect source spans and incorrectly classify unchanged shifted test bodies as updated/reordered.

Changes
- Merge mixed C++ macro node locations into one original source span in LocationInfo
- Reuse one shared init(...) path for C++ source range initialization
- Avoid generating noisy MultiMove actions for equivalent ambiguous groups that remain in source order
- Attach MultiMove actions only to their specific destination node during classification

- Add test coverage for:
- macro-expansion source mapping
- unchanged shifted macro test bodies not being marked updated/moved/multi-moved
- actually reordered macro test bodies still being detected as moved


Test with these commits 
        url = "https://github.com/tensorflow/tensorflow/commit/723a9d85c35552fde85ea7f59326ab679547752e";
       url = "https://github.com/tensorflow/tensorflow/commit/2813047201deaeb555efbbab36b1a4e7ae8d4887";
       url = "https://github.com/tensorflow/tensorflow/commit/52b48e57da4dc11928b84ad99383ba18ab8cfe4a";

