### PR TITLE
feat: toward deterministic narrative

### DIFF
--- a/src/main/java/org/refactoringminer/astDiff/graph/Context.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/Context.java
@@ -16,6 +16,9 @@ public class Context {
       return List.of(constants.CLASS_INSTANCE_CREATION, constants.METHOD_INVOCATION,
           constants.METHOD_INVOCATION_RECEIVER, constants.EXPRESSION_STATEMENT);
     }
+    if (treeType.equals(constants.RETURN_STATEMENT)) {
+      return List.of(constants.METHOD_DECLARATION);
+    }
     if (treeType.equals(constants.SIMPLE_NAME)) {
       return List.of(constants.VARIABLE_DECLARATION_STATEMENT, constants.METHOD_INVOCATION,
           constants.CLASS_INSTANCE_CREATION, constants.EXPRESSION_STATEMENT, constants.IF_STATEMENT,
@@ -49,19 +52,19 @@ public class Context {
       return List.of(constants.CONSTRUCTOR_INVOCATION,
           constants.VARIABLE_DECLARATION_STATEMENT, constants.METHOD_INVOCATION,
           constants.CLASS_INSTANCE_CREATION, constants.ENUM_CONSTANT_DECLARATION,
-          constants.IF_STATEMENT, constants.RETURN_STATEMENT);
+          constants.IF_STATEMENT, constants.RETURN_STATEMENT, constants.FIELD_DECLARATION);
     }
     if (treeType.equals(constants.NUMBER_LITERAL)) {
       return List.of(constants.CONSTRUCTOR_INVOCATION,
           constants.VARIABLE_DECLARATION_STATEMENT, constants.METHOD_INVOCATION,
           constants.CLASS_INSTANCE_CREATION, constants.ENUM_CONSTANT_DECLARATION,
-          constants.IF_STATEMENT, constants.RETURN_STATEMENT);
+          constants.IF_STATEMENT, constants.RETURN_STATEMENT, constants.FIELD_DECLARATION);
     }
     if (treeType.equals(constants.STRING_LITERAL)) {
       return List.of(constants.CONSTRUCTOR_INVOCATION,
           constants.VARIABLE_DECLARATION_STATEMENT, constants.METHOD_INVOCATION,
           constants.CLASS_INSTANCE_CREATION, constants.ENUM_CONSTANT_DECLARATION,
-          constants.IF_STATEMENT, constants.RETURN_STATEMENT);
+          constants.IF_STATEMENT, constants.RETURN_STATEMENT, constants.FIELD_DECLARATION);
     }
     if (treeType.equals(constants.METHOD_INVOCATION)) {
       return List.of(constants.IF_STATEMENT, constants.METHOD_INVOCATION,

--- a/src/main/java/org/refactoringminer/astDiff/graph/HunkNetwork.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/HunkNetwork.java
@@ -33,7 +33,6 @@ public class HunkNetwork {
 
   private final Graph<Node, Edge> graph;
   private final Map<String, Node> idNodeMap = new HashMap<>();
-  private final Map<String, Node> promptIdNodeMap = new HashMap<>();
   private final UMLModelDiff modelDiff;
   private final UMLsGenerator umlsGenerator;
   private final Map<String, String> srcContents;
@@ -81,21 +80,17 @@ public class HunkNetwork {
 
     srcTrees.addAll(getValidTrees(srcPath, classifier.getMovedSrcs()).stream()
             .map(tree -> new ImportTree(tree, NodeType.SRC_MOVE, diff, srcPath, SrcDst.SRC)).toList());
-    if (srcPath.equals(dstPath)) {
-      srcTrees.addAll(getValidTrees(srcPath, classifier.getDeletedSrcs()).stream()
-          .map(tree -> new ImportTree(tree, NodeType.DELETION, diff, srcPath, SrcDst.SRC)).toList());
-      srcTrees.addAll(getValidTrees(srcPath, classifier.getUpdatedSrcs()).stream()
-          .map(tree -> new ImportTree(tree, NodeType.SRC_UPDATE, diff, srcPath, SrcDst.SRC)).toList());
-    }
+    srcTrees.addAll(getValidTrees(srcPath, classifier.getDeletedSrcs()).stream()
+            .map(tree -> new ImportTree(tree, NodeType.DELETION, diff, srcPath, SrcDst.SRC)).toList());
+    srcTrees.addAll(getValidTrees(srcPath, classifier.getUpdatedSrcs()).stream()
+            .map(tree -> new ImportTree(tree, NodeType.SRC_UPDATE, diff, srcPath, SrcDst.SRC)).toList());
 
     dstTrees.addAll(getValidTrees(dstPath, classifier.getMovedDsts()).stream()
             .map(tree -> new ImportTree(tree, NodeType.DST_MOVE, diff, dstPath, SrcDst.DST)).toList());
-    if (srcPath.equals(dstPath)) {
-      dstTrees.addAll(getValidTrees(dstPath, classifier.getInsertedDsts()).stream()
-          .map(tree -> new ImportTree(tree, NodeType.ADDITION, diff, dstPath, SrcDst.DST)).toList());
-      dstTrees.addAll(getValidTrees(dstPath, classifier.getUpdatedDsts()).stream()
-          .map(tree -> new ImportTree(tree, NodeType.DST_UPDATE, diff, dstPath, SrcDst.DST)).toList());
-    }
+    dstTrees.addAll(getValidTrees(dstPath, classifier.getInsertedDsts()).stream()
+            .map(tree -> new ImportTree(tree, NodeType.ADDITION, diff, dstPath, SrcDst.DST)).toList());
+    dstTrees.addAll(getValidTrees(dstPath, classifier.getUpdatedDsts()).stream()
+            .map(tree -> new ImportTree(tree, NodeType.DST_UPDATE, diff, dstPath, SrcDst.DST)).toList());
   }
 
   private Set<Tree> getValidTrees(String path, Collection<Tree> trees) {
@@ -155,12 +150,12 @@ public class HunkNetwork {
       Set<ImportTree> subs = entry.getValue();
       String fileContent = getFileContent(parent.srcDst, parent.path);
       Set<Node> subsNode = subs.stream().map(sub -> {
-        Node subNode = new Node(fileContent, sub.path, parent.srcDst, sub.tree, null, sub.type, null);
+        Node subNode = new Node(fileContent, sub.path, parent.srcDst, sub.tree, null, sub.type);
         subNode.addDiff(sub.diff);
         return subNode;
       }).collect(Collectors.toSet());
 
-      Node parentNode = new Node(fileContent, parent.path, parent.srcDst, parent.tree, subsNode, parent.type, promptIdNodeMap);
+      Node parentNode = new Node(fileContent, parent.path, parent.srcDst, parent.tree, subsNode, parent.type);
       parentNode.addDiff(parent.diff);
 
       return parentNode;
@@ -174,7 +169,7 @@ public class HunkNetwork {
             .filter(e -> e.getValue().getRoot().equals(extensionRoot)).findFirst().get().getKey();
 
     Node node = new Node(getFileContent(extendedNode.getSrcDst(), path), path, extendedNode.getSrcDst(),
-            extensionTree, null, NodeType.EXTENSION, promptIdNodeMap);
+            extensionTree, null, NodeType.EXTENSION);
     node.addDiffs(extendedNode.getDiffs());
     return addNode(node);
   }
@@ -200,7 +195,6 @@ public class HunkNetwork {
 
     graph.addVertex(node);
     idNodeMap.put(node.getId(), node);
-    promptIdNodeMap.put(node.getPromptId(), node);
     node.setUMLs(umlsGenerator.getUMLs(node.getTree(), node.getSrcDst(), node.getPath(), false));
 
     addNodeContexts(node);
@@ -217,10 +211,9 @@ public class HunkNetwork {
       String potentialContextId = Node.formatId(path, srcDst, context.second, context.first);
 
       if (!idNodeMap.containsKey(potentialContextId)) {
-        Node contextNode = new Node(node.getFileContent(), path, srcDst, context.first, null, context.second, promptIdNodeMap);
+        Node contextNode = new Node(node.getFileContent(), path, srcDst, context.first, null, context.second);
         graph.addVertex(contextNode);
         idNodeMap.put(contextNode.getId(), contextNode);
-        promptIdNodeMap.put(contextNode.getPromptId(), contextNode);
       }
 
       Node contextNode = idNodeMap.get(potentialContextId);
@@ -284,6 +277,29 @@ public class HunkNetwork {
     processExtensions(SrcDst.DST);
     processMapping();
     processSuccession();
+
+    assignPromptIds();
+  }
+
+  private void assignPromptIds() {
+    for (int length = Node.PROMPT_ID_LENGTH; length <= Node.MAX_PROMPT_ID_LENGTH; length++) {
+      Set<String> promptIds = new HashSet<>();
+      boolean collision = false;
+
+      for (Node node : graph.vertexSet()) {
+        node.assignPromptId(length);
+        if (!promptIds.add(node.getPromptId())) {
+          collision = true;
+          break;
+        }
+      }
+
+      if (!collision) {
+        return;
+      }
+    }
+
+    throw new IllegalStateException("Failed to assign unique prompt ids");
   }
 
   private void processMapping() {

--- a/src/main/java/org/refactoringminer/astDiff/graph/Node.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/Node.java
@@ -8,7 +8,11 @@ import com.github.gumtreediff.tree.Tree;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.refactoringminer.astDiff.graph.cluster.traverse.Util;
 import org.jgrapht.Graph;
@@ -18,11 +22,19 @@ import org.refactoringminer.astDiff.utils.TreeUtilFunctions;
 
 public class Node {
 
-  private static final java.util.Random RANDOM = new java.util.Random();
-  private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  public static final Comparator<Node> COMPARATOR = Comparator.comparing(Node::getSrcDst)
+      .thenComparing(Node::getPath)
+      .thenComparingInt(node -> node.getTree().getPos());
+
+  private static final String ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+  static final int PROMPT_ID_LENGTH = 5;
+  static final int MAX_PROMPT_ID_LENGTH = 12;
+  private static final String PROMPT_ID_PREFIX = "#";
+  public static final Pattern PROMPT_ID_PATTERN = Pattern.compile(
+      PROMPT_ID_PREFIX + "[0-9A-HJKMNP-TV-Z]{" + PROMPT_ID_LENGTH + ",}(?![0-9A-Z])");
 
   private final String id;
-  private final String promptId;
+  private String promptId;
   private final String path;
   private final Constants constants;
   private final SrcDst srcDst;
@@ -37,7 +49,7 @@ public class Node {
   private UMLs umls = null;
 
   public Node(String fileContent, String path, SrcDst srcDst, Tree tree,
-      @Nullable Set<Node> subs, NodeType nodeType, @Nullable Map<String, Node> promptIdNodeMap) {
+      @Nullable Set<Node> subs, NodeType nodeType) {
     this.id = formatId(path, srcDst, nodeType, tree);
     this.fileContent = fileContent;
     this.path = path;
@@ -46,12 +58,7 @@ public class Node {
     this.tree = tree;
     this.subs = subs;
     this.nodeType = nodeType;
-
-    String promptId = generateShortId();
-    while (promptIdNodeMap != null && promptIdNodeMap.containsKey(promptId)) {
-      promptId = generateShortId();
-    }
-    this.promptId = promptId;
+    this.promptId = PROMPT_ID_PREFIX + shortId(this.id, PROMPT_ID_LENGTH);
   }
 
   public static String formatId(String path, SrcDst srcDst, NodeType nodeType, Tree tree) {
@@ -59,10 +66,32 @@ public class Node {
         tree.getEndPos(), tree.getType().name);
   }
 
-  private String generateShortId() {
-    StringBuilder sb = new StringBuilder(4);
-    for (int i = 0; i < 4; i++) {
-      sb.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+  void assignPromptId(int length) {
+    this.promptId = PROMPT_ID_PREFIX + shortId(this.id, length);
+  }
+
+  static String shortId(String formatId, int length) {
+    if (length < 1 || length > MAX_PROMPT_ID_LENGTH) {
+      throw new IllegalArgumentException("Unsupported prompt id length: " + length);
+    }
+
+    byte[] digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256")
+          .digest(formatId.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is not available", e);
+    }
+
+    long value = 0;
+    for (int i = 0; i < 8; i++) {
+      value = (value << 8) | (digest[i] & 0xFFL);
+    }
+
+    StringBuilder sb = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      sb.append(ALPHABET.charAt((int) (value & 31)));
+      value >>>= 5;
     }
     return sb.toString();
   }
@@ -142,8 +171,8 @@ public class Node {
   }
 
   public boolean isBase() {
-    return nodeType.equals(DELETION) || nodeType.equals(NodeType.SRC_MOVE)
-        || nodeType.equals(ADDITION) || nodeType.equals(NodeType.DST_MOVE);
+    return nodeType.equals(DELETION) || nodeType.equals(NodeType.SRC_MOVE) || nodeType.equals(NodeType.SRC_UPDATE)
+        || nodeType.equals(ADDITION) || nodeType.equals(NodeType.DST_MOVE) || nodeType.equals(NodeType.DST_UPDATE);
   }
 
   public boolean isContext() {
@@ -304,7 +333,8 @@ public class Node {
   }
 
   public String baseXml(Graph<Node, Edge> graph) {
-    String xmlPrompt = "<" + this.getPromptType(graph) + " id=\"" + getPromptId() + "\"";
+    String promptType = this.getPromptType(graph);
+    String xmlPrompt = "<" + promptType + " id=\"" + getPromptId() + "\"";
 
     String contextString = getContextString(graph);
     if (!contextString.isEmpty()) {
@@ -313,7 +343,7 @@ public class Node {
 
     xmlPrompt += ">\n    ";
     xmlPrompt += this.normalizeContent().replace("\n", "\n    ");
-    xmlPrompt += "\n</" + this.getPromptType(graph) + ">";
+    xmlPrompt += "\n</" + promptType + ">";
 
     return xmlPrompt;
   }
@@ -324,12 +354,17 @@ public class Node {
     List<Node> alts = new ArrayList<>();
     alts.addAll(this.getMappingSources(graph));
     alts.addAll(this.getMappingTargets(graph));
-    Node alt = alts.isEmpty() ? null : alts.get(0);
-
-    if (alt == null) {
+    if (alts.isEmpty()) {
       return operations;
     }
 
+    if (!isOneToOneMapping(graph)) {
+      operations.add("move");
+      operations.add("change");
+      return operations;
+    }
+
+    Node alt = alts.get(0);
     String thisContextString = this.getContextString(graph);
     String altContextString = alt.getContextString(graph);
     if (!thisContextString.equals(altContextString)) {
@@ -347,6 +382,30 @@ public class Node {
     }
 
     return operations;
+  }
+
+  private boolean isOneToOneMapping(Graph<Node, Edge> graph) {
+    Set<Node> component = new HashSet<>();
+    Deque<Node> queue = new ArrayDeque<>();
+    component.add(this);
+    queue.add(this);
+
+    while (!queue.isEmpty()) {
+      Node current = queue.poll();
+      for (Node source : current.getMappingSources(graph)) {
+        if (component.add(source)) {
+          queue.add(source);
+        }
+      }
+      for (Node target : current.getMappingTargets(graph)) {
+        if (component.add(target)) {
+          queue.add(target);
+        }
+      }
+    }
+
+    return component.stream().filter(Node::isSrc).count() == 1
+        && component.stream().filter(Node::isDst).count() == 1;
   }
 
   private String getPromptType(Graph<Node, Edge> graph) {

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/Narrator.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/Narrator.java
@@ -172,101 +172,49 @@ public class Narrator {
         int n = subs.size();
         if (n <= 1) return subs;
 
-        Map<TraversalPattern, Integer> dependencies = new HashMap<>();
-        Map<TraversalPattern, List<TraversalPattern>> dependedBy = new HashMap<>();
+        Map<TraversalPattern, List<TraversalPattern>> dependents = new HashMap<>();
+        Map<TraversalPattern, Integer> inDegree = new HashMap<>();
         for (TraversalPattern s : subs) {
-            dependencies.put(s, 0);
-            dependedBy.put(s, new ArrayList<>());
+            dependents.put(s, new ArrayList<>());
+            inDegree.put(s, 0);
         }
         for (TraversalPattern a : subs) {
             for (TraversalPattern b : subs) {
                 if (a == b) continue;
-                boolean aDependsOnB = a.dependsOn(b);
-                boolean bDependsOnA = b.dependsOn(a);
-                if (aDependsOnB && !bDependsOnA) {
-                    dependedBy.get(b).add(a);
-                    dependencies.put(a, dependencies.get(a) + 1);
+                if (a.dependsOn(b) && !b.dependsOn(a)) {
+                    dependents.get(b).add(a);
+                    inDegree.merge(a, 1, Integer::sum);
                 }
             }
         }
 
-        List<TraversalPattern> ready = new ArrayList<>();
+        // longest-path level; cycles are broken upstream by TraversalEngine
+        Map<TraversalPattern, Integer> level = new HashMap<>();
+        Deque<TraversalPattern> queue = new ArrayDeque<>();
         for (TraversalPattern s : subs) {
-            if (dependencies.get(s) == 0) {
-                ready.add(s);
+            if (inDegree.get(s) == 0) {
+                level.put(s, 0);
+                queue.add(s);
             }
         }
-        List<TraversalPattern> result = new ArrayList<>();
-        TraversalPattern last = null;
-        while (!ready.isEmpty()) {
-            TraversalPattern next = pickNext(last, ready);
-            ready.remove(next);
-            result.add(next);
-            last = next;
-
-            for (TraversalPattern dependent : dependedBy.get(next)) {
-                int updated = dependencies.get(dependent) - 1;
-                dependencies.put(dependent, updated);
-                if (updated == 0) {
-                    ready.add(dependent);
-                }
+        while (!queue.isEmpty()) {
+            TraversalPattern cur = queue.poll();
+            for (TraversalPattern nxt : dependents.get(cur)) {
+                level.merge(nxt, level.get(cur) + 1, Math::max);
+                if (inDegree.merge(nxt, -1, Integer::sum) == 0) queue.add(nxt);
             }
         }
 
-        if (result.size() < n) {
-            for (TraversalPattern s : subs) {
-                if (!result.contains(s)) {
-                    result.add(s);
-                }
-            }
+        List<TraversalPattern> unleveled = subs.stream().filter(s -> !level.containsKey(s)).toList();
+        if (!unleveled.isEmpty()) {
+            throw new IllegalStateException("Dependency cycle among siblings, unbroken by TraversalEngine: "
+                    + String.join(", ", unleveled.stream().map(TraversalPattern::getId).toList()));
         }
 
-        return result;
-    }
-
-    private static TraversalPattern pickNext(TraversalPattern last, List<TraversalPattern> ready) {
-        TraversalPattern best = null;
-        int bestCommon = -1;
-
-        for (TraversalPattern candidate : ready) {
-            int common = last == null ? 0 : last.commonNodes(candidate).size();
-
-            if (best == null
-                    || common > bestCommon
-                    || (common == bestCommon && compareByDepthAndPosition(candidate, best) < 0)) {
-                best = candidate;
-                bestCommon = common;
-            }
-        }
-
-        return best;
-    }
-
-    private static int compareByDepthAndPosition(TraversalPattern s1, TraversalPattern s2) {
-        int d1 = s1.getDepth();
-        int d2 = s2.getDepth();
-        if (d1 != d2) {
-            return Integer.compare(d2, d1);
-        }
-
-        List<Node> mains1 = s1.getMains();
-        List<Node> mains2 = s2.getMains();
-
-        int points1 = 0;
-        int points2 = 0;
-
-        for (Node m1 : mains1) {
-            for (Node m2 : mains2) {
-                if (m1.getSrcDst().equals(m2.getSrcDst()) && m1.getPath().equals(m2.getPath())) {
-                    if (m1.getTree().getPos() < m2.getTree().getPos()) {
-                        points1++;
-                    } else if (m2.getTree().getPos() < m1.getTree().getPos()) {
-                        points2++;
-                    }
-                }
-            }
-        }
-        return Integer.compare(points2, points1);
+        return subs.stream().sorted(
+                Comparator.comparingInt((TraversalPattern p) -> level.get(p))
+                        .thenComparing(TraversalPattern::sortKey)
+        ).toList();
     }
 
     public List<ChapterUnit> getFlatChapters(GrainLevel level) {

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/SuccessivePattern.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/SuccessivePattern.java
@@ -77,9 +77,9 @@ public class SuccessivePattern extends TraversalPattern implements Leaf {
         }
 
         List<String> mappingHunks = new ArrayList<>();
-        List<TraversalPattern.MappingGroup> aggregated = aggregateByMapping(sequence).stream()
+        List<TraversalPattern.MergeGroup> aggregated = aggregateByMapping(sequence).stream()
                 .filter(mg -> !mg.sources().isEmpty() && !mg.targets().isEmpty()).toList();
-        for (TraversalPattern.MappingGroup mg : aggregated) {
+        for (TraversalPattern.MergeGroup mg : aggregated) {
             List<Node> sources = mg.sources();
             List<Node> targets = mg.targets();
 

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/TraversalEngine.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/TraversalEngine.java
@@ -3,6 +3,7 @@ package org.refactoringminer.astDiff.graph.cluster.traverse;
 import com.github.gumtreediff.utils.Pair;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -508,13 +509,15 @@ public class TraversalEngine {
     private void mergeByUsageChain() {
         Map<UsagePattern, Set<TraversalPattern>> usageRequirements = new HashMap<>();
         for (UsagePattern usagePattern : usagePatterns) {
-            usageRequirements.put(usagePattern,
-                    new HashSet<>(usagePattern.getRequirements().values()));
+            usageRequirements.put(usagePattern, new HashSet<>(usagePattern.getRequirements().values()));
         }
 
         while (!usageRequirements.isEmpty()) {
             Optional<UsagePattern> requirementLeaf = usageRequirements.entrySet().stream()
-                    .filter(entry -> entry.getValue().isEmpty()).map(Entry::getKey).findFirst();
+                    .filter(entry -> entry.getValue().isEmpty()).map(Entry::getKey)
+                    .min(Comparator.comparing((UsagePattern usage) -> usage.useNode.getPath())
+                            .thenComparingInt(usage -> usage.useNode.getTree().getPos())
+                            .thenComparing(usage -> usage.useNode.getId()));
             if (requirementLeaf.isEmpty()) {
                 break;
             }

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/TraversalPattern.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/TraversalPattern.java
@@ -9,77 +9,22 @@ import org.refactoringminer.astDiff.graph.NodeType;
 import org.refactoringminer.astDiff.graph.cluster.GraphWrapper;
 import org.jgrapht.Graph;
 
+import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class TraversalPattern extends GraphWrapper {
     protected Graph<Node, Edge> clusterGraph;
     protected final Util util = new Util(getGraph());
     protected final Set<String> identifiers = new HashSet<>();
     private final Narrator narrator = new Narrator(this);
-    private final Map<TraversalPattern, Boolean> dependsOnCache = new HashMap<>();
-    private final Map<TraversalPattern, Set<Node>> commonNodesCache = new HashMap<>();
     protected Node cachedLead = null;
     protected NodeType nodeType;
     private List<TraversalPattern> cachedFlatten = null;
+    private SortKey cachedSortKey;
 
     public void setClusterGraph(Graph<Node, Edge> clusterGraph) {
         this.clusterGraph = clusterGraph;
-    }
-
-    public List<MappingGroup> aggregateByMapping(Collection<Node> nodes) {
-        Set<Node> allowedNodes = new HashSet<>(nodes);
-        for (Node node : nodes) {
-            allowedNodes.addAll(node.getMappingSources(clusterGraph));
-            allowedNodes.addAll(node.getMappingTargets(clusterGraph));
-        }
-
-        List<MappingGroup> result = new ArrayList<>();
-
-        Set<Node> visited = new HashSet<>();
-        for (Node node : nodes) {
-            if (visited.contains(node)) continue;
-
-            Set<Node> component = new HashSet<>();
-            Queue<Node> queue = new LinkedList<>();
-            queue.add(node);
-            visited.add(node);
-
-            while (!queue.isEmpty()) {
-                Node curr = queue.poll();
-                component.add(curr);
-
-                for (Node src : curr.getMappingSources(clusterGraph)) {
-                    if (!visited.contains(src)) {
-                        visited.add(src);
-                        queue.add(src);
-                    }
-                }
-                for (Node dst : curr.getMappingTargets(clusterGraph)) {
-                    if (!visited.contains(dst)) {
-                        visited.add(dst);
-                        queue.add(dst);
-                    }
-                }
-            }
-
-            List<Node> srcNodes = new ArrayList<>();
-            List<Node> dstNodes = new ArrayList<>();
-            for (Node n : component) {
-                if (!allowedNodes.contains(n)) continue;
-                if (n.isSrc()) srcNodes.add(n);
-                else dstNodes.add(n);
-            }
-
-            // TODO: Sort by Dependency
-            Comparator<Node> nodeComparator = Comparator.comparing(Node::getPath)
-                    .thenComparingInt(n -> n.getTree().getPos());
-            srcNodes.sort(nodeComparator);
-            dstNodes.sort(nodeComparator);
-
-            result.add(new MappingGroup(srcNodes, dstNodes));
-        }
-
-        return result;
     }
 
     public Narrator getNarrator() {
@@ -93,51 +38,34 @@ public class TraversalPattern extends GraphWrapper {
     public List<NarrativeElement> getElements(List<TraversalPattern> filterPatterns) {
         List<Node> aggMains = getMains();
 
-        List<MappingGroup> mappingGroups = aggregateByMapping(aggMains);
+        List<MergeGroup> allGroups = new ArrayList<>();
 
-        // Merge Groups by Context
-        Map<MappingGroup, Set<Node>> mappingGroupContexts = new HashMap<>();
-        for (MappingGroup mg : mappingGroups) {
-            Set<Node> contexts = new HashSet<>();
-            for (Node target : mg.targets()) {
-                List<Node> semanticContexts = target.getSemanticContexts(clusterGraph);
-                if (!semanticContexts.isEmpty()) {
-                    Node semanticContext = semanticContexts.get(0);
-                    contexts.add(semanticContext);
-                    contexts.addAll(semanticContext.getMappingSources(clusterGraph));
-                }
-            }
-            for (Node source : mg.sources()) {
-                List<Node> semanticContexts = source.getSemanticContexts(clusterGraph);
-                if (!semanticContexts.isEmpty()) {
-                    Node semanticContext = semanticContexts.get(0);
-                    contexts.add(semanticContext);
-                    contexts.addAll(semanticContext.getMappingTargets(clusterGraph));
-                }
-            }
-            mappingGroupContexts.put(mg, filterLargest(contexts));
-        }
-        List<MergedGroup> mergedGroups = new ArrayList<>();
-        for (Map.Entry<MappingGroup, Set<Node>> entry : mappingGroupContexts.entrySet()) {
-            MappingGroup mg = entry.getKey();
-            Set<Node> context = entry.getValue();
-            boolean merged = false;
-            for (MergedGroup mergedGroup : mergedGroups) {
-                if (isCompatible(context, mergedGroup.context)) {
-                    mergedGroup.groups.add(mg);
-                    Set<Node> union = new HashSet<>(mergedGroup.context);
-                    union.addAll(context);
-                    mergedGroup.context = filterLargest(union);
-                    merged = true;
-                    break;
-                }
-            }
-            if (!merged) {
-                MergedGroup newGroup = new MergedGroup(context);
-                newGroup.groups.add(mg);
-                mergedGroups.add(newGroup);
+        List<MergeGroup> mappingGroups = aggregateByMapping(aggMains);
+        List<MergeGroup> contextMappingGroups = aggregateByContextMapping(aggMains);
+
+        for (MergeGroup mappingGroup : mappingGroups) {
+            boolean covered = contextMappingGroups.stream().anyMatch(contextGroup ->
+                    contextGroup.nodes().size() > mappingGroup.nodes().size()
+                            && contextGroup.nodes().containsAll(mappingGroup.nodes()));
+            if (!covered) {
+                allGroups.add(mappingGroup);
             }
         }
+        for (MergeGroup contextGroup : contextMappingGroups) {
+            boolean covered = mappingGroups.stream().anyMatch(mappingGroup ->
+                    mappingGroup.nodes().containsAll(contextGroup.nodes()));
+            if (!covered) {
+                allGroups.add(contextGroup);
+            }
+        }
+
+        // Nodes without any semantic context (e.g. method declaration and above)
+        List<Node> remainingNodes = aggMains.stream().filter(main -> allGroups.stream().noneMatch(mg -> mg.nodes().contains(main))).toList();
+        List<MergeGroup> remainingGroups = remainingNodes.stream().map(rm -> new MergeGroup(Set.of(rm), MergeType.REMAINING)).toList();
+        allGroups.addAll(remainingGroups);
+
+        allGroups.sort(Comparator.comparing(MergeGroup::mergeType)
+                .thenComparing(mg -> MergeGroup.sortNodes(mg.nodes()).get(0), Node.COMPARATOR));
 
         List<TraversalPattern> leaves = this.getNarrator().getNarrative(GrainLevel.LEAF);
 
@@ -147,7 +75,7 @@ public class TraversalPattern extends GraphWrapper {
                 allMains.addAll(fp.getMains());
             }
         }
-        Map<Node, Set<Node>> sideToMains = new HashMap<>();
+        Map<Node, Set<Node>> printingSidesToMains = new HashMap<>();
         for (TraversalPattern leaf : leaves) {
             List<Node> leafMains = leaf.getMains();
             List<Node> leafSides = leaf.getSides();
@@ -156,7 +84,8 @@ public class TraversalPattern extends GraphWrapper {
                     continue;
                 }
 
-                Set<Node> relyingMains = sideToMains.computeIfAbsent(side, k -> new HashSet<>());
+                printingSidesToMains.putIfAbsent(side, new HashSet<>());
+                Set<Node> relyingMains = printingSidesToMains.get(side);
                 for (Node m : leafMains) {
                     if (allMains.contains(m)) {
                         relyingMains.add(m);
@@ -165,32 +94,47 @@ public class TraversalPattern extends GraphWrapper {
             }
         }
 
-        Map<Node, MergedGroup> mainToGroup = new HashMap<>();
-        for (MergedGroup mg : mergedGroups) {
-            for (Node n : mg.nodes()) mainToGroup.put(n, mg);
+        Map<Node, Set<MergeGroup>> mainToGroup = new HashMap<>();
+        for (MergeGroup mg : allGroups) {
+            for (Node n : mg.nodes()) {
+                mainToGroup.putIfAbsent(n, new HashSet<>());
+                mainToGroup.get(n).add(mg);
+            };
         }
-        Set<Node> globalSides = new HashSet<>();
-        Map<MergedGroup, List<Node>> localSidesMap = new HashMap<>();
-        for (Map.Entry<Node, Set<Node>> entry : sideToMains.entrySet()) {
-            Node side = entry.getKey();
+        Set<Node> globalPrintingSides = new HashSet<>();
+        Map<MergeGroup, List<Node>> localPrintingSidesMap = new HashMap<>();
+        for (Map.Entry<Node, Set<Node>> entry : printingSidesToMains.entrySet()) {
+            Node printingSide = entry.getKey();
             Set<Node> mains = entry.getValue();
-            Set<MergedGroup> chapters = new HashSet<>();
+            Set<MergeGroup> groups = new HashSet<>();
             for (Node m : mains) {
-                MergedGroup mg = mainToGroup.get(m);
-                if (mg != null) chapters.add(mg);
+                Set<MergeGroup> mgs = mainToGroup.get(m);
+                if (mgs != null) {
+                    groups.addAll(mgs);
+                }
             }
 
-            if (chapters.size() > 1) {
-                globalSides.add(side);
-            } else if (chapters.size() == 1) {
-                MergedGroup mg = chapters.iterator().next();
-                localSidesMap.computeIfAbsent(mg, k -> new ArrayList<>()).add(side);
+            if (groups.size() > 1) {
+                globalPrintingSides.add(printingSide);
+            } else if (groups.size() == 1) {
+                MergeGroup mg = groups.iterator().next();
+                localPrintingSidesMap.putIfAbsent(mg, new ArrayList<>());
+                localPrintingSidesMap.get(mg).add(printingSide);
             }
         }
+        localPrintingSidesMap.replaceAll((mg, sides) -> {
+            Map<Node, Integer> changeIndex = changeIndex(mg);
+            Comparator<Node> byEarliestUsingChange = Comparator.comparingInt(side ->
+                    printingSidesToMains.get(side).stream()
+                            .mapToInt(main -> changeIndex.getOrDefault(main, Integer.MAX_VALUE))
+                            .min().orElse(Integer.MAX_VALUE));
+            return sides.stream()
+                    .sorted(byEarliestUsingChange.thenComparing(Node.COMPARATOR))
+                    .toList();
+        });
 
-        // TODO: Sort Must be Done By Dependency, Not Latest Index
-        Map<MergedGroup, Integer> groupLatestIndex = new HashMap<>();
-        for (MergedGroup mg : mergedGroups) {
+        Map<MergeGroup, Integer> groupLatestIndex = new HashMap<>();
+        for (MergeGroup mg : allGroups) {
             int maxIdx = -1;
 
             for (Node n : mg.nodes()) {
@@ -208,19 +152,19 @@ public class TraversalPattern extends GraphWrapper {
         // Produce Elements
         List<NarrativeElement> elements = new ArrayList<>();
         Set<Node> outputtedSides = new HashSet<>();
-        Set<MergedGroup> outputtedGroups = new HashSet<>();
+        Set<MergeGroup> outputtedGroups = new HashSet<>();
         for (int i = 0; i < leaves.size(); i++) {
             TraversalPattern leaf = leaves.get(i);
             for (Node s : leaf.getSides()) {
-                if (globalSides.contains(s) && !outputtedSides.contains(s)) {
+                if (globalPrintingSides.contains(s) && !outputtedSides.contains(s)) {
                     String content = "<dependency>\n    " + s.baseXml(clusterGraph).replace("\n", "\n    ") + "\n</dependency>";
                     elements.add(new NarrativeElement(content, Set.of(s), clusterGraph));
                     outputtedSides.add(s);
                 }
             }
-            for (MergedGroup mg : mergedGroups) {
+            for (MergeGroup mg : allGroups) {
                 if (groupLatestIndex.get(mg) == i && !outputtedGroups.contains(mg)) {
-                    String content = buildSubChapterXml(mg, leaves, localSidesMap);
+                    String content = buildSubChapterXml(mg, leaves, localPrintingSidesMap.get(mg));
                     Set<Node> mgMains = mg.nodes();
                     elements.add(new NarrativeElement(content, mgMains, clusterGraph));
                     outputtedGroups.add(mg);
@@ -229,6 +173,153 @@ public class TraversalPattern extends GraphWrapper {
         }
 
         return elements;
+    }
+
+    private static Map<Set<Node>, Set<Node>> aggregateByContextMapping(List<Node> nodes, Graph<Node, Edge> graph) {
+        Set<Node> contexts = new HashSet<>();
+        for (Node node : nodes) {
+            List<Node> semanticContexts = node.getSemanticContexts(graph);
+            if (semanticContexts.isEmpty()) {
+                continue;
+            }
+
+            contexts.add(semanticContexts.get(0));
+        }
+
+        Set<Node> parentContexts = new HashSet<>();
+        for (Node subject : contexts) {
+            boolean isParent = true;
+
+            List<Node> subjectAlternatives = subject.isSrc() ? subject.getMappingTargets(graph) : subject.getMappingSources(graph);
+            Node subjectAlternative = subjectAlternatives.isEmpty() ? null : subjectAlternatives.get(0);
+            for (Node object : contexts) {
+                if (subject.equals(object)) {
+                    continue;
+                }
+
+                if (subject.isDescendantOf(object)) {
+                    isParent = false;
+                    break;
+                }
+
+                if (subject.getSrcDst().equals(object.getSrcDst())) {
+                    continue;
+                }
+
+                if (subjectAlternative == null) {
+                    continue;
+                }
+
+                if (subjectAlternative.isDescendantOf(object)) {
+                    isParent = false;
+                    break;
+                }
+            }
+
+            if (isParent) {
+                parentContexts.add(subject);
+            }
+        }
+
+        Map<Set<Node>, Set<Node>> result = new HashMap<>();
+        for (Node parentContext : parentContexts) {
+            Set<Node> descendants = new HashSet<>();
+            for (Node node : nodes) {
+                if (node.isDescendantOf(parentContext)) {
+                    descendants.add(node);
+                }
+            }
+
+            List<Node> alternatives = parentContext.isSrc() ? parentContext.getMappingTargets(graph) : parentContext.getMappingSources(graph);
+            Node alternative = alternatives.isEmpty() ? null : alternatives.get(0);
+            Set<Node> alternativeDescendants = new HashSet<>();
+            if (alternative != null) {
+                for (Node node : nodes) {
+                    if (node.isDescendantOf(alternative)) {
+                        alternativeDescendants.add(node);
+                    }
+                }
+            }
+
+            Set<Node> parents = new HashSet<>();
+            parents.add(parentContext);
+            if (!alternativeDescendants.isEmpty()) {
+                parents.add(alternative);
+            }
+            Set<Node> allDescendants = new HashSet<>();
+            allDescendants.addAll(descendants);
+            allDescendants.addAll(alternativeDescendants);
+
+            result.put(parents, allDescendants);
+        }
+
+        return result;
+    }
+
+    private List<MergeGroup> aggregateByContextMapping(List<Node> nodes) {
+        return aggregateByContextMapping(nodes, clusterGraph).values().stream()
+                .map(aggregatedNodes -> new MergeGroup(aggregatedNodes, MergeType.CONTEXT)).toList();
+    }
+
+    protected static Map<Set<Node>, Set<Node>> aggregateByMapping(List<Node> nodes, Graph<Node, Edge> graph) {
+        Set<Node> allowedNodes = new HashSet<>(nodes);
+        for (Node node : nodes) {
+            allowedNodes.addAll(node.getMappingSources(graph));
+            allowedNodes.addAll(node.getMappingTargets(graph));
+        }
+
+        Map<Set<Node>, Set<Node>> result = new HashMap<>();
+
+        Set<Node> visited = new HashSet<>();
+        for (Node node : nodes) {
+            if (visited.contains(node)) continue;
+
+            Set<Node> component = new HashSet<>();
+            Queue<Node> queue = new LinkedList<>();
+            queue.add(node);
+            visited.add(node);
+
+            while (!queue.isEmpty()) {
+                Node curr = queue.poll();
+                component.add(curr);
+
+                for (Node src : curr.getMappingSources(graph)) {
+                    if (!visited.contains(src)) {
+                        visited.add(src);
+                        queue.add(src);
+                    }
+                }
+                for (Node dst : curr.getMappingTargets(graph)) {
+                    if (!visited.contains(dst)) {
+                        visited.add(dst);
+                        queue.add(dst);
+                    }
+                }
+            }
+
+            Set<Node> srcNodes = new HashSet<>();
+            Set<Node> dstNodes = new HashSet<>();
+            for (Node n : component) {
+                if (!allowedNodes.contains(n)) continue;
+                if (n.isSrc()) srcNodes.add(n);
+                else dstNodes.add(n);
+            }
+
+            if (!srcNodes.isEmpty() && !dstNodes.isEmpty()) {
+                result.put(srcNodes, dstNodes);
+            }
+        }
+
+        return result;
+    }
+
+    protected List<MergeGroup> aggregateByMapping(List<Node> nodes) {
+        return aggregateByMapping(nodes, clusterGraph).entrySet().stream().map(e -> {
+            Set<Node> mergedNodes = new HashSet<>();
+            mergedNodes.addAll(e.getKey());
+            mergedNodes.addAll(e.getValue());
+            return new MergeGroup(mergedNodes, MergeType.MAPPING);
+        }).toList();
     }
 
     public Node getLead() {
@@ -266,13 +357,6 @@ public class TraversalPattern extends GraphWrapper {
         return getGraph().vertexSet();
     }
 
-    public int getDepth() {
-        if (this instanceof AggregatorPattern aggregator) {
-            return aggregator.subs.stream().mapToInt(TraversalPattern::getDepth).max().orElse(0) + 1;
-        }
-        return 0;
-    }
-
     public void addIdentifier(String identifier) {
         this.identifiers.add(identifier);
     }
@@ -290,17 +374,12 @@ public class TraversalPattern extends GraphWrapper {
     }
 
     private boolean dependsOnRecursive(TraversalPattern p, Set<TraversalPattern> visited) {
-        if (dependsOnCache.containsKey(p)) {
-            return dependsOnCache.get(p);
-        }
-
         if (visited.contains(this)) {
             return false;
         }
         visited.add(this);
 
         if (this.flatten().contains(p)) {
-            dependsOnCache.put(p, true);
             return true;
         }
 
@@ -308,14 +387,12 @@ public class TraversalPattern extends GraphWrapper {
             if (tp instanceof UsagePattern usage) {
                 for (TraversalPattern req : usage.subs) {
                     if (req.dependsOnRecursive(p, visited)) {
-                        dependsOnCache.put(p, true);
                         return true;
                     }
                 }
             }
         }
 
-        dependsOnCache.put(p, false);
         return false;
     }
 
@@ -343,52 +420,60 @@ public class TraversalPattern extends GraphWrapper {
         result.add(p);
     }
 
-    public Set<Node> commonNodes(TraversalPattern other) {
-        if (commonNodesCache.containsKey(other)) {
-            return commonNodesCache.get(other);
+    public SortKey sortKey() {
+        if (cachedSortKey == null) {
+            List<Node> mains = flatten().stream()
+                    .filter(fl -> fl instanceof Leaf).map(TraversalPattern::getMains).flatMap(List::stream).toList();
+            cachedSortKey = mains.stream()
+                    .map(n -> new SortKey(n.getPath(), n.getTree().getPos()))
+                    .min(Comparator.naturalOrder())
+                    .orElse(new SortKey("", 0));
         }
-
-        Set<Node> thisNodes = aggregatedLeafNodes(this);
-        Set<Node> otherNodes = aggregatedLeafNodes(other);
-
-        Set<Node> common = new HashSet<>(thisNodes);
-        common.retainAll(otherNodes);
-
-        commonNodesCache.put(other, common);
-        return common;
+        return cachedSortKey;
     }
 
-    private static Set<Node> aggregatedLeafNodes(TraversalPattern pattern) {
-        List<TraversalPattern> leaves = pattern.getNarrator().getNarrative(GrainLevel.LEAF);
+    public record SortKey(String path, int pos) implements Comparable<SortKey> {
+        private static final Comparator<SortKey> COMPARATOR = Comparator.comparing(SortKey::path)
+                .thenComparingInt(SortKey::pos);
 
-        Set<Node> nodes = new HashSet<>();
-        for (TraversalPattern leaf : leaves) {
-            nodes.addAll(leaf.getMains());
-            nodes.addAll(leaf.getSides());
+        @Override
+        public int compareTo(SortKey other) {
+            return COMPARATOR.compare(this, other);
         }
-        return nodes;
     }
 
-    private String buildSubChapterXml(MergedGroup mergedGroup, List<TraversalPattern> leaves, Map<MergedGroup, List<Node>> localSidesMap) {
+    private String buildSubChapterXml(MergeGroup mergeGroup, List<TraversalPattern> leaves, @Nullable List<Node> localSides) {
         StringBuilder sb = new StringBuilder();
         sb.append("<sub_chapter>");
 
-        for (MappingGroup mg : mergedGroup.groups) {
-            sb.append("\n    ").append(buildXmlMappingHunk(mg.sources(), mg.targets()).replace("\n", "\n    "));
-        }
-
-        if (!mergedGroup.context.isEmpty()) {
-            sb.append("\n    <context>");
-            Set<String> contextsText = new HashSet<>();
-            for (Node context : mergedGroup.context) {
-                contextsText.add(context.mappingXml(clusterGraph));
+        switch (mergeGroup.mergeType) {
+            case MAPPING -> {
+                sb.append("\n    ").append(buildXmlMappingHunk(mergeGroup.sources(), mergeGroup.targets()).replace("\n", "\n    "));
+                List<Set<Node>> contexts = orderContexts(mergeGroup);
+                if (!contexts.isEmpty()) {
+                    sb.append("\n    ").append(buildXmlContext(contexts).replace("\n", "\n    "));
+                }
             }
-            sb.append("\n        ").append(String.join("\n        ", contextsText.stream().map(text -> text.replace("\n", "\n        ")).toList()));
-            sb.append("\n    </context>");
+            case CONTEXT -> {
+                List<Set<Node>> contexts = orderContexts(mergeGroup);
+                if (!contexts.isEmpty()) {
+                    sb.append("\n    ").append(buildXmlContext(contexts).replace("\n", "\n    "));
+                }
+                List<Node> sources = mergeGroup.sources();
+                if (!sources.isEmpty()) {
+                    sb.append("\n    ").append(buildXmlMappingHunk(sources, List.of()).replace("\n", "\n    "));
+                }
+                List<Node> targets = mergeGroup.targets();
+                if (!targets.isEmpty()) {
+                    sb.append("\n    ").append(buildXmlMappingHunk(List.of(), targets).replace("\n", "\n    "));
+                }
+            }
+            case REMAINING -> {
+                sb.append("\n    ").append(buildXmlMappingHunk(mergeGroup.sources(), mergeGroup.targets()).replace("\n", "\n    "));
+            }
         }
 
-        List<Node> localSides = localSidesMap.getOrDefault(mergedGroup, List.of());
-        if (!localSides.isEmpty()) {
+        if (localSides != null && !localSides.isEmpty()) {
             sb.append("\n    <dependencies>");
             for (Node side : localSides) {
                 sb.append("\n        ").append(side.baseXml(clusterGraph).replace("\n", "\n        "));
@@ -417,72 +502,67 @@ public class TraversalPattern extends GraphWrapper {
         return xmlOutput.toString();
     }
 
-    private boolean isCompatible(Set<Node> setA, Set<Node> setB) {
-        if (setA.isEmpty() || setB.isEmpty()) return false;
+    private static Map<Node, Integer> changeIndex(MergeGroup mergeGroup) {
+        List<Node> printedChanges = new ArrayList<>(mergeGroup.sources());
+        printedChanges.addAll(mergeGroup.targets());
 
-        boolean aCoveredByB = true;
-        for (Node a : setA) {
-            boolean matched = false;
-            for (Node b : setB) {
-                if (a.equals(b) || a.getSemanticContexts(clusterGraph).contains(b) || b.getSemanticContexts(clusterGraph).contains(a)) {
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched) {
-                aCoveredByB = false;
-                break;
-            }
+        Map<Node, Integer> changeIndex = new HashMap<>();
+        for (int i = 0; i < printedChanges.size(); i++) {
+            changeIndex.put(printedChanges.get(i), i);
         }
-
-        boolean bCoveredByA = true;
-        for (Node b : setB) {
-            boolean matched = false;
-            for (Node a : setA) {
-                if (a.equals(b) || a.getSemanticContexts(clusterGraph).contains(b) || b.getSemanticContexts(clusterGraph).contains(a)) {
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched) {
-                bCoveredByA = false;
-                break;
-            }
-        }
-
-        return aCoveredByB || bCoveredByA;
+        return changeIndex;
     }
 
-    private Set<Node> filterLargest(Set<Node> contexts) {
-        return contexts.stream().filter(ctx -> ctx.getSemanticContexts(clusterGraph).stream()
-                .noneMatch(sc -> sc != ctx && contexts.contains(sc))).collect(java.util.stream.Collectors.toSet());
+    private List<Set<Node>> orderContexts(MergeGroup mergeGroup) {
+        Map<Set<Node>, Set<Node>> contextAggregatedNodes =
+                aggregateByContextMapping(mergeGroup.nodes().stream().toList(), clusterGraph);
+        if (contextAggregatedNodes.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Node, Integer> changeIndex = changeIndex(mergeGroup);
+
+        Comparator<Map.Entry<Set<Node>, Set<Node>>> byEarliestChange =
+                Comparator.comparingInt(entry -> entry.getValue().stream()
+                        .mapToInt(node -> changeIndex.getOrDefault(node, Integer.MAX_VALUE))
+                        .min().orElse(Integer.MAX_VALUE));
+        Comparator<Map.Entry<Set<Node>, Set<Node>>> byContextPosition =
+                Comparator.comparing((Map.Entry<Set<Node>, Set<Node>> entry) -> MergeGroup.sortNodes(entry.getKey()).get(0),
+                        Node.COMPARATOR);
+
+        return contextAggregatedNodes.entrySet().stream()
+                .sorted(byEarliestChange.thenComparing(byContextPosition))
+                .map(Map.Entry::getKey)
+                .toList();
     }
 
-    public record MappingGroup(List<Node> sources, List<Node> targets) {
-        public Set<Node> nodes() {
-            Set<Node> result = new HashSet<>();
-            result.addAll(sources);
-            result.addAll(targets);
+    private String buildXmlContext(Collection<Set<Node>> contextsSets) {
+        return String.join("\n", contextsSets.stream().map(contexts -> {
+            StringBuilder xmlOutput = new StringBuilder();
+            xmlOutput.append("<context>");
+            xmlOutput.append("\n    ").append(contexts.iterator().next().mappingXml(clusterGraph).replace("\n", "\n    "));
+            xmlOutput.append("\n</context>");
+            return xmlOutput.toString();
+        }).toList());
+    }
 
-            return result;
+    protected record MergeGroup(Set<Node> nodes, MergeType mergeType) {
+        public List<Node> sources() {
+            return sortNodes(nodes.stream().filter(Node::isSrc).collect(Collectors.toSet()));
+        }
+
+        public List<Node> targets() {
+            return sortNodes(nodes.stream().filter(Node::isDst).collect(Collectors.toSet()));
+        }
+
+        static List<Node> sortNodes(Set<Node> nodes) {
+            return nodes.stream().sorted(Node.COMPARATOR).toList();
         }
     }
 
-    private static class MergedGroup {
-        Set<Node> context;
-        List<MappingGroup> groups = new ArrayList<>();
-
-        MergedGroup(Set<Node> context) {
-            this.context = context;
-        }
-
-        public Set<Node> nodes() {
-            Set<Node> result = new HashSet<>();
-            for (MappingGroup group : groups) {
-                result.addAll(group.nodes());
-            }
-
-            return result;
-        }
+    protected enum MergeType {
+        MAPPING,
+        CONTEXT,
+        REMAINING
     }
 }

--- a/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/UsagePattern.java
+++ b/src/main/java/org/refactoringminer/astDiff/graph/cluster/traverse/UsagePattern.java
@@ -89,7 +89,7 @@ public class UsagePattern extends AggregatorPattern implements Leaf {
 
     @Override
     public List<Node> getSides() {
-        return getUsedNodes().stream().toList();
+        return getUsedNodes().stream().sorted(Node.COMPARATOR).toList();
     }
 
     @Override


### PR DESCRIPTION
This PR is a solid step toward producing deterministic narratives for commits and PRs;
- promptId is now always the same for the same hunk
- Narrator supports dependency as a hard requirement, it uses locality as a soft sorting criteria instead of unusual graph based criteria. Those criteria can be used for targeted tasks on a hunk.
- All the loose random orders by JVM stored data is replaced by concrete location based orders
These changes address 90% of undeterminism is the narrative output, while it may need addressing edge cases