### PR TITLE
Replace previous raw inlined <script> with < and </ escaped JSON

### DIFF
--- a/src/main/java/gui/webdiff/viewers/monaco/MonacoCore.java
+++ b/src/main/java/gui/webdiff/viewers/monaco/MonacoCore.java
@@ -136,7 +136,7 @@ public class MonacoCore {
             b.append("url:").append("\"/left/" + id + "\"").append(",");
             String escapedContent = "";
             try {
-                escapedContent = mapper.writeValueAsString(srcFileContent);
+                escapedContent = mapper.writeValueAsString(srcFileContent).replace("</", "<\\/");
             } catch (JsonProcessingException e) {
 //                throw new RuntimeException(e);
             }
@@ -198,7 +198,7 @@ public class MonacoCore {
             b.append("url:").append("\"/right/" + id + "\"").append(",");
             String escapedContent = "";
             try {
-                escapedContent = mapper.writeValueAsString(dstFileContent);
+                escapedContent = mapper.writeValueAsString(dstFileContent).replace("</", "<\\/");
             } catch (JsonProcessingException e) {
 //                throw new RuntimeException(e);
             }

--- a/src/main/java/gui/webdiff/viewers/monaco/SingleMonacoContent.java
+++ b/src/main/java/gui/webdiff/viewers/monaco/SingleMonacoContent.java
@@ -1,5 +1,8 @@
 package gui.webdiff.viewers.monaco;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import gui.webdiff.WebDiff;
 import gui.webdiff.dir.PullRequestReviewComment;
 import gui.webdiff.rest.AbstractMenuBar;
@@ -53,20 +56,26 @@ public class SingleMonacoContent implements Renderable {
     @Override
     public void renderOn(HtmlCanvas html) throws IOException {
         String editorId = "monaco-editor-" + Math.abs(path.hashCode());
-        String scriptSourceId = "java-code-source-" + Math.abs(path.hashCode());
         String comments = filterComments(this.comments, path, isAdded ? PullRequestReviewComment.Side.RIGHT : PullRequestReviewComment.Side.LEFT);
+
+        String escapedContent;
+        try {
+            escapedContent = new ObjectMapper().writeValueAsString(this.content).replace("</", "<\\/");
+        } catch (JsonProcessingException e) {
+            escapedContent = "\"\"";
+        }
 
         String monacoHook = """
             (function() {
-                const rawCode = document.getElementById('%s').textContent;
+                const rawCode = %s;
                 loadSingleMonacoEditor({
-                    id: '%s', 
-                    value: rawCode, 
-                    language: 'java', 
-                    comments: %s 
+                    id: '%s',
+                    value: rawCode,
+                    language: 'java',
+                    comments: %s
                 });
             })();
-            """.formatted(scriptSourceId, editorId, comments);
+            """.formatted(escapedContent, editorId, comments);
         html
                 .render(DocType.HTML5)
                 .html(lang("en").class_("h-100"))
@@ -94,9 +103,6 @@ public class SingleMonacoContent implements Renderable {
                 ._div()
                 .div(style("height: 10px; flex-shrink: 0; background:#eee;"))
                 ._div();
-        html.script(id(scriptSourceId).type("text/plain").style("display:none;"))
-                .write(this.content, false) // false prevents escaping HTML entities like < or > inside the content
-                ._script();
         html.script(type("text/javascript"))
                 .write("/*<![CDATA[*/" + monacoHook + "/*]]>*/", false)
                 ._script();


### PR DESCRIPTION
## Problem

Loading a diff where either side's file contains a literal `</script` substring (e.g. `docs/docsgen/source/onnx_sphinx.py` in onnx/onnx, whose docstrings embed `<script>...</script>` snippets) breaks the Monaco viewer with:

Uncaught SyntaxError: "" literal not terminated before end of script
Uncaught SyntaxError: invalid escape sequence

## Root cause

`MonacoCore.getLeftJsConfig()`/`getRightJsConfig()` JSON-encode file content via Jackson before embedding it in the `mymonaco({...})` script. JSON encoding doesn't escape `/`, so `</script` survives verbatim into the page. The browser's HTML tokenizer ends a `<script>` element the moment it sees that literal byte sequence — even mid JS-string — which truncates the script and produces exactly these errors.

I checked this against the history of this code, since I wanted to avoid re-fixing something already covered:

- The two-pane diff view (`MonacoCore.java`) had a cruder bug here before — naive manual escaping (`\\`, `\"`, `\n` only) — fixed in `a97e07d2b` by switching to Jackson's `ObjectMapper.writeValueAsString(...)`. That fix never covered `</script`, since nothing had hit it yet.
- The single add/delete view (`SingleMonacoContent.java`) had a different, more severe bug (#1077): raw content was spliced unescaped into a JS *template literal* (`` value: `${content}` ``), so any file with a backtick or a `${...}`-shaped substring would break interpolation and silently abort the script, leaving a blank editor. #1079 fixed that by moving the raw content into a `<script type="text/plain">` element and reading it back via `.textContent`, avoiding JS string embedding entirely.

Neither historical fix addressed `</script`, and my assessment is that #1079's `text/plain`/`textContent` approach can't cleanly patch it either: HTML's script-raw-text tokenization ends *any* `<script>` element on that literal sequence regardless of its `type` attribute, so it's equally exposed. Patching it there would mean inserting an extra character into a text node with no decode step to undo it, which would either corrupt the displayed source or require a second, ad hoc unescape pass with its own false-positive risk.

## Solution

Fix #1177

- `MonacoCore.java`: escape `</` to `<\/` in the JSON-encoded content before embedding it. This rides on the JSON string's existing decode step — `\/` is a no-op JS escape, so the value the editor receives is byte-for-byte identical to the original.
- `SingleMonacoContent.java`: dropped the `text/plain`/`textContent` workaround and switched to the same JSON-encoding + `</`-escape pattern used in `MonacoCore.java`, embedding content directly as a JSON string literal in the executing `<script>` block.

This consolidates both viewers onto one escaping scheme that covers everything either historical fix handled individually (quotes, backslashes, control characters, template-literal interpolation) plus the `</script` gap neither one closed.