### PR TITLE
Fix C++ macro expansion source locations

### DIFF
--- a/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppFileProcessor.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -146,7 +145,10 @@ public class CppFileProcessor {
 					return (InternalFileContent) FileContent.createForExternalFileLocation(astPath);
 				}
 			};
-			int options = GPPLanguage.OPTION_IS_SOURCE_UNIT | GPPLanguage.OPTION_PARSE_INACTIVE_CODE | GPPLanguage.OPTION_NO_IMAGE_LOCATIONS;
+			int options = GPPLanguage.OPTION_IS_SOURCE_UNIT | GPPLanguage.OPTION_PARSE_INACTIVE_CODE;
+			if(!astDiff) {
+				options |= GPPLanguage.OPTION_NO_IMAGE_LOCATIONS;
+			}
 
 			if(PathFileUtils.isCppFile(filePath)) {
 				if (astDiff) {
@@ -171,9 +173,8 @@ public class CppFileProcessor {
 				UMLClass moduleClass = createModuleClass(ast, sourceFolder);
 				preprocessor.buildConditionalBranches(ast.getAllPreprocessorStatements());
 				processPreprocessorStatements(sourceFolder, moduleClass, ast.getAllPreprocessorStatements());
-				IASTDeclaration[] declarations = ast.getDeclarations(true);
-				IASTDeclaration[] declarationsWithinFile = Arrays.stream(declarations).filter(d -> d.getFileLocation().toString().startsWith(filePath)).toArray(IASTDeclaration[]::new);
-				preprocessor.processDeclarations(moduleClass.getName(), sourceFolder, moduleClass, declarationsWithinFile, comments, new ICPPASTTemplateParameter[0]);
+				preprocessor.processDeclarations(moduleClass.getName(), sourceFolder, moduleClass,
+						ast.getDeclarations(true), comments, new ICPPASTTemplateParameter[0]);
 				this.umlModel.addClass(moduleClass);
 				//add remaining comments to moduleClass
 				//TODO consider assigning comments to individual preprocessor statements
@@ -201,7 +202,8 @@ public class CppFileProcessor {
 				this.umlModel.getCommentMap().put(filePath, comments);
 				UMLClass moduleClass = createModuleClass(ast, sourceFolder);
 				processPreprocessorStatements(sourceFolder, moduleClass, ast.getAllPreprocessorStatements());
-				preprocessor.processDeclarations(moduleClass.getName(), sourceFolder, moduleClass, ast.getDeclarations(), comments, new ICPPASTTemplateParameter[0]);
+				preprocessor.processDeclarations(moduleClass.getName(), sourceFolder, moduleClass,
+						ast.getDeclarations(), comments, new ICPPASTTemplateParameter[0]);
 				this.umlModel.addClass(moduleClass);
 				//add remaining comments to moduleClass
 				moduleClass.getComments().addAll(comments);
@@ -215,6 +217,9 @@ public class CppFileProcessor {
 	private List<UMLComment> extractInternalComments(IASTComment[] astComments, String sourceFolder, String sourceFile, String fileContent) {
 		List<UMLComment> comments = new ArrayList<UMLComment>();
 		for(IASTComment comment : astComments) {
+			if(!comment.isPartOfTranslationUnitFile()) {
+				continue;
+			}
 			LocationInfo locationInfo = null;
 			if(comment.isBlockComment()) {
 				locationInfo = new LocationInfo(sourceFolder, sourceFile, comment, CodeElementType.BLOCK_COMMENT, fileContent);
@@ -252,6 +257,9 @@ public class CppFileProcessor {
 
 	private void processPreprocessorStatements(String sourceFolder, UMLClass moduleClass, IASTPreprocessorStatement[] allPreprocessorStatements) {
 		for(IASTPreprocessorStatement statement : allPreprocessorStatements) {
+			if(!statement.isPartOfTranslationUnitFile()) {
+				continue;
+			}
 			LocationInfo locationInfo = new LocationInfo(
 				sourceFolder,
 				filePath,
@@ -364,6 +372,9 @@ public class CppFileProcessor {
 	public Visibility processDeclaration(String packageName, String sourceFolder, UMLAbstractClass parentContainer,
 			List<UMLComment> comments, Visibility currentVisibility, IASTDeclaration declaration, ICPPASTTemplateParameter[] templateParameters,
 			List<IASTDeclaration> inactiveContainerAlternatives) {
+		if(!shouldProcessDeclaration(declaration)) {
+			return currentVisibility;
+		}
 		if(declaration instanceof CPPASTStructuredBindingDeclaration cppStructuredBindingDeclaration) {
 			//A structured binding declaration is a feature introduced in C++17 that allows you to unpack or decompose a target object into individual named variables.
 			//Similar to destructuring or unpacking in languages like JavaScript and Python, it directly binds specified identifiers to the sub-objects, members, or elements of an initializer.
@@ -514,6 +525,10 @@ public class CppFileProcessor {
 			}
 		}
 		return currentVisibility;
+	}
+
+	boolean shouldProcessDeclaration(IASTDeclaration declaration) {
+		return declaration.isPartOfTranslationUnitFile() || declaration instanceof ICPPASTVisibilityLabel;
 	}
 
 	private UMLClass createModuleClass(IASTTranslationUnit ast, String sourceFolder) {

--- a/src/main/java/gr/uom/java/xmi/CppPreprocessor.java
+++ b/src/main/java/gr/uom/java/xmi/CppPreprocessor.java
@@ -82,7 +82,11 @@ public class CppPreprocessor {
 			List<DeclarationGroup> declarationGroups, List<UMLComment> comments, ICPPASTTemplateParameter[] templateParameters) {
 		List<IASTDeclaration> allDeclarations = new ArrayList<>();
 		for(DeclarationGroup group : declarationGroups) {
-			Collections.addAll(allDeclarations, group.declarations);
+			for(IASTDeclaration declaration : group.declarations) {
+				if(fileProcessor.shouldProcessDeclaration(declaration)) {
+					allDeclarations.add(declaration);
+				}
+			}
 		}
 		Map<IASTDeclaration, List<IASTDeclaration>> alternatives = new IdentityHashMap<>();
 		Set<IASTDeclaration> mergedInactiveContainers = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -90,7 +94,7 @@ public class CppPreprocessor {
 		for(DeclarationGroup group : declarationGroups) {
 			Visibility currentVisibility = group.initialVisibility;
 			for(IASTDeclaration declaration : group.declarations) {
-				if(!mergedInactiveContainers.contains(declaration)) {
+				if(fileProcessor.shouldProcessDeclaration(declaration) && !mergedInactiveContainers.contains(declaration)) {
 					currentVisibility = fileProcessor.processDeclaration(packageName, sourceFolder, parentContainer, comments, currentVisibility,
 							declaration, templateParameters, alternatives.getOrDefault(declaration, Collections.emptyList()));
 				}

--- a/src/main/java/gr/uom/java/xmi/LocationInfo.java
+++ b/src/main/java/gr/uom/java/xmi/LocationInfo.java
@@ -3,9 +3,11 @@ package gr.uom.java.xmi;
 import java.util.List;
 
 import org.eclipse.cdt.core.dom.ast.IASTFileLocation;
+import org.eclipse.cdt.core.dom.ast.IASTImageLocation;
 import org.eclipse.cdt.core.dom.ast.IASTMacroExpansionLocation;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTNodeLocation;
+import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.jetbrains.kotlin.com.intellij.openapi.editor.Document;
@@ -227,16 +229,33 @@ public class LocationInfo {
 		this.codeElementType = codeElementType;
 		IASTNodeLocation[] locations = node.getNodeLocations();
 		if (locations.length == 1 && locations[0] instanceof IASTMacroExpansionLocation) {
-			IASTMacroExpansionLocation macroLoc = (IASTMacroExpansionLocation) locations[0];
-			//macroLoc.asFileLocation()
-			//macroLoc.getExpansion().getFileLocation()
-			//macroLoc.getExpansion().getMacroReference().getFileLocation()
-			//macroLoc.getExpansion().getMacroDefinition().getName().getImageLocation()
-			init(fileContent, macroLoc.asFileLocation());
+			IASTMacroExpansionLocation macroLocation = (IASTMacroExpansionLocation) locations[0];
+			IASTImageLocation imageLocation = getImageLocation(node);
+			if(isSourceMacroArgument(node, imageLocation)) {
+				init(fileContent, imageLocation);
+			}
+			else {
+				init(fileContent, macroLocation.asFileLocation());
+			}
 		}
 		else {
 			init(fileContent, node.getFileLocation());
 		}
+	}
+
+	private IASTImageLocation getImageLocation(IASTNode node) {
+		if(node instanceof org.eclipse.cdt.internal.core.dom.parser.ASTNode astNode) {
+			return astNode.getImageLocation();
+		}
+		return null;
+	}
+
+	private boolean isSourceMacroArgument(IASTNode node, IASTImageLocation imageLocation) {
+		if(imageLocation == null || imageLocation.getLocationKind() != IASTImageLocation.ARGUMENT_TO_MACRO_EXPANSION) {
+			return false;
+		}
+		IASTTranslationUnit translationUnit = node.getTranslationUnit();
+		return translationUnit != null && translationUnit.getFilePath().equals(imageLocation.getFileName());
 	}
 
 	private void init(String fileContent, IASTFileLocation fileLocation) {
@@ -248,11 +267,38 @@ public class LocationInfo {
 			this.endOffset = startOffset + length;
 			this.startLine = fileLocation.getStartingLineNumber();
 			this.endLine = fileLocation.getEndingLineNumber();
+			if(this.startLine <= 0) {
+				this.startLine = computeLine(fileContent, startOffset);
+			}
+			if(this.endLine <= 0) {
+				this.endLine = computeLine(fileContent, Math.max(startOffset, endOffset - 1));
+			}
 			// Columns are derived from the original file content so CodeRange remains UI-friendly.
 			this.startColumn = computeColumn(fileContent, startOffset);
 			this.endColumn = computeColumn(fileContent, Math.max(startOffset, endOffset - 1));
 			this.compilationUnitLength = computeCompilationUnitLength(fileContent);
 		}
+	}
+
+	private int computeLine(String fileContent, int offset) {
+		if(fileContent == null || fileContent.isEmpty() || offset < 0) {
+			return 0;
+		}
+		int safeOffset = Math.min(offset, fileContent.length());
+		int line = 1;
+		for(int i = 0; i < safeOffset; i++) {
+			char character = fileContent.charAt(i);
+			if(character == '\r') {
+				line++;
+				if(i + 1 < safeOffset && fileContent.charAt(i + 1) == '\n') {
+					i++;
+				}
+			}
+			else if(character == '\n') {
+				line++;
+			}
+		}
+		return line;
 	}
 
 	private int computeColumn(String fileContent, int offset) {

--- a/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
+++ b/src/test/java/gr/uom/java/xmi/CppFileProcessorTest.java
@@ -6,12 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import gr.uom.java.xmi.LocationInfo.CodeElementType;
+import gr.uom.java.xmi.UMLPreprocessorStatement.Directive;
+import gr.uom.java.xmi.decomposition.AbstractCall;
 import gr.uom.java.xmi.decomposition.AbstractCodeFragment;
 import gr.uom.java.xmi.decomposition.CompositeStatementObject;
 import gr.uom.java.xmi.decomposition.TryStatementObject;
@@ -1232,6 +1238,109 @@ class CppFileProcessorTest {
 		assertTrue(partialBox.getActualSignature().contains("class Box<T*>"));
 		assertEquals(List.of("T"), partialBox.getTypeParameterNames());
 		assertEquals("T*", findOperation(partialBox.getOperations(), "value").getReturnParameter().getType().toString().replace(" ", ""));
+	}
+
+	@Test
+	void preservesMacroArgumentLocationsDuringAstDiffProcessing() {
+		String filePath = "src/assertions.cpp";
+		String fileContent = String.join("\n",
+				"#define ASSERT_EQ(lhs, rhs) if ((lhs) == (rhs)) {}",
+				"void run() {",
+				"  ASSERT_EQ(foo(), bar());",
+				"}") + "\n";
+		UMLModel model = new UMLModel(Set.of("src"));
+
+		new CppFileProcessor(model).processCppFile(filePath, fileContent, true);
+
+		UMLOperation run = findOperation(findClass(model.getClassList(), "assertions").getOperations(), "run");
+		List<LocationInfo> invocationLocations = run.getAllOperationInvocations().stream()
+				.map(AbstractCall::getLocationInfo)
+				.toList();
+		assertContainsLocation(invocationLocations, fileContent.indexOf("foo()"), "foo()".length());
+		assertContainsLocation(invocationLocations, fileContent.indexOf("bar()"), "bar()".length());
+	}
+
+	@Test
+	void excludesIncludedHeaderNodesFromSourceModel(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve("fixture.h"), String.join("\n",
+				"// HEADER_SENTINEL",
+				"class HeaderOnly {",
+				"public:",
+				"  void hidden() {}",
+				"};",
+				"#define DECLARE_SOURCE_FUNCTION(name) void name() {}") + "\n");
+		String fileContent = String.join("\n",
+				"#include \"fixture.h\"",
+				"// SOURCE_SENTINEL",
+				"DECLARE_SOURCE_FUNCTION(sourceFunction)") + "\n";
+		String filePath = tempDir.resolve("sample.cpp").toString();
+		UMLModel model = new UMLModel(Set.of());
+
+		new CppFileProcessor(model).processCppFile(filePath, fileContent, false);
+
+		assertFalse(model.getClassList().stream()
+				.anyMatch(umlClass -> umlClass.getName().equals("HeaderOnly") || umlClass.getName().endsWith(".HeaderOnly")));
+		UMLClass moduleClass = findClass(model.getClassList(), "sample");
+		assertNotNull(findOperation(moduleClass.getOperations(), "sourceFunction"));
+		assertEquals(List.of(Directive.INCLUDE), moduleClass.getPreprocessorStatements().stream()
+				.map(UMLPreprocessorStatement::getType)
+				.toList());
+		assertFalse(model.getCommentMap().values().stream()
+				.flatMap(List::stream)
+				.anyMatch(comment -> comment.getText().contains("HEADER_SENTINEL")));
+		assertFalse(model.getClassList().stream()
+				.flatMap(umlClass -> umlClass.getComments().stream())
+				.anyMatch(comment -> comment.getText().contains("HEADER_SENTINEL")));
+	}
+
+	@Test
+	void excludesIncludedHeaderNodesNestedInsideNamespace(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve("nested.h"), String.join("\n",
+				"class HeaderNested {",
+				"public:",
+				"  void hidden() {}",
+				"};") + "\n");
+		String fileContent = String.join("\n",
+				"namespace Wrapper {",
+				"#include \"nested.h\"",
+				"void visible() {}",
+				"}") + "\n";
+		String filePath = tempDir.resolve("sample.cpp").toString();
+		UMLModel model = new UMLModel(Set.of());
+
+		new CppFileProcessor(model).processCppFile(filePath, fileContent, false);
+
+		assertFalse(model.getClassList().stream()
+				.anyMatch(umlClass -> umlClass.getName().equals("HeaderNested") ||
+						umlClass.getName().endsWith(".HeaderNested")));
+		assertNotNull(findOperation(findClass(model.getClassList(), "sample").getOperations(), "visible"));
+	}
+
+	@Test
+	void preservesIncludedAccessLabelForFollowingSourceMember(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve("public.inc"), "public:\n");
+		String fileContent = String.join("\n",
+				"class Container {",
+				"private:",
+				"#include \"public.inc\"",
+				"void visible();",
+				"};") + "\n";
+		String filePath = tempDir.resolve("sample.cpp").toString();
+		UMLModel model = new UMLModel(Set.of());
+
+		new CppFileProcessor(model).processCppFile(filePath, fileContent, false);
+
+		UMLOperation visible = findOperation(findClass(model.getClassList(), "Container").getOperations(), "visible");
+		assertEquals(Visibility.PUBLIC, visible.getVisibility());
+	}
+
+	private static void assertContainsLocation(List<LocationInfo> locations, int startOffset, int length) {
+		assertTrue(locations.stream().anyMatch(location ->
+				location.getStartOffset() == startOffset && location.getLength() == length),
+				() -> "Expected location [" + startOffset + ", " + (startOffset + length) + ") but found " +
+						locations.stream()
+								.map(location -> "[" + location.getStartOffset() + ", " + location.getEndOffset() + ")")
+								.toList());
 	}
 
 	private static UMLOperation findOperation(List<UMLOperation> operations, String name) {

--- a/src/test/java/gr/uom/java/xmi/LocationInfoCppTest.java
+++ b/src/test/java/gr/uom/java/xmi/LocationInfoCppTest.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 import org.eclipse.cdt.core.dom.ast.ASTVisitor;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
+import org.eclipse.cdt.core.dom.ast.IASTExpression;
+import org.eclipse.cdt.core.dom.ast.IASTFunctionCallExpression;
+import org.eclipse.cdt.core.dom.ast.IASTImageLocation;
 import org.eclipse.cdt.core.dom.ast.IASTMacroExpansionLocation;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTNodeLocation;
@@ -21,6 +24,7 @@ import org.eclipse.cdt.core.parser.IParserLogService;
 import org.eclipse.cdt.core.parser.IScannerInfo;
 import org.eclipse.cdt.core.parser.IncludeFileContentProvider;
 import org.eclipse.cdt.core.parser.ScannerInfo;
+import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
 import org.eclipse.core.runtime.CoreException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -114,6 +118,7 @@ class LocationInfoCppTest {
 		assertEquals(0, location.getEndColumn());
 		assertEquals(0, location.getCompilationUnitLength());
 	}
+
 	@Test
 	void mapsMixedMacroExpansionLocationsToOriginalCppSourceSpan() throws Exception {
 		String source = String.join("\n",
@@ -147,6 +152,63 @@ class LocationInfoCppTest {
 		assertEquals(5, location.getEndLine());
 		assertEquals(1, location.getStartColumn());
 		assertEquals(1, location.getEndColumn());
+	}
+
+	@Test
+	void mapsMacroArgumentExpressionsToTheirOriginalSourceRanges() throws Exception {
+		String source = String.join("\n",
+				"#define ASSERT_EQ(lhs, rhs) if ((lhs) == (rhs)) {}",
+				"void run() {",
+				"  ASSERT_EQ(foo(), bar());",
+				"}") + "\n";
+		IASTTranslationUnit translationUnit = parseTranslationUnit(source);
+
+		assertMacroArgumentLocation(translationUnit, source, "foo()");
+		assertMacroArgumentLocation(translationUnit, source, "bar()");
+	}
+
+	private static void assertMacroArgumentLocation(IASTTranslationUnit translationUnit, String source,
+			String expressionText) {
+		IASTExpression expression = findMacroArgumentExpression(translationUnit, source, expressionText);
+		LocationInfo location = new LocationInfo(SRC_FOLDER, FILE_PATH, expression,
+				LocationInfo.CodeElementType.METHOD_INVOCATION, source);
+
+		int startOffset = source.indexOf(expressionText);
+		assertEquals(startOffset, location.getStartOffset());
+		assertEquals(startOffset + expressionText.length(), location.getEndOffset());
+		assertEquals(3, location.getStartLine());
+		assertEquals(3, location.getEndLine());
+	}
+
+	private static IASTExpression findMacroArgumentExpression(IASTTranslationUnit translationUnit, String source,
+			String expressionText) {
+		class MacroArgumentVisitor extends ASTVisitor {
+			private IASTExpression match;
+
+			private MacroArgumentVisitor() {
+				shouldVisitExpressions = true;
+			}
+
+			@Override
+			public int visit(IASTExpression expression) {
+				if(expression instanceof IASTFunctionCallExpression && expression instanceof ASTNode astNode) {
+					IASTImageLocation imageLocation = astNode.getImageLocation();
+					if(imageLocation != null &&
+							imageLocation.getLocationKind() == IASTImageLocation.ARGUMENT_TO_MACRO_EXPANSION &&
+							expressionText.equals(source.substring(imageLocation.getNodeOffset(),
+									imageLocation.getNodeOffset() + imageLocation.getNodeLength()))) {
+						match = expression;
+						return PROCESS_ABORT;
+					}
+				}
+				return PROCESS_CONTINUE;
+			}
+		}
+
+		MacroArgumentVisitor visitor = new MacroArgumentVisitor();
+		translationUnit.accept(visitor);
+		assertNotNull(visitor.match, "Could not find macro argument expression: " + expressionText);
+		return visitor.match;
 	}
 
 	//Search parsed C++ AST for specific declaration and return its node


### PR DESCRIPTION
Fixes #1169

## Summary

- Use CDT `ARGUMENT_TO_MACRO_EXPANSION` image locations to recover the exact source range of expressions passed through C++ macros.
- Accept an image location only when it belongs to the same translation unit, while preserving the existing aggregate range for multi-location macro-generated declarations and the safe outer-expansion fallback.
- Enable image locations only for AST-diff parsing.
- Recursively exclude declarations, comments, and preprocessor statements owned by resolved headers, while retaining included access labels that determine the visibility of following source members.

## Motivation

On current `master`, both `foo()` and `bar()` in `ASSERT_EQ(foo(), bar())` resolve to the full outer invocation (`66+23`). With this change, they resolve to their original source ranges (`76+5` and `83+5`).

This deliberately does not restore PR #1170's reverted `MultiMove`/classifier changes or hard-code an include directory. The location fix is confined to CDT source ownership and image-location handling.

## Tests

- Added exact macro-argument range tests, including line reconstruction because CDT image locations report zero line numbers.
- Added AST-diff processing coverage for macro arguments.
- Added direct and nested included-header filtering tests, plus included access-label context coverage.
- Retained and passed the upstream mixed macro-expansion and macro-body movement regressions kept after PR #1170 was reverted.
- Focused C++ suite: `BUILD SUCCESSFUL` (`LocationInfoCppTest`, `CppFileProcessorTest`, and `CppDiffTest`).
- Clean full suite without token-required tests: `./gradlew clean test -Pnotoken --no-daemon` — `BUILD SUCCESSFUL`.
- TensorFlow/gtest reproduction: 5,227 mappings, 6 reported actions, and no spurious moved mappings or refactorings.
