### PR TITLE
fix: avoid UnsupportedOperationException for Python attribute lambdas

### DIFF
--- a/src/main/java/extension/umladapter/processor/UMLAdapterVariableProcessor.java
+++ b/src/main/java/extension/umladapter/processor/UMLAdapterVariableProcessor.java
@@ -1,6 +1,7 @@
 package extension.umladapter.processor;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 
 import extension.ast.node.declaration.LangSingleVariableDeclaration;
 import extension.ast.node.expression.LangAssignment;
@@ -42,7 +43,7 @@ public class UMLAdapterVariableProcessor {
                 assignment,
                 container,
                 attributeName,
-                Collections.emptyMap(),
+                new LinkedHashMap<>(),
                 fileContent
         );
 

--- a/src/test/java/org/refactoringminer/test/TestPythonAttributeLambda.java
+++ b/src/test/java/org/refactoringminer/test/TestPythonAttributeLambda.java
@@ -1,0 +1,43 @@
+package org.refactoringminer.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import gr.uom.java.xmi.UMLAttribute;
+import gr.uom.java.xmi.UMLModel;
+import gr.uom.java.xmi.UMLModelASTReader;
+import gr.uom.java.xmi.decomposition.LambdaExpressionObject;
+
+public class TestPythonAttributeLambda {
+
+	@Test
+	public void testDictionaryAttributeContainingLambda() {
+		String source = """
+				mapping = {"number": lambda x: x + 1}
+
+				def anchor():
+				    return mapping
+				""";
+
+		UMLModel model = assertDoesNotThrow(() ->
+				new UMLModelASTReader(Map.of("sample.py", source), Set.of(""), false).getUmlModel());
+		UMLAttribute mapping = model.getClassList().stream()
+				.flatMap(umlClass -> umlClass.getAttributes().stream())
+				.filter(attribute -> attribute.getName().equals("mapping"))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("The mapping attribute must be included in the model"));
+
+		List<LambdaExpressionObject> lambdas = mapping.getAllLambdas();
+		assertEquals(1, lambdas.size());
+		LambdaExpressionObject lambda = lambdas.get(0);
+		assertEquals(List.of("x"), lambda.getParameterNameList());
+		assertNotNull(lambda.getExpression());
+	}
+}


### PR DESCRIPTION
## Problem

Parsing a Python attribute initializer containing a lambda with parameters can throw UnsupportedOperationException. A minimal reproducer is:

```python
mapping = {"number": lambda x: x + 1}

def anchor():
    return mapping
```

The exception occurs during model construction, not execution of the Python code:

```text
java.lang.UnsupportedOperationException
    at java.util.AbstractMap.put(AbstractMap.java:213)
    at gr.uom.java.xmi.decomposition.LambdaExpressionObject.<init>(LambdaExpressionObject.java:104)
    ...
    at extension.umladapter.processor.UMLAdapterVariableProcessor.processAttributeAssignment(...)
```

## Cause and fix

processAttributeAssignment passes Collections.emptyMap() to VariableDeclaration. Initializer traversal subsequently registers lambda parameters in that map using put().

Pass a fresh LinkedHashMap instead, matching the existing field-initializer handling in JavaFileProcessor. This confines the change to the attribute-assignment call site and does not change constructor sharing semantics or introduce a map shared between attributes. The separate Collections.emptyMap() in processVariableDeclarations is unchanged.

## Regression test

Add TestPythonAttributeLambda.testDictionaryAttributeContainingLambda. The top-level anchor function ensures that the module attribute is included in the model. In addition to successful parsing, the test checks that the mapping attribute, its lambda, the parameter named x, and the lambda expression are present. Thus, silently omitting the attribute cannot make the test pass.

## Validation

Tested against upstream master ec07cc1921f7d89866fde0c7a7259fd22821245e by building the upstream project:

- Test only, before the fix: 1 test failed with the AbstractMap.put / LambdaExpressionObject:104 exception above.
- With the call-site fix: 1 test passed, 0 failures, 0 errors, 0 skipped.
- git diff --check passed.

Local environment: macOS ARM64, Gradle Wrapper 8.14.2 running on Zulu JDK 21.0.8, with compilation and test execution forked to Zulu JDK 25.0.0.

The following is the external init script used for validation, with machine-specific paths replaced. Save it outside the checkout as `java_toolchains.gradle` and replace the JDK 25 paths with your installed JDK location:

```groovy
gradle.projectsEvaluated {
    allprojects {
        tasks.withType(JavaCompile).configureEach {
            options.fork = true
            options.forkOptions.executable = '/absolute/path/to/jdk-25/bin/javac'
            options.forkOptions.memoryMaximumSize = '2g'
        }
        tasks.withType(Test).configureEach {
            executable = '/absolute/path/to/jdk-25/bin/java'
            maxParallelForks = 1
        }
    }
}
```

Run the targeted test from the checkout, replacing the JDK 21 and init-script paths:

```sh
JAVA_HOME=/absolute/path/to/jdk-21 ./gradlew test \
  --tests org.refactoringminer.test.TestPythonAttributeLambda \
  -Pnotoken \
  --no-daemon \
  --max-workers=2 \
  -I /absolute/path/to/java_toolchains.gradle \
  -Dorg.gradle.jvmargs=-Xmx2g
```

This keeps Gradle itself on JDK 21 while compilation and tests use JDK 25, and limits test forks to one. No build configuration or dependency changes are included in this PR.

The full upstream test suite was not run.