### PR TITLE
Properly indent -json CLI output for readability

### DIFF
--- a/src/main/java/gr/uom/java/xmi/diff/CodeRange.java
+++ b/src/main/java/gr/uom/java/xmi/diff/CodeRange.java
@@ -8,6 +8,9 @@ import gr.uom.java.xmi.LocationInfo;
 import gr.uom.java.xmi.LocationInfo.CodeElementType;
 import gr.uom.java.xmi.decomposition.AbstractCodeFragment;
 
+import static org.refactoringminer.util.JSONIndentUtils.NEW_LINE;
+import static org.refactoringminer.util.JSONIndentUtils.SINGLE_TAB;
+
 public class CodeRange {
 	private final int startOffset;
 	private final int endOffset;
@@ -91,7 +94,7 @@ public class CodeRange {
 
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("{").append("\n");
+		sb.append("{").append(NEW_LINE);
 		encodeStringProperty(sb, "filePath", filePath, false);
 		encodeIntProperty(sb, "startLine", startLine, false);
 		encodeIntProperty(sb, "endLine", endLine, false);
@@ -116,22 +119,22 @@ public class CodeRange {
 
 	private void encodeStringProperty(StringBuilder sb, String propertyName, String value, boolean last) {
 		if(value != null)
-			sb.append("\t").append("\t").append("\"" + propertyName + "\"" + ": " + "\"" + value + "\"");
+			sb.append(SINGLE_TAB).append("\"" + propertyName + "\"" + ": " + "\"" + value + "\"");
 		else
-			sb.append("\t").append("\t").append("\"" + propertyName + "\"" + ": " + value);
+			sb.append(SINGLE_TAB).append("\"" + propertyName + "\"" + ": " + value);
 		insertNewLine(sb, last);
 	}
 
 	private void encodeIntProperty(StringBuilder sb, String propertyName, int value, boolean last) {
-		sb.append("\t").append("\t").append("\"" + propertyName + "\"" + ": " + value);
+		sb.append(SINGLE_TAB).append("\"" + propertyName + "\"" + ": " + value);
 		insertNewLine(sb, last);
 	}
 
 	private void insertNewLine(StringBuilder sb, boolean last) {
 		if(last)
-			sb.append("\n");
+			sb.append(NEW_LINE);
 		else
-			sb.append(",").append("\n");
+			sb.append(",").append(NEW_LINE);
 	}
 
 	public static CodeRange computeRange(Set<AbstractCodeFragment> codeFragments) {

--- a/src/main/java/org/refactoringminer/RefactoringMiner.java
+++ b/src/main/java/org/refactoringminer/RefactoringMiner.java
@@ -19,6 +19,11 @@ import org.refactoringminer.api.RefactoringHandler;
 import org.refactoringminer.mcp.RefactoringMinerMcpServer;
 import org.refactoringminer.rm1.GitHistoryRefactoringMinerImpl;
 import org.refactoringminer.util.GitServiceImpl;
+import org.refactoringminer.util.JSONIndentUtils;
+
+import static org.refactoringminer.util.JSONIndentUtils.DOUBLE_TAB;
+import static org.refactoringminer.util.JSONIndentUtils.NEW_LINE;
+import static org.refactoringminer.util.JSONIndentUtils.SINGLE_TAB;
 
 public class RefactoringMiner {
 	private static Path path = null;
@@ -320,29 +325,31 @@ public class RefactoringMiner {
 					normalizedCloneURL.startsWith("https://gitlab.com/") ||
 					normalizedCloneURL.startsWith("https://bitbucket.org/");
 			StringBuilder sb = new StringBuilder();
-			sb.append("{").append("\n");
-			sb.append("\t").append("\"").append("repository").append("\"").append(": ").append("\"").append(normalizedCloneURL).append("\"").append(",").append("\n");
-			sb.append("\t").append("\"").append("sha1").append("\"").append(": ").append("\"").append(currentCommitId).append("\"").append(",").append("\n");
+			sb.append("{").append(NEW_LINE);
+			sb.append(SINGLE_TAB).append("\"").append("repository").append("\"").append(": ").append("\"").append(normalizedCloneURL).append("\"").append(",").append(NEW_LINE);
+			sb.append(SINGLE_TAB).append("\"").append("sha1").append("\"").append(": ").append("\"").append(currentCommitId).append("\"").append(",").append(NEW_LINE);
 			String url = hasBrowsableCloneURL ? GitHistoryRefactoringMinerImpl.extractCommitURL(normalizedCloneURL, currentCommitId) : "";
-			sb.append("\t").append("\"").append("url").append("\"").append(": ").append("\"").append(url).append("\"").append(",").append("\n");
-			sb.append("\t").append("\"").append("refactorings").append("\"").append(": ");
-			sb.append("[");
-			int counter = 0;
-			for(Refactoring refactoring : refactoringsAtRevision) {
-				if(url.isEmpty())
-					sb.append(refactoring.toJSON());
-				else
-					sb.append(refactoring.toJSON(url));
-				if(counter < refactoringsAtRevision.size()-1) {
-					sb.append(",");
+			sb.append(SINGLE_TAB).append("\"").append("url").append("\"").append(": ").append("\"").append(url).append("\"").append(",").append(NEW_LINE);
+			sb.append(SINGLE_TAB).append("\"").append("refactorings").append("\"").append(": ");
+			if(refactoringsAtRevision.isEmpty()) {
+				sb.append("[]").append(NEW_LINE);
+			} else {
+				sb.append("[").append(NEW_LINE);
+				int counter = 0;
+				for(Refactoring refactoring : refactoringsAtRevision) {
+					String refactoringJSON = url.isEmpty() ? refactoring.toJSON() : refactoring.toJSON(url);
+					sb.append(JSONIndentUtils.indentLines(refactoringJSON, DOUBLE_TAB));
+					if(counter < refactoringsAtRevision.size()-1) {
+						sb.append(",");
+					}
+					sb.append(NEW_LINE);
+					counter++;
 				}
-				sb.append("\n");
-				counter++;
+				sb.append(SINGLE_TAB).append("]").append(NEW_LINE);
 			}
-			sb.append("]").append("\n");
 			sb.append("}");
 			try {
-				Files.write(path, sb.toString().getBytes(), StandardOpenOption.APPEND);
+				Files.write(path, JSONIndentUtils.indentLines(sb.toString(), DOUBLE_TAB).getBytes(), StandardOpenOption.APPEND);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
@@ -352,7 +359,7 @@ public class RefactoringMiner {
 	private static void betweenCommitsJSON() {
 		if(path != null) {
 			StringBuilder sb = new StringBuilder();
-			sb.append(",").append("\n");
+			sb.append(",").append(NEW_LINE);
 			try {
 				Files.write(path, sb.toString().getBytes(), StandardOpenOption.APPEND);
 			} catch (IOException e) {
@@ -364,9 +371,9 @@ public class RefactoringMiner {
 	private static void startJSON() {
 		if(path != null) {
 			StringBuilder sb = new StringBuilder();
-			sb.append("{").append("\n");
-			sb.append("\"").append("commits").append("\"").append(": ");
-			sb.append("[").append("\n");
+			sb.append("{").append(NEW_LINE);
+			sb.append(SINGLE_TAB).append("\"").append("commits").append("\"").append(": ");
+			sb.append("[").append(NEW_LINE);
 			try {
 				Files.write(path, sb.toString().getBytes(), StandardOpenOption.APPEND);
 			} catch (IOException e) {
@@ -378,8 +385,9 @@ public class RefactoringMiner {
 	private static void endJSON() {
 		if(path != null) {
 			StringBuilder sb = new StringBuilder();
-			sb.append("]").append("\n");
-			sb.append("}");
+			sb.append(NEW_LINE);
+			sb.append(SINGLE_TAB).append("]").append(NEW_LINE);
+			sb.append("}").append(NEW_LINE);
 			try {
 				Files.write(path, sb.toString().getBytes(), StandardOpenOption.APPEND);
 			} catch (IOException e) {

--- a/src/main/java/org/refactoringminer/api/Refactoring.java
+++ b/src/main/java/org/refactoringminer/api/Refactoring.java
@@ -13,6 +13,11 @@ import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
 import gr.uom.java.xmi.decomposition.ReplacementUtil;
 import gr.uom.java.xmi.diff.CodeRange;
+import org.refactoringminer.util.JSONIndentUtils;
+
+import static org.refactoringminer.util.JSONIndentUtils.DOUBLE_TAB;
+import static org.refactoringminer.util.JSONIndentUtils.NEW_LINE;
+import static org.refactoringminer.util.JSONIndentUtils.SINGLE_TAB;
 
 public interface Refactoring extends Serializable, CodeRangeProvider {
 
@@ -119,16 +124,16 @@ public interface Refactoring extends Serializable, CodeRangeProvider {
 	default public String toJSON(String commitURL) {
 		StringBuilder sb = new StringBuilder();
 		JsonStringEncoder encoder = JsonStringEncoder.getInstance();
-		sb.append("{").append("\n");
-		sb.append("\t").append("\"").append("type").append("\"").append(": ").append("\"").append(getName()).append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("description").append("\"").append(": ").append("\"");
+		sb.append("{").append(NEW_LINE);
+		sb.append(SINGLE_TAB).append("\"").append("type").append("\"").append(": ").append("\"").append(getName()).append("\"").append(",").append(NEW_LINE);
+		sb.append(SINGLE_TAB).append("\"").append("description").append("\"").append(": ").append("\"");
 		encoder.quoteAsString(toString().replace('\t', ' '), sb);
-		sb.append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("markup").append("\"").append(": ").append("\"");
+		sb.append("\"").append(",").append(NEW_LINE);
+		sb.append(SINGLE_TAB).append("\"").append("markup").append("\"").append(": ").append("\"");
 		encoder.quoteAsString(toMarkupStringWithGitHubLinks(commitURL).replace('\t', ' '), sb);
-		sb.append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("leftSideLocations").append("\"").append(": ").append(leftSide()).append(",").append("\n");
-		sb.append("\t").append("\"").append("rightSideLocations").append("\"").append(": ").append(rightSide()).append("\n");
+		sb.append("\"").append(",").append(NEW_LINE);
+		appendLocationsArray(sb, "leftSideLocations", leftSide(), false);
+		appendLocationsArray(sb, "rightSideLocations", rightSide(), true);
 		sb.append("}");
 		return sb.toString();
 	}
@@ -136,14 +141,36 @@ public interface Refactoring extends Serializable, CodeRangeProvider {
 	default public String toJSON() {
 		StringBuilder sb = new StringBuilder();
 		JsonStringEncoder encoder = JsonStringEncoder.getInstance();
-		sb.append("{").append("\n");
-		sb.append("\t").append("\"").append("type").append("\"").append(": ").append("\"").append(getName()).append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("description").append("\"").append(": ").append("\"");
+		sb.append("{").append(NEW_LINE);
+		sb.append(SINGLE_TAB).append("\"").append("type").append("\"").append(": ").append("\"").append(getName()).append("\"").append(",").append(NEW_LINE);
+		sb.append(SINGLE_TAB).append("\"").append("description").append("\"").append(": ").append("\"");
 		encoder.quoteAsString(toString().replace('\t', ' '), sb);
-		sb.append("\"").append(",").append("\n");
-		sb.append("\t").append("\"").append("leftSideLocations").append("\"").append(": ").append(leftSide()).append(",").append("\n");
-		sb.append("\t").append("\"").append("rightSideLocations").append("\"").append(": ").append(rightSide()).append("\n");
+		sb.append("\"").append(",").append(NEW_LINE);
+		appendLocationsArray(sb, "leftSideLocations", leftSide(), false);
+		appendLocationsArray(sb, "rightSideLocations", rightSide(), true);
 		sb.append("}");
 		return sb.toString();
+	}
+
+	private void appendLocationsArray(StringBuilder sb, String propertyName, List<CodeRange> locations, boolean last) {
+		sb.append(SINGLE_TAB).append("\"").append(propertyName).append("\"").append(": ");
+		if (locations.isEmpty()) {
+			sb.append("[]");
+		} else {
+			sb.append("[").append(NEW_LINE);
+			for (int i = 0; i < locations.size(); i++) {
+				sb.append(JSONIndentUtils.indentLines(locations.get(i).toString(), DOUBLE_TAB));
+				if (i < locations.size() - 1) {
+					sb.append(",");
+				}
+				sb.append(NEW_LINE);
+			}
+			sb.append(SINGLE_TAB).append("]");
+		}
+		if (last) {
+			sb.append(NEW_LINE);
+		} else {
+			sb.append(",").append(NEW_LINE);
+		}
 	}
 }

--- a/src/main/java/org/refactoringminer/util/JSONIndentUtils.java
+++ b/src/main/java/org/refactoringminer/util/JSONIndentUtils.java
@@ -1,0 +1,28 @@
+package org.refactoringminer.util;
+
+public class JSONIndentUtils {
+
+	public static final String SINGLE_TAB = "\t";
+	public static final String DOUBLE_TAB = SINGLE_TAB + SINGLE_TAB;
+	public static final String NEW_LINE = "\n";
+
+	private JSONIndentUtils() {
+	}
+
+	/**
+	 * Prefixes every line of a self-contained, pretty-printed JSON fragment with the given indent,
+	 * so it can be embedded as an element of an array/object one or more nesting levels deeper
+	 * without losing its own internal indentation.
+	 */
+	public static String indentLines(String text, String indent) {
+		String[] lines = text.split(NEW_LINE, -1);
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < lines.length; i++) {
+			sb.append(indent).append(lines[i]);
+			if (i < lines.length - 1) {
+				sb.append(NEW_LINE);
+			}
+		}
+		return sb.toString();
+	}
+}


### PR DESCRIPTION

**Description:**                                                                                                                                                        
  Fixes the JSON format for -json CLI output by adding proper indentation, making it much more readable.                                               
                                                                                                                                                       
**Testing:**                                                                                                                                             
  Built a local Docker image and ran it against two commits; the output formatting was correct in both cases with proper indentation. The generated JSON file looks much better now.                                                                                                                                          
                     